### PR TITLE
New Feature: Making Eff Plots from Ultra Latency Scans

### DIFF
--- a/macros/plot_eff.py
+++ b/macros/plot_eff.py
@@ -1,0 +1,144 @@
+#!/bin/env python
+
+# Returns binomial error on eff
+def calcEffErr(eff, nTriggers):
+    import math
+    return math.sqrt( (eff * ( 1. - eff) ) / nTriggers )
+
+# Returns a tuple of (eff, sigma_eff)
+def calcEff(cName, scandate, vfatList, latBin):
+    import os
+
+    # Setup paths
+    dataPath  = os.getenv('DATA_PATH')
+    dirPath = "%s/%s/latency/trk/%s/"%(dataPath,cName,scandate)
+    filename = dirPath + "LatencyScanData.root"
+
+    # Load data
+    import root_numpy as rp
+    import numpy as np
+    list_bNames = ["vfatN","lat","Nhits","Nev"]
+    try:
+        array_VFATData = rp.root2array(filename,"latTree",list_bNames)
+        pass
+    except Exception as e:
+        print '%s does not seem to exist'%filename
+        print e
+        pass
+
+    # Determine hits and triggers
+    nTriggers = np.asscalar(np.unique(array_VFATData['Nev']))
+    nHits = 0.0
+    for vfat in vfatList:
+        vfatData = array_VFATData[ array_VFATData['vfatN'] == vfat]
+        latData = vfatData[vfatData['lat'] == latBin]
+        nHits += np.asscalar(latData['Nhits'])
+
+    # Calc Eff & Error
+    return (nHits / nTriggers, calcEffErr(nHits / nTriggers, nTriggers) )
+
+# Here --infilename should be a tab delimited file
+#   the first row of this file should be column headings
+#   the subsequent rows of this file should be data lines
+#   Example:
+#       ChamberName scandate    EffGain
+#       GEMINIm27L1 2017.08.29.18.11    5000
+#       GEMINIm27L1 2017.08.29.18.19    7500
+#       GEMINIm27L1 2017.08.29.18.33    10000
+#       GEMINIm27L1 2017.08.29.18.06    15000
+#       GEMINIm27L1 2017.08.30.08.22    20000
+#
+#   Then this will make a plot of Eff vs. EffGain from the data supplied
+if __name__ == '__main__':
+    from gempython.utils.wrappers import envCheck
+    from macros.plotoptions import parser
+    from mapping.chamberInfo import chamber_config, GEBtype
+    
+    import os
+    
+    parser.add_option("--latSig", type="int", dest="latSig", default=None,
+                      help="Latency bin where signal is found", metavar="latSig")
+    parser.add_option("--scandate", type="string", dest="scandate", default="current",
+                      help="Specify specific date to analyze", metavar="scandate")
+    parser.add_option("--vfatList", type="string", dest="vfatList", default=None,
+                      help="Comma separated list of VFATs to consider, e.g. '12,13'", metavar="vfatList")
+    parser.add_option("-p","--print", action="store_true", dest="printData",
+                      help="Prints a comma separated table with the data to the terminal", metavar="printData")
+
+    parser.set_defaults(filename="listOfScanDates.txt")
+    (options, args) = parser.parse_args()
+    
+    # Check Paths
+    envCheck('DATA_PATH')
+    envCheck('ELOG_PATH')
+    elogPath  = os.getenv('ELOG_PATH')
+
+    # Get VFAT List
+    list_VFATs = []
+    if options.vfatList != None:
+        list_VFATs = map(int, options.vfatList.split(','))
+    elif options.vfat != None:
+        list_VFATs.append(options.vfat)
+    else:
+        print "You must specify at least one VFAT to be considered"
+        exit(-1)
+
+    # Check that the user supplied a latency value
+    if options.latSig == None:
+        print "You must specify the latency bin of the signal peak"
+        exit(-1)
+    
+    # Loop Over inputs
+    fileScanDates = open(options.filename, 'r') #tab '\t' delimited file, first line column headings, subsequent lines data: cName\tscandate\tindepvar
+    list_EffData = []
+    strIndepVar = ""
+    strChamberName = ""
+    for i,line in enumerate(fileScanDates):
+        # Split the line
+        line = line.strip('\n')
+        analysisList = line.rsplit('\t') #chamber name, scandate, independent var
+
+        # On 1st iteration get independent variable name
+        if i == 0:
+            #strChamberName = analysisList[0]
+            strIndepVar = analysisList[2]
+            continue
+
+        if len(strChamberName) == 0 and i > 0:
+            strChamberName = analysisList[0]
+        
+        tuple_eff = calcEff(analysisList[0], analysisList[1], list_VFATs, options.latSig)
+        list_EffData.append((float(analysisList[2]), tuple_eff[0], tuple_eff[1]))
+
+    # Print to the user
+    # Using format compatible with: https://github.com/cms-gem-detqc-project/CMS_GEM_Analysis_Framework#4eiviii-header-parameters---data
+    if options.printData:
+        print ""
+        print "[BEGIN_DATA]"
+        print "\tVAR_INDEP,VAR_DEP,VAR_DEP_ERR"
+        for dataPt in list_EffData:
+            print "\t%f,%f,%f"%(dataPt[0],dataPt[1],dataPt[2])
+        print "[END_DATA]"
+        print ""
+
+    # Plot the efficiency plot
+    import ROOT as r
+    r.gROOT.SetBatch(True)
+    grEffPlot = r.TGraphErrors(len(list_EffData))
+    grEffPlot.GetXaxis().SetTitle(strIndepVar)
+    grEffPlot.GetYaxis().SetTitle("Efficiency")
+    grEffPlot.GetYaxis().SetRangeUser(0.0,1.0)
+    grEffPlot.SetMarkerStyle(20)
+    grEffPlot.SetLineWidth(2)
+    for idx in range(len(list_EffData)):
+        grEffPlot.SetPoint(idx, list_EffData[idx][0], list_EffData[idx][1])
+        grEffPlot.SetPointError(idx, 0., list_EffData[idx][2])
+
+    # Draw this plot on a canvas
+    canvEff = r.TCanvas("%s_Eff_vs_%s"%(strChamberName,strIndepVar),"%s: Eff vs. %s"%(strChamberName,strIndepVar),600,600)
+    canvEff.cd()
+    grEffPlot.Draw("APE1")
+    canvEff.SaveAs(elogPath + "/%s_Eff_vs_%s.png"%(strChamberName,strIndepVar))
+    print ""
+    print "To view your plot, execute:"
+    print ("eog " + elogPath + "/%s_Eff_vs_%s.png"%(strChamberName,strIndepVar))

