### PR TITLE
Read the event count from the SCurve data tree

### DIFF
--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -32,12 +32,17 @@ class ScanDataFitter(DeadChannelFinder):
                 self.scanCount[vfat][ch] = 0
 
         self.fitValid = [ np.zeros(128, dtype=bool) for vfat in range(24) ]
+        self.Nev = -1
 
     def feed(self, event):
         super(ScanDataFitter, self).feed(event)
         self.scanHistos[event.vfatN][event.vfatCH].Fill(event.vcal,event.Nhits)
         if(event.vcal > 250):
             self.scanCount[event.vfatN][event.vfatCH] += event.Nhits
+        if self.Nev < 0:
+            self.Nev = event.Nev
+        else:
+            assert self.Nev == event.Nev, 'Inconsistent S-curve tree'
 
     def readFile(self, treeFileName):
         inF = r.TFile(treeFileName)
@@ -50,7 +55,8 @@ class ScanDataFitter(DeadChannelFinder):
 
         random = r.TRandom3()
         random.SetSeed(0)
-        fitTF1 = r.TF1('myERF','500*TMath::Erf((TMath::Max([2],x)-[0])/(TMath::Sqrt(2)*[1]))+500',1,253)
+        fitTF1 = r.TF1('myERF','[3]*TMath::Erf((TMath::Max([2],x)-[0])/(TMath::Sqrt(2)*[1]))+[3]',1,253)
+        fitTF1.FixParameter(3, self.Nev / 2.)
         for vfat in range(0,24):
             print 'fitting vfat %i'%vfat
             for ch in range(0,128):

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -55,8 +55,7 @@ class ScanDataFitter(DeadChannelFinder):
 
         random = r.TRandom3()
         random.SetSeed(0)
-        fitTF1 = r.TF1('myERF','[3]*TMath::Erf((TMath::Max([2],x)-[0])/(TMath::Sqrt(2)*[1]))+[3]',1,253)
-        fitTF1.FixParameter(3, self.Nev / 2.)
+        fitTF1 = r.TF1('myERF','%f*TMath::Erf((TMath::Max([2],x)-[0])/(TMath::Sqrt(2)*[1]))+%f'%(self.Nev/2.),1,253)
         for vfat in range(0,24):
             print 'fitting vfat %i'%vfat
             for ch in range(0,128):


### PR DESCRIPTION
Addesses issue #15 by reading the number of events from the S-curve trees.

## Description
The S-curve fit function has the number of events hard-coded to 1000, but can be changed in `ultraScurve`. Detect it from the S-curve tree instead, to enable using data produced with non-default `--nevts`.

The implementation is not as suggested in #15, but will rather read the number of events from the tree. It's IMHO less error-prone: there is no need for an additional parameter to `fitScanData` (and flag to `anaUltraScurve.py`), that could be forgotten. The fit function will "just work" unless supplied with inconsistent trees (for sample merged using `hadd`), in which case an error may even be thrown (depending on the parameters used to generate the `hadd`ed trees).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
See #15.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The changes were tested using data from http://cmsonline.cern.ch/cms-elog/1005623. Cross-checks:

* The number of failed fits doesn't change (much) with the number of events. The scan at 10000 events fails to fit weird channels with no data on VFAT 9.
* The average `chi^2` of fits doesn't change linearly (as I would expect if the normalization stayed fixed) with the number of events, but is `~sqrt(nevt)` (as I would expect from statistical fluctuations):

| `nevts` | `<chi^2>` | 
|--------:|---------:|
| 10000 | 114 |
| 1000 | 25 |
| 100 | 13 |
| 10 | 10 |

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
