### PR TITLE
Bug Fix: TDirectory usage in anaUltraLatency.py

### DIFF
--- a/anaUltraLatency.py
+++ b/anaUltraLatency.py
@@ -95,7 +95,8 @@ for vfat in dict_hVFATHitsVsLat:
     dict_grNHitsVFAT[vfat].Draw("APE1")
 
     #Write
-    outF.mkdir("VFAT%i"%vfat)
+    dirVFAT = outF.mkdir("VFAT%i"%vfat)
+    dirVFAT.cd()
     dict_grNHitsVFAT[vfat].Write()
     dict_hVFATHitsVsLat[vfat].Write()
     dict_fitNHitsVFAT[vfat].Write()
@@ -146,7 +147,10 @@ canv_MaxHitsPerLatByVFAT.SaveAs(filename+'/MaxHitsPerLatByVFAT.png')
 
 #Store - TObjects
 outF.cd()
+grNMaxLatBinByVFAT.SetName("grNMaxLatBinByVFAT")
 grNMaxLatBinByVFAT.Write()
+grMaxLatBinByVFAT.SetName("grMaxLatBinByVFAT")
 grMaxLatBinByVFAT.Write()
+grVFATSigOverSigPBkg.SetName("grVFATSigOverSigPBkg")
 grVFATSigOverSigPBkg.Write()
 outF.Close()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addressing: https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/30

TObjects produced by `anaUltraLatency.py` stored in the output file will now be placed in the correct `VFATN` TDirectories.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Output TFile was not organized, plots for VFATN were not stored in `VFATN` TDirectory.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Re-analyzed old data.

```
anaUltraLatency.py -i LatencyScanData.root -o LatTest.root
```

### Screenshots (if appropriate):
<img width="219" alt="screen shot 2017-08-31 at 17 49 04" src="https://user-images.githubusercontent.com/6432141/29932599-031bb468-8e75-11e7-8baf-b23c17df0037.png">
<img width="1074" alt="screen shot 2017-08-31 at 17 52 27" src="https://user-images.githubusercontent.com/6432141/29932631-14ca9846-8e75-11e7-816c-09f109e966a9.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