--- a/macros/plot_eff.py
+++ b/macros/plot_eff.py
@@ -125,8 +125,9 @@ if __name__ == '__main__':
     import ROOT as r
     r.gROOT.SetBatch(True)
     grEffPlot = r.TGraphErrors(len(list_EffData))
-    grEffPlot.GetXaxis().SetTitle(strIndepVar)
-    grEffPlot.GetYaxis().SetTitle("Efficiency")
+    grEffPlot.SetTitle("Eff from VFATs: [%s]"%(options.vfatList))
+    grEffPlot.GetYaxis().SetTitle(strIndepVar)
+    grEffPlot.GetXaxis().SetTitle("Efficiency")
     grEffPlot.GetYaxis().SetRangeUser(0.0,1.0)
     grEffPlot.SetMarkerStyle(20)
     grEffPlot.SetLineWidth(2)

--- a/setup/paths.sh
+++ b/setup/paths.sh
@@ -1,5 +1,5 @@
 # Setup cmsgemos
-echo "Checking paths" 
+echo "Checking paths"
 
 #export BUILD_HOME=<your path>/cmsgemos/../
 if [[ -n "$BUILD_HOME" ]]; then
@@ -41,6 +41,7 @@ export GEM_PLOTTING_PROJECT=$BUILD_HOME/gem-plotting-tools
 
 # Setup Path
 export PATH=$PATH:$GEM_PLOTTING_PROJECT
+export PATH=$PATH:$GEM_PLOTTING_PROJECT/macros
 
 # Setup PYTHONPATH
 export PYTHONPATH=$PYTHONPATH:$GEM_PLOTTING_PROJECT


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The script `macros/plot_eff.py` will make an efficiency plot from data acquired with `vfatqc-python-scripts/ultraLatency.py`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
If someone has a controlled trigger source to take data only from a given spot on the detector you could use `vfatqc-python-scripts/ultraLatency.py` to measure the detector's efficiency

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Sample data put in the input file:

```
more listOfScanDates.txt           
ChamberName	scandate	V_{mon}
GE11-VI-L-CERN-0001	2017.08.30.15.03	3551
GE11-VI-L-CERN-0001	2017.08.30.21.39	3663
GE11-VI-L-CERN-0001	2017.08.31.08.28	3714
```

Calling:
```
plot_eff.py listOfScanDates.txt --vfatList=12,13 --latSig=44 --print
```

Here:

- `--vfatList` is the list of VFATs your targeted trigger source covers (e.g. a 10x10 scintillating tile above VFATs 12 & 13).
- `--latSig` is the latency bin you'd like to see the efficiency from
- `--print` is an optional parameter and if used will print a table of the data to the terminal.

Generates the plot (sample data) attached.

### Screenshots (if appropriate):
<img width="597" alt="screen shot 2017-08-31 at 16 43 08" src="https://user-images.githubusercontent.com/6432141/29929304-6b352c1e-8e6b-11e7-984b-84c698d1ceaf.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
