### PR TITLE
Feature Request: Sync Default ztrim with vfatqc-python-scripts

### DIFF
--- a/anaoptions.py
+++ b/anaoptions.py
@@ -19,5 +19,5 @@ parser.add_option("--scandatetrim", type="string", dest="scandatetrim", default=
                   help="Specify the scan date of the trim run that corresponds to the chConfig.txt used in scandate", metavar="scandatetrim")
 parser.add_option("-t", "--type", type="string", dest="GEBtype", default="long",
                   help="Specify GEB (long/short)", metavar="GEBtype")
-parser.add_option("--ztrim", type="float", dest="ztrim", default=0.0,
+parser.add_option("--ztrim", type="float", dest="ztrim", default=4.0,
                   help="Specify the p value of the trim", metavar="ztrim")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Addressing: https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/18

In `anaoptions.py` have changed the default ztrim value from 0 to 4 to match with what is set as the default value when scans are taken in `vfatqc-python-scripts/qcoptions.py` at:

https://github.com/cms-gem-daq-project/vfatqc-python-scripts/blob/4b03d64b08c1bc9b70ae2fcbd5f4ea624d289c6f/qcoptions.py#L13

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Possible that the user tries to analyze data with the wrong ztrim due to ignorance. For example the user takes an scurve without supplying anything to the `--ztrim` argument in `vfatqc-python-scripts/ultraScurve.py`.  Here the data is recorded with `options.ztrim=4` by default.  The user then tries to analyze this data with `anaUltraScurve.py` and again does not supply a `--ztrim` argument.  Here the analysis is performed with `options.ztrim=0`.
<!--- If it fixes an open issue, please link to the issue(s) here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
http://cmsonline.cern.ch/cms-elog/1005268
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):
<img width="1079" alt="summary_defaultztrimtest" src="https://user-images.githubusercontent.com/6432141/29526276-8674ec9a-8695-11e7-93fa-540c50b8c537.png">
<img width="1078" alt="fitsummary_defaultztrimtest" src="https://user-images.githubusercontent.com/6432141/29526278-8687557e-8695-11e7-89d2-b95cc0611d5a.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
