### PR TITLE
Feature Implementation: Adding Generic Plotter by scandate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,6 @@
 #Don't ignore requirements.txt
 !requirements.txt
 
-#Don't ignore setup
+#Don't ignore select scripts
+!macros/gemPlotterAllChannels.sh
 !setup/paths.sh

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This should be a `tab` deliminited text file.  The first line of this file shoul
 ChamberName scandate    <Indep. Variable Name>
 ```
 
-Subsequent lines of this file are the values that correspond to these column headings.  The value of the `ChamberName` column must correspond to the value of one entry in the `chamber_config` dictionary found in `mapping/chamberInfo.py`.  The **Indep. Variable Name** is the independent variable that `--branchName` will be plotted against and is assumed to be numeric.
+Subsequent lines of this file are the values that correspond to these column headings.  The value of the `ChamberName` column must correspond to the value of one entry in the `chamber_config` dictionary found in `mapping/chamberInfo.py`.  The **Indep. Variable Name** is the independent variable that `--branchName` will be plotted against and is assumed to be numeric.  Please note the `#` character is  understood as a comment, lines starting with a `#` will be skipped.
 
 A complete example for a single detector is given as:
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ source $BUILD_HOME/gem-plotting-tools/setup/paths.sh
 See extensive documentation written on the [GEM DOC Twiki Page](https://twiki.cern.ch/twiki/bin/view/CMS/GEMDOCDoc#How_to_Produce_Scan_Plots).
 
 ## Using the Arbitray Plotter - gemPlotter.py
-An arbitrary plotter `gemPlotter.py` has been created to help you plot results from python ultra scans. The following subsections describe first the input arguments, the structure of the input file, the calling syntax, and then helper scripts.
+An arbitrary plotter `gemPlotter.py` has been created to help you plot results from python ultra scans. The following subsections describe first the input arguments, the structure of the input file, and the calling syntax.
 
 ### Command Line Arguments
 The following table shows the mandatory inputs that must be supplied to execute the script:
@@ -136,6 +136,12 @@ Additional VFATs could be plotted by either:
 - Making successive calls of the above command and using the `--rootOpt=UPDATE`,
 - Using the `--vfatList` argument instead of the `--vfat` argument, or
 - Using the `-a` argument to make all VFATs.
+
+To automatically extend this to all channels execute:
+
+```
+gemPlotterAllChannels.sh <InFile> <anaType> <branchName>
+```
 
 ### Making a 2D Plot
 To make a 2D plot for a given VFAT execute:

--- a/README.md
+++ b/README.md
@@ -1,19 +1,159 @@
 # gem-plotting-tools
 
-1. Setup:
+Table of Contents
+=================
 
-    The following `$SHELL` variables should be defined:
+   * [gem-plotting-tools](#gem-plotting-tools)
+      * [Setup:](#setup)
+      * [Analyzing Scans:](#analyzing-scans)
+      * [Using the Arbitray Plotter - gemPlotter.py](#using-the-arbitray-plotter---gemplotterpy)
+         * [Command Line Arguments](#command-line-arguments)
+         * [Input File Structure](#input-file-structure)
+         * [Making a 1D Plot - Channel Level](#making-a-1d-plot---channel-level)
+         * [Making a 1D Plot - VFAT Level](#making-a-1d-plot---vfat-level)
+         * [Making a 2D Plot](#making-a-2d-plot)
 
-    - $BUILD_HOME
-    - $DATA_PATH
-    - $ELOG_PATH
+Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc)
 
-    Then execute:
+## Setup:
+The following `$SHELL` variables should be defined:
 
-    `source $BUILD_HOME/gem-plotting-tools/setup/paths.sh`
+- $BUILD_HOME
+- $DATA_PATH
+- $ELOG_PATH
 
-2. Analyzing Scans:
+Then execute:
 
-    See extensive documentation written at:
+```
+source $BUILD_HOME/gem-plotting-tools/setup/paths.sh
+```
 
-    [GEM DOC Twiki Page](https://twiki.cern.ch/twiki/bin/view/CMS/GEMDOCDoc#How_to_Produce_Scan_Plots)
+## Analyzing Scans:
+See extensive documentation written on the [GEM DOC Twiki Page](https://twiki.cern.ch/twiki/bin/view/CMS/GEMDOCDoc#How_to_Produce_Scan_Plots).
+
+## Using the Arbitray Plotter - gemPlotter.py
+An arbitrary plotter `gemPlotter.py` has been created to help you plot results from python ultra scans. The following subsections describe first the input arguments, the structure of the input file, the calling syntax, and then helper scripts.
+
+### Command Line Arguments
+The following table shows the mandatory inputs that must be supplied to execute the script:
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| --anaType | string | Analysis type to be executed, see `tree_names.keys()` of `anaInfo.py` for possible inputs |
+| --branchName | string | Name of TBranch where dependent variable is found, note that this TBranch should be found in the `TTree` that corresponds to the value given to the `--anaType` argument |
+| -i, --infilename | string | physical filename of the input file to be passed to `gemPlotter.py`.  See [Input File Structure](#input-file-structure) for details on the format and contents of this file. |
+| -v, --vfat | int | Specify VFAT to plot |
+
+Note for those `anaType` values which have the substring `Ana` in their names it is expected that the user has already run `ana_scans.py` on the corresponding `scandate` to produce the necessary input file for `gemPlotter.py`.
+
+The following table shows the optional inputs that can be supplied when executing the script:
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| -a, --all | none | When providing this flag data from all 24 VFATs will be plotted.  Additionally a summary plot in the typical 3x8 grid will be created showing the results of all 24 VFATs. May be used instead of the `--vfat` option. |
+| --axisMax | float | Maximum value for the axis depicting `--branchName`. |
+| --axisMin | float | Minimum value for the axis depicting `--branchName`. |
+| -c, --channels | none | When providing this flag the `--strip` option is interpreted as VFAT channel number instead of readout board (ROB) strip number. |
+| -s, --strip | int | Specific ROB strip number to plot for `--branchName`.  Note for ROB strip level `--branchName` values (e.g. `trimDAC`) if this option is *not* provided the data point (error bar) will represent the mean (standard deviation) of `--branchName` from all strips. |
+| --make2D | none| When providing this flag a 2D plot of ROB strip/vfat channel vs. independent variable will be plotted whose z-axis value is `--branchName`. |
+| -p, --print | none | Prints a comma separated table of the plot's data to the terminal.  The format of this table will be compatible with the `genericPlotter` executable of the [CMS_GEM_Analysis_Framework](https://github.com/cms-gem-detqc-project/CMS_GEM_Analysis_Framework#4eiviii-header-parameters---data). | 
+| --rootOpt | string | Option for creating the output `TFile`, e.g. {'RECREATE','UPDATE'} |
+| --showStat | none | Causes the statistics box to be drawn on created plots. Note only applicable when used with `--make2D`. |
+| --vfatList | Comma separated list of int's | List of VFATs that should be plotted.  May be used instead of the `--vfat` option. |
+
+### Input File Structure
+This should be a `tab` deliminited text file.  The first line of this file should be a list of column headers formatted as:
+
+```
+ChamberName scandate    <Indep. Variable Name>
+```
+
+Subsequent lines of this file are the values that correspond to these column headings.  The value of the `ChamberName` column must correspond to the value of one entry in the `chamber_config` dictionary found in `mapping/chamberInfo.py`.  The **Indep. Variable Name** is the independent variable that `--branchName` will be plotted against and is assumed to be numeric.
+
+A complete example for a single detector is given as:
+
+```
+ChamberName scandate    VT_{1}
+GE11-VI-L-CERN-0002 2017.09.04.20.12    10
+GE11-VI-L-CERN-0002 2017.09.04.22.52    20
+GE11-VI-L-CERN-0002 2017.09.05.01.33    30
+GE11-VI-L-CERN-0002 2017.09.05.04.21    40
+GE11-VI-L-CERN-0002 2017.09.05.07.11    50
+```
+
+Here the `ChamberName` is always `GE11-VI-L-CERN-0002` and `--branchName` will be plotted against `VT_{1}` which is the **Indep. Variable Name** is `RunNo`.  Note the axis of interest will be assigned the label, with subscripts in this case, of `VT_{1}`.
+
+A complete example for multiple detectors is given as:
+
+```
+ChamberName scandate    Layer
+GEMINIm27L1 2019.09.04.20.12    -27.0
+GEMINIm27L2 2019.09.04.22.52    -27.5
+GEMINIm28L1 2019.09.05.01.33    -28.0
+GEMINIm28L2 2019.09.05.04.21    -28.5
+GEMINIp02L1 2019.09.05.07.11    2.0
+GEMINIp02L2 2019.09.05.07.11    2.5
+```
+
+Here the `ChamberName` is different for each line and `--branchName` will be plotted against `Layer`.  Note we have provided a numerical equivalent for mXXLY and pXXLY:
+- minus (plus) given by m (p) corresponds to a negative (positive) number, and
+- L1(2) is a whole (half) integer number.
+
+### Making a 1D Plot - Channel Level
+To make a 1D plot for a given strip of a given VFAT execute:
+
+```
+gemPlotter.py --infilename=<inputfilename> --anaType=<anaType> --branchName=<TBranch Name> --vfat=<VFAT No.> --strip=<Strip No.>
+```
+
+For example, to plot `trimDAC` vs. an **Indep. Variable Name** defined in `listOfScanDates.txt` for VFAT 12, strip number 49 execute:
+
+```
+gemPlotter.py -ilistOfScanDates.txt --anaType=trimAna --branchName=trimDAC --vfat=12 --strip=49
+```
+
+Additional VFATs could be plotted by either:
+- Making successive calls of the above command and using the `--rootOpt=UPDATE`,
+- Using the `--vfatList` argument instead of the `--vfat` argument, or
+- Using the `-a` argument to make all VFATs.
+
+### Making a 1D Plot - VFAT Level
+To make a 1D plot for a given VFAT execute:
+
+```
+gemPlotter.py --infilename=<inputfilename> --anaType=<anaType> --branchName=<TBranch Name> --vfat=<VFAT No.> 
+```
+
+For example, to plot `trimRange` vs. an **Indep. Variable Name** defined in `listOfScanDates.txt` for VFAT 12 execute:
+
+```
+gemPlotter.py -ilistOfScanDates.txt --anaType=trimAna --branchName=trimRange --vfat=12
+```
+
+Note if **TBranch Name** is a strip level observable the data points (y-error bars) in the produced plot will represent the mean (standard deviation) from all of the VFAT's channels.
+
+Additional VFATs could be plotted by either:
+- Making successive calls of the above command and using the `--rootOpt=UPDATE`,
+- Using the `--vfatList` argument instead of the `--vfat` argument, or
+- Using the `-a` argument to make all VFATs.
+
+### Making a 2D Plot
+To make a 2D plot for a given VFAT execute:
+
+```
+gemPlotter.py --infilename=<inputfilename> --anaType=<anaType> --branchName=<TBranch Name> --vfat=<VFAT No.> --make2D
+```
+
+Here the output plot will be of the form "ROB Strip/VFAT Channel vs. Indep. Variable Name" with the z-axis storing the value of `--branchName`.
+
+For example to plot `trimDAC` for "ROB Strip vs. Indep. Variable Name" wher
+For example to make a 2D plot with the z-axis as `trimDAC` and the **Indep. Variable Name** defined in `listOfScanDates.txt` for VFAT 12 execute:
+
+```
+gemPlotter.py -ilistOfScanDates.txt --anaType=trimAna --branchName=trimDAC --vfat=12 --make2D 
+```
+
+Additional VFATs could be plotted by either:
+- Making successive calls of the above command and using the `--rootOpt=UPDATE`,
+- Using the `--vfatList` argument instead of the `--vfat` argument, or
+- Using the `-a` argument to make all VFATs.

--- a/anaInfo.py
+++ b/anaInfo.py
@@ -7,6 +7,19 @@ ana_config = {
         "trim":"anaUltraScurve.py"
         }
 
+# key values match ana_config
+# stores a tuple where:
+#   [0] -> path of root file inside scandate/ 
+#   [1] -> name of TTree inside root file
+tree_names = {
+        "latency":("LatencyScanData.root","latTree"),
+        "scurve":("SCurveData.root","scurveTree"),
+        "scurveAna":("SCurveData/SCurveFitData.root","scurveFitTree")
+        "threshold":("ThresholdScanData.root","thrTree"),
+        "trim":("SCurveData_Trimmed.root","scurveTree")
+        "trimAna":("SCurveData_Trimmed/SCurveFitData.root","scurveFitTree")
+        }
+
 class MaskReason:
     """Enum-like class to represent the reasons for which a channel was masked.
     Reasons are bitmasks. Example usage:

--- a/anaInfo.py
+++ b/anaInfo.py
@@ -14,9 +14,9 @@ ana_config = {
 tree_names = {
         "latency":("LatencyScanData.root","latTree"),
         "scurve":("SCurveData.root","scurveTree"),
-        "scurveAna":("SCurveData/SCurveFitData.root","scurveFitTree")
+        "scurveAna":("SCurveData/SCurveFitData.root","scurveFitTree"),
         "threshold":("ThresholdScanData.root","thrTree"),
-        "trim":("SCurveData_Trimmed.root","scurveTree")
+        "trim":("SCurveData_Trimmed.root","scurveTree"),
         "trimAna":("SCurveData_Trimmed/SCurveFitData.root","scurveFitTree")
         }
 

--- a/ana_scans.py
+++ b/ana_scans.py
@@ -12,10 +12,11 @@ def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0,
   import subprocess
   from subprocess import CalledProcessError
   from anaInfo import ana_config
+  from anautilities import getDirByAnaType
   from gempython.utils.wrappers import runCommand
 
-  dataPath  = os.getenv('DATA_PATH')
-  dirPath   = ""
+  #dataPath  = os.getenv('DATA_PATH')
+  dirPath   = getDirByAnaType(anaType, cName, ztrim)
   elogPath  = "%s/%s"%(os.getenv('ELOG_PATH'),scandate)
     
   print "Analysis Requested: %s"%(anaType)
@@ -25,7 +26,7 @@ def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0,
   postCmds = []
   postCmds.append(["mkdir","-p","%s"%(elogPath)])
   if anaType == "latency":
-    dirPath = "%s/%s/%s/trk/%s/"%(dataPath,cName,anaType,scandate)
+    dirPath = "%s/%s/"%(dirPath,scandate)
     filename = dirPath + "LatencyScanData.root"
     if not os.path.isfile(filename):
       print "No file to analyze. %s does not exist"%(filename)
@@ -43,7 +44,7 @@ def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0,
     
     pass
   elif anaType == "scurve":
-    dirPath = "%s/%s/%s/%s/"%(dataPath,cName,anaType,scandate)
+    dirPath = "%s/%s/"%(dirPath,scandate)
     filename = dirPath + "SCurveData.root"
     if not os.path.isfile(filename):
       print "No file to analyze. %s does not exist"%(filename)
@@ -66,7 +67,7 @@ def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0,
                  "%s/chConfig_%s_ztrim%2.2f.txt"%(elogPath,cName,ztrim)])
     pass
   elif anaType == "threshold":
-    dirPath = "%s/%s/%s/channel/%s/"%(dataPath,cName,anaType,scandate)
+    dirPath = "%s/%s/"%(dirPath,scandate)
     filename = dirPath + "ThresholdScanData.root"
     if not os.path.isfile(filename):
       print "No threshold file to analyze. %s does not exist"%(filename)
@@ -77,7 +78,8 @@ def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0,
    
     if chConfigKnown:
       cmd.append("--chConfigKnown")
-      dirPath_Trim = "%s/%s/trim/z%f/%s/SCurveData_Trimmed/"%(dataPath,cName,ztrim,scandatetrim)
+      #dirPath_Trim = "%s/%s/trim/z%f/%s/SCurveData_Trimmed/"%(dataPath,cName,ztrim,scandatetrim)
+      dirPath_Trim = "%s/%s/SCurveData_Trimmed/"%(getDirByAnaType("trim", cName, ztrim),scandatetrim)
       filename_Trim = dirPath_Trim + "SCurveFitData.root"
       if not os.path.isfile(filename_Trim):
         print "No scurve fit data file to analyze. %s does not exist"%(filename_Trim)
@@ -98,7 +100,7 @@ def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0,
       pass
     pass
   elif anaType == "trim":
-    dirPath = "%s/%s/%s/z%f/%s/"%(dataPath,cName,anaType,ztrim,scandate)
+    dirPath = "%s/%s/"%(dirPath,scandate)
     filename = dirPath + "SCurveData_Trimmed.root"
     if not os.path.isfile(filename):
       print "No file to analyze. %s does not exist"%(filename)

--- a/anautilities.py
+++ b/anautilities.py
@@ -20,16 +20,17 @@ def filePathExists(searchPath, subPath, debug=False):
 def getDirByAnaType(anaType, cName, ztrim=4):
     from anaInfo import ana_config
     
+    import os
+
     # Check anaType is understood
     if anaType not in ana_config.keys():
         print "getDirByAnaType() - Invalid analysis specificed, please select only from the list:"
         print ana_config.keys()
-        exit(-1)
+        exit(os.EX_USAGE)
         pass
 
     # Check Paths
     from gempython.utils.wrappers import envCheck
-    import os
     envCheck('DATA_PATH')
     dataPath  = os.getenv('DATA_PATH')
 

--- a/anautilities.py
+++ b/anautilities.py
@@ -29,6 +29,33 @@ def filePathExists(searchPath, subPath):
         print "Found %s"%s(subPath)
         return True
 
+def getDirByAnaType(anaType, cName, ztrim=4):
+    from anaInfo import ana_config
+    from gempython.utils.wrappers import envCheck
+    
+    # Check anaType is understood
+    if options.anaType not in ana_config.keys():
+        print "getDirByAnaType() - Invalid analysis specificed, please select only from the list:"
+        print ana_config.keys()
+        exit(-1)
+        pass
+
+    # Check Paths
+    envCheck('DATA_PATH')
+    dataPath  = os.getenv('DATA_PATH')
+
+    dirPath = ""
+    if anaType == "latency":
+        dirPath = "%s/%s/%s/trk/"%(dataPath,cName,anaType)
+    elif anaType == "scurve":
+        dirPath = "%s/%s/%s/"%(dataPath,cName,anaType)
+    elif anaType == "threshold":
+        dirPath = "%s/%s/%s/channel/"%(dataPath,cName,anaType)
+    elif anaType == "trim":
+        dirPath = "%s/%s/%s/z%f/"%(dataPath,cName,anaType,ztrim)
+
+    return dirPath
+
 def initVFATArray(array_dtype, nstrips=128):
     list_dtypeTuple = []
 

--- a/anautilities.py
+++ b/anautilities.py
@@ -6,17 +6,9 @@ By: Brian Dorney (brian.l.dorney@cern.ch)
 """
 
 def filePathExists(searchPath, subPath, debug=False):
-    import glob
-
-    dirs        = glob.glob(searchPath)
-    foundDir    = False
-
-    for path in dirs:
-        if path.rfind(subPath) > 0:
-            foundDir = True
-            pass
-        pass
-    if not foundDir:
+    import os
+    
+    if not os.path.exists("%s/%s"%(searchPath, subPath)):
         if debug:
             print "Unable to find %s in location: %s"%(subPath, searchPath)
         return False

--- a/anautilities.py
+++ b/anautilities.py
@@ -34,7 +34,7 @@ def getDirByAnaType(anaType, cName, ztrim=4):
     from gempython.utils.wrappers import envCheck
     
     # Check anaType is understood
-    if options.anaType not in ana_config.keys():
+    if anaType not in ana_config.keys():
         print "getDirByAnaType() - Invalid analysis specificed, please select only from the list:"
         print ana_config.keys()
         exit(-1)

--- a/anautilities.py
+++ b/anautilities.py
@@ -5,7 +5,7 @@ Utilities for vfatqc scans
 By: Brian Dorney (brian.l.dorney@cern.ch)
 """
 
-def filePathExists(searchPath, subPath):
+def filePathExists(searchPath, subPath, debug=False):
     import glob
 
     dirs        = glob.glob(searchPath)
@@ -17,10 +17,12 @@ def filePathExists(searchPath, subPath):
             pass
         pass
     if not foundDir:
-        print "Unable to find %s in location: %s"%(subPath, searchPath)
+        if debug:
+            print "Unable to find %s in location: %s"%(subPath, searchPath)
         return False
     else:
-        print "Found %s"%s(subPath)
+        if debug:
+            print "Found %s"%s(subPath)
         return True
 
 def getDirByAnaType(anaType, cName, ztrim=4):

--- a/anautilities.py
+++ b/anautilities.py
@@ -5,12 +5,6 @@ Utilities for vfatqc scans
 By: Brian Dorney (brian.l.dorney@cern.ch)
 """
 
-# Imports
-import sys, os
-import numpy as np
-import ROOT as r
-#import root_numpy as rp
-
 def filePathExists(searchPath, subPath):
     import glob
 
@@ -31,7 +25,6 @@ def filePathExists(searchPath, subPath):
 
 def getDirByAnaType(anaType, cName, ztrim=4):
     from anaInfo import ana_config
-    from gempython.utils.wrappers import envCheck
     
     # Check anaType is understood
     if anaType not in ana_config.keys():
@@ -41,6 +34,8 @@ def getDirByAnaType(anaType, cName, ztrim=4):
         pass
 
     # Check Paths
+    from gempython.utils.wrappers import envCheck
+    import os
     envCheck('DATA_PATH')
     dataPath  = os.getenv('DATA_PATH')
 
@@ -57,6 +52,8 @@ def getDirByAnaType(anaType, cName, ztrim=4):
     return dirPath
 
 def initVFATArray(array_dtype, nstrips=128):
+    import numpy as np
+    
     list_dtypeTuple = []
 
     for idx in range(0,len(array_dtype)):
@@ -70,11 +67,16 @@ def initVFATArray(array_dtype, nstrips=128):
     return np.zeros(nstrips, dtype=list_dtypeTuple)
 
 def make3x8Canvas(name, initialContent = None, drawOption = ''):
-    """Creates a 3x8 canvas for summary plots.
+    """
+    Creates a 3x8 canvas for summary plots.
 
     initialContent should be None or an array of 24 (one per VFAT) TObject that
     will be drawn on the canvas. drawOption will be passed to the Draw
-    function."""
+    function.
+    """
+
+    import ROOT as r
+    
     canv = r.TCanvas(name,name,500*8,500*3)
     canv.Divide(8,3)
     if initialContent != None:
@@ -91,7 +93,6 @@ def rejectOutliersMAD(arrayData, thresh=3.5):
     arrayOutliers = isOutlierMAD(arrayData, thresh)
     return arrayData[arrayOutliers != True]
 
-
 #Use MAD to reject outliers, but consider only high or low tail
 def rejectOutliersMADOneSided(arrayData, thresh=3.5, rejectHighTail=True):
     arrayOutliers = isOutlierMADOneSided(arrayData, thresh, rejectHighTail)
@@ -100,6 +101,8 @@ def rejectOutliersMADOneSided(arrayData, thresh=3.5, rejectHighTail=True):
 #Use inter-quartile range (IQR) to reject outliers
 #Returns a boolean array with True if points are outliers and False otherwise.
 def isOutlierIQR(arrayData):
+    import numpy as np
+    
     dMin    = np.min(arrayData,     axis=0)
     dMax    = np.max(arrayData,     axis=0)
     median  = np.median(arrayData,  axis=0)
@@ -112,6 +115,8 @@ def isOutlierIQR(arrayData):
 #Use inter-quartile range (IQR) to reject outliers, but consider only high or low tail
 #Returns a boolean array with True if points are outliers and False otherwise.
 def isOutlierIQROneSided(arrayData, rejectHighTail=True):
+    import numpy as np
+    
     dMin    = np.min(arrayData,     axis=0)
     dMax    = np.max(arrayData,     axis=0)
     median  = np.median(arrayData,  axis=0)
@@ -128,6 +133,8 @@ def isOutlierIQROneSided(arrayData, rejectHighTail=True):
 #See: https://github.com/joferkington/oost_paper_code/blob/master/utilities.py
 #Returns a boolean array with True if points are outliers and False otherwise.
 def isOutlierMAD(arrayData, thresh=3.5):
+    import numpy as np
+    
     median = np.median(arrayData, axis=0)
     diff = np.abs(arrayData - median)
     med_abs_deviation = np.median(diff)
@@ -141,6 +148,8 @@ def isOutlierMAD(arrayData, thresh=3.5):
 #Use MAD to reject outliers, but consider only high or low tail
 #Returns a boolean array with True if points are outliers and False otherwise.
 def isOutlierMADOneSided(arrayData, thresh=3.5, rejectHighTail=True):
+    import numpy as np
+    
     median = np.median(arrayData, axis=0)
     diff = arrayData - median
     med_abs_deviation = np.median(np.abs(diff))

--- a/macros/gemPlotter.py
+++ b/macros/gemPlotter.py
@@ -249,9 +249,6 @@ if __name__ == '__main__':
                 listIndepVarLowEdge.append(listIndepVarVals[i] - 0.5 * arraydeltaIndepVar[i-1])
         listIndepVarLowEdge.append(listIndepVarVals[len(listIndepVarVals)-1] + 0.5 * arraydeltaIndepVar[len(arraydeltaIndepVar)-1])
 
-        #print "len(listDataPtTuples) = %i"%len(listDataPtTuples)
-        #print "len(listIndepVarLowEdge) = %i"%len(listIndepVarLowEdge)
-
     # Loop over the vfats in listVFATs and make the requested plot for each
     strIndepVarNoBraces = strIndepVar.replace('{','').replace('}','').replace('_','')
     strRootName = elogPath + "/gemPlotterOutput_%s_vs_%s.root"%(options.branchName, strIndepVarNoBraces)

--- a/macros/gemPlotter.py
+++ b/macros/gemPlotter.py
@@ -14,7 +14,7 @@ def arbitraryPlotter(anaType, listDataPtTuples, rootFileName, treeName, branchNa
     strip - strip of the detector that should be used, if None an average is performed w/stdev for error bar, mutually exclusive w/vfatCH
     """
   
-    from anautilities import getDirByAnaType
+    from anautilities import filePathExists, getDirByAnaType
 
     import numpy as np
     import root_numpy as rp
@@ -37,20 +37,24 @@ def arbitraryPlotter(anaType, listDataPtTuples, rootFileName, treeName, branchNa
 
         # Setup Paths
         dirPath = getDirByAnaType(anaType.strip("Ana"), cName, ztrim=4)
+        if not filePathExists(dirPath, scandate):
+            print 'Filepath %s/%s does not exist!'%(dirPath, scandate)
+            print 'Please cross-check, exiting!'
+            exit(-10)
         filename = "%s/%s/%s"%(dirPath, scandate, rootFileName)
 
         # Get TTree
         try:
             dataFile = r.TFile(filename, "READ")
             dataTree = dataFile.Get(treeName)
+            knownBranches = dataTree.GetListOfBranches()
         except Exception as e:
-            print '%s does not seem to exist'%filename
+            print '%s may not exist in %s, please cross check'%(treeName,filename)
             print e
-            exit(-10)
+            exit(-20)
             pass
 
         # Check to make sure listNames are present in dataTree
-        knownBranches = dataTree.GetListOfBranches()
         for testBranch in listNames:
             if testBranch not in knownBranches:
                 print "Branch %s not in TTree %s of file %s"%(branchName, treeName, filename)
@@ -58,7 +62,7 @@ def arbitraryPlotter(anaType, listDataPtTuples, rootFileName, treeName, branchNa
                 for realBranch in knownBranches:
                     print realBranch
                 print "Please try again using one of the existing branches"
-                exit(-20)
+                exit(-30)
 
         # Get dependent variable value
         arrayVFATData = rp.tree2array(dataTree,listNames)
@@ -93,7 +97,7 @@ def arbitraryPlotter2D(anaType, listDataPtTuples, rootFileName, treeName, branch
     vfat - vfat number that plots should be made for
     """
   
-    from anautilities import getDirByAnaType
+    from anautilities import filePathExists, getDirByAnaType
 
     import numpy as np
     import root_numpy as rp
@@ -119,20 +123,24 @@ def arbitraryPlotter2D(anaType, listDataPtTuples, rootFileName, treeName, branch
 
         # Setup Paths
         dirPath = getDirByAnaType(anaType.strip("Ana"), cName, ztrim=4)
+        if not filePathExists(dirPath, scandate):
+            print 'Filepath %s/%s does not exist!'%(dirPath, scandate)
+            print 'Please cross-check, exiting!'
+            exit(-10)
         filename = "%s/%s/%s"%(dirPath, scandate, rootFileName)
 
         # Get TTree
         try:
             dataFile = r.TFile(filename, "READ")
             dataTree = dataFile.Get(treeName)
+            knownBranches = dataTree.GetListOfBranches()
         except Exception as e:
-            print '%s does not seem to exist'%filename
+            print '%s may not exist in %s, please cross check'%(treeName,filename)
             print e
             exit(-10)
             pass
 
         # Check to make sure listNames are present in dataTree
-        knownBranches = dataTree.GetListOfBranches()
         for testBranch in listNames:
             if testBranch not in knownBranches:
                 print "Branch %s not in TTree %s of file %s"%(branchName, treeName, filename)
@@ -231,6 +239,9 @@ if __name__ == '__main__':
     strIndepVar = ""
     listDataPtTuples = []
     for i,line in enumerate(fileScanDates):
+        if line[0] == "#":
+            continue
+
         # Split the line
         line = line.strip('\n')
         analysisList = line.rsplit('\t') #chamber name, scandate, independent var

--- a/macros/gemPlotter.py
+++ b/macros/gemPlotter.py
@@ -39,19 +39,34 @@ def arbitraryPlotter(anaType, listDataPtTuples, rootFileName, treeName, branchNa
         dirPath = getDirByAnaType(anaType.strip("Ana"), cName, ztrim=4)
         filename = "%s/%s/%s"%(dirPath, scandate, rootFileName)
 
+        # Get TTree
         try:
-            arrayVFATData = rp.root2array(filename,treeName,listNames)
-            pass
+            dataFile = r.TFile(filename, "READ")
+            dataTree = dataFile.Get(treeName)
         except Exception as e:
             print '%s does not seem to exist'%filename
-            print 'Better double check scandate %s'%scandate
             print e
             exit(-10)
             pass
 
+        # Check to make sure listNames are present in dataTree
+        knownBranches = dataTree.GetListOfBranches()
+        for testBranch in listNames:
+            if testBranch not in knownBranches:
+                print "Branch %s not in TTree %s of file %s"%(branchName, treeName, filename)
+                print "Existing Branches are:"
+                for realBranch in knownBranches:
+                    print realBranch
+                print "Please try again using one of the existing branches"
+                exit(-20)
+
         # Get dependent variable value
+        arrayVFATData = rp.tree2array(dataTree,listNames)
         dataThisVFAT = arrayVFATData[ arrayVFATData['vfatN'] == vfat] #VFAT Level
 
+        # Close the TFile
+        dataFile.Close()
+        
         if vfatCH is not None and strip is None:
             dataThisVFAT = dataThisVFAT[ dataThisVFAT['vfatCH'] == vfatCH ] #VFAT Channel Level
         elif strip is not None and vfatCH is None:
@@ -106,18 +121,33 @@ def arbitraryPlotter2D(anaType, listDataPtTuples, rootFileName, treeName, branch
         dirPath = getDirByAnaType(anaType.strip("Ana"), cName, ztrim=4)
         filename = "%s/%s/%s"%(dirPath, scandate, rootFileName)
 
+        # Get TTree
         try:
-            arrayVFATData = rp.root2array(filename,treeName,listNames)
-            pass
+            dataFile = r.TFile(filename, "READ")
+            dataTree = dataFile.Get(treeName)
         except Exception as e:
             print '%s does not seem to exist'%filename
-            print 'Better double check scandate %s'%scandate
             print e
             exit(-10)
             pass
 
+        # Check to make sure listNames are present in dataTree
+        knownBranches = dataTree.GetListOfBranches()
+        for testBranch in listNames:
+            if testBranch not in knownBranches:
+                print "Branch %s not in TTree %s of file %s"%(branchName, treeName, filename)
+                print "Existing Branches are:"
+                for realBranch in knownBranches:
+                    print realBranch
+                print "Please try again using one of the existing branches"
+                exit(-20)
+
         # Get dependent variable value - VFAT Level
+        arrayVFATData = rp.tree2array(dataTree,listNames)
         dataThisVFAT = arrayVFATData[ arrayVFATData['vfatN'] == vfat] #VFAT Level
+
+        # Close the TFile
+        dataFile.Close()
 
         # Get the data for each strip and store it as a tuple in the list to be returned
         for chan in range(0,128):
@@ -263,7 +293,6 @@ if __name__ == '__main__':
         else:
             dirVFAT = outF.mkdir("VFAT%i"%vfat)
             pass
-        dirVFAT.cd()
 
         # Make the output canvas, use a temp name and temp title for now
         strCanvName = ""
@@ -323,6 +352,7 @@ if __name__ == '__main__':
             hPlot2D.GetYaxis().SetTitleOffset(1.2)
             
             # Store the plot
+            dirVFAT.cd()
             hPlot2D.Write()
             listPlots.append(hPlot2D)
         else:
@@ -370,6 +400,7 @@ if __name__ == '__main__':
             grPlot.GetYaxis().SetTitleOffset(1.2)
         
             # Store the plot
+            dirVFAT.cd()
             grPlot.Write()
             listPlots.append(grPlot)
             pass
@@ -383,6 +414,7 @@ if __name__ == '__main__':
         # Store the Canvas
         canvPlot.Update()
         canvPlot.SaveAs(strCanvName)
+        dirVFAT.cd()
         canvPlot.Write()
         pass
 

--- a/macros/gemPlotter.py
+++ b/macros/gemPlotter.py
@@ -17,6 +17,7 @@ def arbitraryPlotter(anaType, listDataPtTuples, rootFileName, treeName, branchNa
     from anautilities import filePathExists, getDirByAnaType
 
     import numpy as np
+    import os
     import root_numpy as rp
 
     # Make branches to load
@@ -40,7 +41,7 @@ def arbitraryPlotter(anaType, listDataPtTuples, rootFileName, treeName, branchNa
         if not filePathExists(dirPath, scandate):
             print 'Filepath %s/%s does not exist!'%(dirPath, scandate)
             print 'Please cross-check, exiting!'
-            exit(-10)
+            exit(os.EX_DATAERR)
         filename = "%s/%s/%s"%(dirPath, scandate, rootFileName)
 
         # Get TTree
@@ -51,7 +52,7 @@ def arbitraryPlotter(anaType, listDataPtTuples, rootFileName, treeName, branchNa
         except Exception as e:
             print '%s may not exist in %s, please cross check'%(treeName,filename)
             print e
-            exit(-20)
+            exit(os.EX_NOTFOUND)
             pass
 
         # Check to make sure listNames are present in dataTree
@@ -62,7 +63,7 @@ def arbitraryPlotter(anaType, listDataPtTuples, rootFileName, treeName, branchNa
                 for realBranch in knownBranches:
                     print realBranch
                 print "Please try again using one of the existing branches"
-                exit(-30)
+                exit(os.EX_NOTFOUND)
 
         # Get dependent variable value
         arrayVFATData = rp.tree2array(dataTree,listNames)
@@ -100,6 +101,7 @@ def arbitraryPlotter2D(anaType, listDataPtTuples, rootFileName, treeName, branch
     from anautilities import filePathExists, getDirByAnaType
 
     import numpy as np
+    import os
     import root_numpy as rp
 
     # Make branches to load
@@ -126,7 +128,7 @@ def arbitraryPlotter2D(anaType, listDataPtTuples, rootFileName, treeName, branch
         if not filePathExists(dirPath, scandate):
             print 'Filepath %s/%s does not exist!'%(dirPath, scandate)
             print 'Please cross-check, exiting!'
-            exit(-10)
+            exit(os.EX_DATAERR)
         filename = "%s/%s/%s"%(dirPath, scandate, rootFileName)
 
         # Get TTree
@@ -137,7 +139,7 @@ def arbitraryPlotter2D(anaType, listDataPtTuples, rootFileName, treeName, branch
         except Exception as e:
             print '%s may not exist in %s, please cross check'%(treeName,filename)
             print e
-            exit(-10)
+            exit(os.EX_NOTFOUND)
             pass
 
         # Check to make sure listNames are present in dataTree
@@ -148,7 +150,7 @@ def arbitraryPlotter2D(anaType, listDataPtTuples, rootFileName, treeName, branch
                 for realBranch in knownBranches:
                     print realBranch
                 print "Please try again using one of the existing branches"
-                exit(-20)
+                exit(os.EX_NOTFOUND)
 
         # Get dependent variable value - VFAT Level
         arrayVFATData = rp.tree2array(dataTree,listNames)
@@ -217,13 +219,13 @@ if __name__ == '__main__':
         listVFATs.append(options.vfat)
     else:
         print "You must specify at least one VFAT to be considered"
-        exit(-3)
+        exit(os.EX_USAGE)
     
     # Check anaType is understood
     if options.anaType not in tree_names.keys():
         print "Invalid analysis specificed, please select only from the list:"
         print tree_names.keys()
-        exit(-2)
+        exit(os.EX_USAGE)
         pass
     
     # Check input file
@@ -232,7 +234,7 @@ if __name__ == '__main__':
     except Exception as e:
         print '%s does not seem to exist'%(options.filename)
         print e
-        exit(-1)
+        exit(os.EX_NOINPUT)
         pass
     
     # Loop Over inputs

--- a/macros/gemPlotter.py
+++ b/macros/gemPlotter.py
@@ -209,7 +209,7 @@ if __name__ == '__main__':
         listVFATs.append(options.vfat)
     else:
         print "You must specify at least one VFAT to be considered"
-        exit(-1)
+        exit(-3)
     
     # Check anaType is understood
     if options.anaType not in tree_names.keys():
@@ -218,8 +218,16 @@ if __name__ == '__main__':
         exit(-2)
         pass
     
+    # Check input file
+    try:
+        fileScanDates = open(options.filename, 'r') #tab '\t' delimited file, first line column headings, subsequent lines data: cName\tscandate\tindepvar
+    except Exception as e:
+        print '%s does not seem to exist'%(options.filename)
+        print e
+        exit(-1)
+        pass
+    
     # Loop Over inputs
-    fileScanDates = open(options.filename, 'r') #tab '\t' delimited file, first line column headings, subsequent lines data: cName\tscandate\tindepvar
     strIndepVar = ""
     listDataPtTuples = []
     for i,line in enumerate(fileScanDates):

--- a/macros/gemPlotter.py
+++ b/macros/gemPlotter.py
@@ -1,0 +1,200 @@
+#!/bin/env python
+
+
+# listDataPtTuples[i] = (cName, scandate, indepVar)
+def arbitraryPlotter(anaType, listDataPtTuples, rootFileName, treeName, branchName, vfat, vfatCh=None, strip=None):
+    """
+
+    dataPath/<scandates>/<dirname>/<root file>
+
+    """
+  
+    from anautilities import getDirByAnaType
+
+    import numpy as np
+    import root_numpy as rp
+
+    # Make branches to load
+    list_bNames = ["vfatN"]
+    if vfatCh is not None and strip is None:
+        list_bNames.append("vfatCH")
+    elif strip is not None and vfatCh is None:
+        list_bNames.append("ROBstr")
+    list_bNames.append(branchName)
+
+    # Load data
+    list_Data = []
+    for dataPt in listDataPtTuples:
+        # Get human readable info
+        cName = dataPt[0]
+        scandate = dataPt[1]
+        indepVarVal = dataPt[2]
+
+        # Setup Paths
+        dirPath = getDirByAnaType(anaType, cName, ztrim=4)
+        filename = "%s/%s/%s"%(dirPath, scandate, rootFileName)
+
+        try:
+            array_VFATData = rp.root2array(filename,treeName,list_bNames)
+            pass
+        except Exception as e:
+            print '%s does not seem to exist'%filename
+            print e
+            pass
+
+        # Get dependent variable value
+        dataThisVFAT = array_VFATData[ array_VFATData['vfatN'] == vfat] #VFAT Level
+        if vfatCh is not None and strip is None:
+            dataThisVFAT = dataThisVFAT[ dataThisVFAT['vfatCH'] == vfatCh ] #VFAT Channel Level
+        elif strip is not None and vfatCh is None:
+            dataThisVFAT = dataThisVFAT[ dataThisVFAT['ROBstr'] == vfatCh ] #Readout Board Strip Level
+        
+        depVarVal = np.mean(dataThisVFAT[branchName])   #If a vfatCH/ROBstr obs & chan/strip not give will be avg over all, else a number
+        depVarValErr = np.std(dataThisVFAT[branchName]) #If a vfatCH/ROBstr obs & chan/strip not given will be stdev over all, or zero
+
+        #Record this dataPt
+        list_Data.append( (indepVarVal, depVarVal, depVarValErr) )
+
+    # Return Data
+    return list_Data
+
+if __name__ == '__main__':
+    from anaInfo import tree_names
+    from gempython.utils.wrappers import envCheck
+    from macros.plotoptions import parser
+    from mapping.chamberInfo import chamber_config
+    
+    import os
+    
+    parser.add_option("--anaType", type="string", dest="anaType",
+                     help="Analysis type to be executed, from list {'latency','scurve','scurveAna','threshold','trim','trimAna'}", metavar="anaType")
+    parser.add_option("--branchName", type="string", dest="branchName",
+                     help="Name of TBranch where dependent variable is store", metavar="branchName")
+    parser.add_option("-p","--print", action="store_true", dest="printData",
+                      help="Prints a comma separated table with the data to the terminal", metavar="printData")
+    parser.add_option("--scandate", type="string", dest="scandate", default="current",
+                      help="Specify specific date to analyze", metavar="scandate")
+    parser.add_option("--vfatList", type="string", dest="vfatList", default=None,
+                      help="Comma separated list of VFATs to consider, e.g. '12,13'", metavar="vfatList")
+
+    parser.set_defaults(filename="listOfScanDates.txt")
+    (options, args) = parser.parse_args()
+  
+    # Check Paths
+    envCheck('DATA_PATH')
+    envCheck('ELOG_PATH')
+    elogPath  = os.getenv('ELOG_PATH')
+
+    # Get VFAT List
+    list_VFATs = []
+    if options.vfatList != None:
+        list_VFATs = map(int, options.vfatList.split(','))
+    elif options.vfat != None:
+        list_VFATs.append(options.vfat)
+    else:
+        print "You must specify at least one VFAT to be considered"
+        exit(-1)
+
+    # Check anaType is understood
+    if options.anaType not in tree_names.keys():
+        print "Invalid analysis specificed, please select only from the list:"
+        print tree_names.keys()
+        exit(-2)
+        pass
+    
+    # Loop Over inputs
+    fileScanDates = open(options.filename, 'r') #tab '\t' delimited file, first line column headings, subsequent lines data: cName\tscandate\tindepvar
+    strIndepVar = ""
+    #strChamberName = ""
+    #listDataPtTuples[i] = (cName, scandate, indepVar)
+    listDataPtTuples = []
+    for i,line in enumerate(fileScanDates):
+        # Split the line
+        line = line.strip('\n')
+        analysisList = line.rsplit('\t') #chamber name, scandate, independent var
+
+        # On 1st iteration get independent variable name
+        if i == 0:
+            strIndepVar = analysisList[2]
+            continue
+
+        # On 1st iteration get indep
+        #if len(strChamberName) == 0 and i > 0:
+        #    strChamberName = analysisList[0]
+       
+        # Make input list for arbitraryPlotter()
+        listDataPtTuples.append( (analysisList[0], analysisList[1], analysisList[2] ) )
+
+    # Do we make strip/channel level plot?
+    vfatCh=None
+    strip=None
+    if options.strip is not None:
+        if options.channels:
+            vfatCh = options.strip
+        else
+            strip = options.strip
+
+    # Get the Requested Data & Store it in an output ROOT File
+    strIndepVarNoBraces = strIndepVar.replace('{','').replace('}','').replace('_','')
+    strRootName = elogPath + "/gemPlotterOutput_%s_vs_%s.root"%(options.branchName, strIndepVarNoBraces)
+    outF = r.TFile(strRootName,"recreate")
+    for vfat in options.vfatList:
+        list_Data = arbitraryPlotter(
+                options.anaType, 
+                listDataPtTuples, 
+                tree_names[options.anaType][0], 
+                tree_names[options.anaType][1], 
+                options.branchName, 
+                options.vfat, 
+                vfatCh, 
+                strip)
+
+        # Print to the user
+        # Using format compatible with: https://github.com/cms-gem-detqc-project/CMS_GEM_Analysis_Framework#4eiviii-header-parameters---data
+        if options.printData:
+            print "===============Printing Data for VFAT%i==============="%(vfat)
+            print "[BEGIN_DATA]"
+            print "\tVAR_INDEP,VAR_DEP,VAR_DEP_ERR"
+            for dataPt in list_Data:
+                print "\t%f,%f,%f"%(dataPt[0],dataPt[1],dataPt[2])
+            print "[END_DATA]"
+            print ""
+
+        # Make the plot
+        import ROOT as r
+        r.gROOT.SetBatch(True)
+        grPlot = r.TGraphErrors(len(list_Data))
+        grPlot.SetName("g_%s_vs_%s_VFAT%i"%(options.branchName, strIndepVarNoBraces, vfat)
+        grPlot.SetMarkerStyle(20)
+        grPlot.SetLineWidth(2)
+        for idx in range(len(list_Data)):
+            grPlot.SetPoint(idx, list_Data[idx][0], list_Data[idx][1])
+            grPlot.SetPointError(idx, 0., list_Data[idx][2])
+
+        # Draw this plot on a canvas
+        canvPlot = r.TCanvas("canv_%s_vs_%s_VFAT%i"%(options.branchName,strIndepVarNoBraces, vfat),"VFAT%i: %s vs. %s"%(vfat,options.branchName,strIndepVarNoBraces),600,600)
+        canvPlot.cd()
+        grPlot.Draw("APE1")
+        grPlot.GetXaxis().SetTitle(strIndepVar)
+        grPlot.GetYaxis().SetDecimals(True)
+        grPlot.GetYaxis().SetRangeUser(0.0,1.0)
+        grPlot.GetYaxis().SetTitle(options.branchName)
+        grPlot.GetYaxis().SetTitleOffset(1.2)
+        canvPlot.Update()
+        strCanvName = elogPath + "/canv_%s_vs_%s_VFAT%i"%(options.branchName,strIndepVarNoBraces, vfat)
+        canvPlot.SaveAs(strCanvName)
+        
+        print ""
+        print "To view your plot, execute:"
+        print ("eog " + strCanvName)
+        print ""
+
+        outF.cd()
+        grPlot.Write()
+        canvPlot.Write()
+        pass
+
+    print ""
+    print "Your plot is stored in a TFile, to open it execute:"
+    print ("root " + strRootName)
+    print ""

--- a/macros/gemPlotter.py
+++ b/macros/gemPlotter.py
@@ -1,6 +1,6 @@
 #!/bin/env python
 
-def arbitraryPlotter(anaType, listDataPtTuples, rootFileName, treeName, branchName, vfat, vfatCh=None, strip=None):
+def arbitraryPlotter(anaType, listDataPtTuples, rootFileName, treeName, branchName, vfat, vfatCH=None, strip=None):
     """
     Provides a list of tuples for 1D data where each element is of the form: (indepVarVal, depVarVal, depVarValErr)
 
@@ -10,8 +10,8 @@ def arbitraryPlotter(anaType, listDataPtTuples, rootFileName, treeName, branchNa
     treeName - name of the TTree inside rootFileName
     branchName - name of a branch inside treeName that the dependent variable will be extracted from
     vfat - vfat number that plots should be made for
-    vfatCh - channel of the vfat that should be used, if None an average is performed w/stdev for error bar, mutually exclusive w/strip
-    strip - strip of the detector that should be used, if None an average is performed w/stdev for error bar, mutually exclusive w/vfatCh
+    vfatCH - channel of the vfat that should be used, if None an average is performed w/stdev for error bar, mutually exclusive w/strip
+    strip - strip of the detector that should be used, if None an average is performed w/stdev for error bar, mutually exclusive w/vfatCH
     """
   
     from anautilities import getDirByAnaType
@@ -20,15 +20,15 @@ def arbitraryPlotter(anaType, listDataPtTuples, rootFileName, treeName, branchNa
     import root_numpy as rp
 
     # Make branches to load
-    list_bNames = ["vfatN"]
-    if vfatCh is not None and strip is None:
-        list_bNames.append("vfatCH")
-    elif strip is not None and vfatCh is None:
-        list_bNames.append("ROBstr")
-    list_bNames.append(branchName)
+    listNames = ["vfatN"]
+    if vfatCH is not None and strip is None:
+        listNames.append("vfatCH")
+    elif strip is not None and vfatCH is None:
+        listNames.append("ROBstr")
+    listNames.append(branchName)
 
     # Load data
-    list_Data = []
+    listData = []
     for dataPt in listDataPtTuples:
         # Get human readable info
         cName = dataPt[0]
@@ -40,29 +40,94 @@ def arbitraryPlotter(anaType, listDataPtTuples, rootFileName, treeName, branchNa
         filename = "%s/%s/%s"%(dirPath, scandate, rootFileName)
 
         try:
-            array_VFATData = rp.root2array(filename,treeName,list_bNames)
+            arrayVFATData = rp.root2array(filename,treeName,listNames)
             pass
         except Exception as e:
             print '%s does not seem to exist'%filename
+            print 'Better double check scandate %s'%scandate
             print e
+            exit(-10)
             pass
 
         # Get dependent variable value
-        dataThisVFAT = array_VFATData[ array_VFATData['vfatN'] == vfat] #VFAT Level
+        dataThisVFAT = arrayVFATData[ arrayVFATData['vfatN'] == vfat] #VFAT Level
 
-        if vfatCh is not None and strip is None:
-            dataThisVFAT = dataThisVFAT[ dataThisVFAT['vfatCH'] == vfatCh ] #VFAT Channel Level
-        elif strip is not None and vfatCh is None:
+        if vfatCH is not None and strip is None:
+            dataThisVFAT = dataThisVFAT[ dataThisVFAT['vfatCH'] == vfatCH ] #VFAT Channel Level
+        elif strip is not None and vfatCH is None:
             dataThisVFAT = dataThisVFAT[ dataThisVFAT['ROBstr'] == strip ] #Readout Board Strip Level
         
         depVarVal = np.asscalar(np.mean(dataThisVFAT[branchName]))   #If a vfatCH/ROBstr obs & chan/strip not give will be avg over all, else a number
         depVarValErr = np.asscalar(np.std(dataThisVFAT[branchName])) #If a vfatCH/ROBstr obs & chan/strip not given will be stdev over all, or zero
 
         #Record this dataPt
-        list_Data.append( (indepVarVal, depVarVal, depVarValErr) )
+        listData.append( (indepVarVal, depVarVal, depVarValErr) )
 
     # Return Data
-    return list_Data
+    return listData
+
+def arbitraryPlotter2D(anaType, listDataPtTuples, rootFileName, treeName, branchName, vfat, ROBstr=True):
+    """
+    Provides a list of tuples for 2D data where each element is of the (x,y,z) form: (indepVarVal, vfatCHOrROBstr, depVarVal)
+
+    anaType - type of analysis to perform, helps build the file path to the input file(s), from set ana_config.keys()
+    listDataPtTuples - list of tuples where each element is of the form: (cName, scandate, indepVar), note indepVar is expected to be numeric
+    rootFileName - name of the TFile that will be found in the data path corresponding to anaType
+    treeName - name of the TTree inside rootFileName
+    branchName - name of a branch inside treeName that the dependent variable will be extracted from
+    vfat - vfat number that plots should be made for
+    """
+  
+    from anautilities import getDirByAnaType
+
+    import numpy as np
+    import root_numpy as rp
+
+    # Make branches to load
+    listNames = ["vfatN"]
+    strChanName = "" #Name of channel TBranch, either 'ROBstr' or 'vfatCH'
+    if ROBstr:
+        listNames.append("ROBstr")
+        strChanName = "ROBstr"
+    else:
+        listNames.append("vfatCH")
+        strChanName = "vfatCH"
+    listNames.append(branchName)
+
+    # Load data
+    listData = []
+    for dataPt in listDataPtTuples:
+        # Get human readable info
+        cName = dataPt[0]
+        scandate = dataPt[1]
+        indepVarVal = dataPt[2]
+
+        # Setup Paths
+        dirPath = getDirByAnaType(anaType.strip("Ana"), cName, ztrim=4)
+        filename = "%s/%s/%s"%(dirPath, scandate, rootFileName)
+
+        try:
+            arrayVFATData = rp.root2array(filename,treeName,listNames)
+            pass
+        except Exception as e:
+            print '%s does not seem to exist'%filename
+            print 'Better double check scandate %s'%scandate
+            print e
+            exit(-10)
+            pass
+
+        # Get dependent variable value - VFAT Level
+        dataThisVFAT = arrayVFATData[ arrayVFATData['vfatN'] == vfat] #VFAT Level
+
+        # Get the data for each strip and store it as a tuple in the list to be returned
+        for chan in range(0,128):
+            dataThisChan = dataThisVFAT[ dataThisVFAT[strChanName] == chan] #Channel Level
+            depVarVal = np.asscalar(np.mean(dataThisChan[branchName]))
+            listData.append( (indepVarVal, chan, depVarVal) )
+            pass
+
+    # Return Data
+    return listData
 
 if __name__ == '__main__':
     from anaInfo import tree_names
@@ -70,18 +135,29 @@ if __name__ == '__main__':
     from macros.plotoptions import parser
     from mapping.chamberInfo import chamber_config
     
+    import array
+    import numpy as np
     import os
+    import ROOT as r
     
     parser.add_option("-a","--all", action="store_true", dest="all_plots",
                     help="vfatList is automatically set to [0,1,...,22,23]", metavar="all_plots")
+    parser.add_option("--axisMax", type="float", dest="axisMax", default=255,
+                    help="Maximum value for axis depicting branchName", metavar="axisMax")
+    parser.add_option("--axisMin", type="float", dest="axisMin", default=0,
+                    help="Minimum value for axis depicting branchName", metavar="axisMin")
     parser.add_option("--anaType", type="string", dest="anaType",
                     help="Analysis type to be executed, from list {'latency','scurve','scurveAna','threshold','trim','trimAna'}", metavar="anaType")
     parser.add_option("--branchName", type="string", dest="branchName",
                     help="Name of TBranch where dependent variable is store", metavar="branchName")
+    parser.add_option("--make2D", action="store_true", dest="make2D",
+                    help="A 2D plot of (indepVar, chan, branchName) is made instead of a 1D plot", metavar="make2D")
     parser.add_option("-p","--print", action="store_true", dest="printData",
                     help="Prints a comma separated table with the data to the terminal", metavar="printData")
     parser.add_option("--rootOpt", type="string", dest="rootOpt", default="RECREATE",
                     help="Option for the output TFile, e.g. {'RECREATE','UPDATE'}", metavar="rootOpt")
+    parser.add_option("--showStat", action="store_true", dest="showStat",
+                    help="Draws the statistics box for 2D plots", metavar="showStat")
     parser.add_option("--vfatList", type="string", dest="vfatList", default=None,
                     help="Comma separated list of VFATs to consider, e.g. '12,13'", metavar="vfatList")
     
@@ -94,13 +170,13 @@ if __name__ == '__main__':
     elogPath  = os.getenv('ELOG_PATH')
 
     # Get VFAT List
-    list_VFATs = []
+    listVFATs = []
     if options.all_plots:
-        list_VFATs = (x for x in range(0,24))
+        listVFATs = (x for x in range(0,24))
     elif options.vfatList != None:
-        list_VFATs = map(int, options.vfatList.split(','))
+        listVFATs = map(int, options.vfatList.split(','))
     elif options.vfat != None:
-        list_VFATs.append(options.vfat)
+        listVFATs.append(options.vfat)
     else:
         print "You must specify at least one VFAT to be considered"
         exit(-1)
@@ -128,71 +204,178 @@ if __name__ == '__main__':
         
         # Make input list for arbitraryPlotter()
         listDataPtTuples.append( (analysisList[0], analysisList[1], float(analysisList[2]) ) )
-
+    
     # Do we make strip/channel level plot?
-    vfatCh=None
+    vfatCH=None
     strip=None
+    strDrawOpt = "APE1"
     strStripOrChan = "All"
+    listIndepVarLowEdge = [] #Only used if options.make2D is True
     if options.strip is not None:
+        # Set the strip or channel name
         if options.channels:
-            vfatCh = options.strip
-            strStripOrChan = "vfatCh%i"%options.strip
+            vfatCH = options.strip
+            strStripOrChan = "vfatCH%i"%options.strip
         else:
             strip = options.strip
             strStripOrChan = "ROBstr%i"%options.strip
+    elif options.make2D:
+        strDrawOpt = "COLZ"
 
-    # Get the Requested Data & Store it in an output ROOT File
+        # Set the strip or channel name - no channel number here, over all of them
+        if options.channels:
+            strStripOrChan = "vfatCH"
+        else:
+            strStripOrChan = "ROBstr"
+        
+        # Get a list of indep variable values & difference between values
+        listIndepVarVals = []
+        arraydeltaIndepVar = np.zeros(len(listDataPtTuples)) #Difference between i and i+1 indepVar
+        for i in range(0,len(listDataPtTuples)):
+            listIndepVarVals.append(listDataPtTuples[i][2])
+            if i == (len(listDataPtTuples) - 1):
+                arraydeltaIndepVar[i] = 0.
+            else:
+                arraydeltaIndepVar[i] = np.fabs(listDataPtTuples[i][2] - listDataPtTuples[i+1][2])
+        arraydeltaIndepVar[len(arraydeltaIndepVar)-1] = np.mean(arraydeltaIndepVar[:(len(arraydeltaIndepVar)-1)])
+
+        # Set the values in listIndepVarLowEdge
+        for i in range(0,len(listIndepVarVals)):
+            if i == 0:
+                # x_low_i = x_i - 0.5 * <delta_x>
+                listIndepVarLowEdge.append(listIndepVarVals[i] - 0.5 * arraydeltaIndepVar[len(arraydeltaIndepVar)-1])
+            else:
+                # x_low_i = x_i - 0.5 * delta_x_(i-1)
+                listIndepVarLowEdge.append(listIndepVarVals[i] - 0.5 * arraydeltaIndepVar[i-1])
+        listIndepVarLowEdge.append(listIndepVarVals[len(listIndepVarVals)-1] + 0.5 * arraydeltaIndepVar[len(arraydeltaIndepVar)-1])
+
+        #print "len(listDataPtTuples) = %i"%len(listDataPtTuples)
+        #print "len(listIndepVarLowEdge) = %i"%len(listIndepVarLowEdge)
+
+    # Loop over the vfats in listVFATs and make the requested plot for each
     strIndepVarNoBraces = strIndepVar.replace('{','').replace('}','').replace('_','')
     strRootName = elogPath + "/gemPlotterOutput_%s_vs_%s.root"%(options.branchName, strIndepVarNoBraces)
-    import ROOT as r
+    r.gROOT.SetBatch(True)
     outF = r.TFile(strRootName,options.rootOpt)
-    list_Plots = []
-    for vfat in list_VFATs:
-        list_Data = arbitraryPlotter(
-                options.anaType, 
-                listDataPtTuples, 
-                tree_names[options.anaType][0], 
-                tree_names[options.anaType][1], 
-                options.branchName, 
-                vfat, 
-                vfatCh, 
-                strip)
+    listPlots = []
+    for vfat in listVFATs:
+        # Make the output directory
+        dirVFAT = r.TDirectory()
+        if options.rootOpt.upper() == "UPDATE":
+            dirVFAT = outF.GetDirectory("VFAT%i"%vfat, False, "GetDirectory")
+        else:
+            dirVFAT = outF.mkdir("VFAT%i"%vfat)
+            pass
+        dirVFAT.cd()
 
-        # Print to the user
-        # Using format compatible with: https://github.com/cms-gem-detqc-project/CMS_GEM_Analysis_Framework#4eiviii-header-parameters---data
-        if options.printData:
-            print "===============Printing Data for VFAT%i==============="%(vfat)
-            print "[BEGIN_DATA]"
-            print "\tVAR_INDEP,VAR_DEP,VAR_DEP_ERR"
-            for dataPt in list_Data:
-                print "\t%f,%f,%f"%(dataPt[0],dataPt[1],dataPt[2])
-            print "[END_DATA]"
-            print ""
+        # Make the output canvas, use a temp name and temp title for now
+        strCanvName = ""
+        canvPlot = r.TCanvas("canv_VFAT%i"%(vfat),"VFAT%i"%(vfat),600,600)
 
-        # Make the plot
-        import ROOT as r
-        r.gROOT.SetBatch(True)
-        grPlot = r.TGraphErrors(len(list_Data))
-        grPlot.SetTitle("VFAT%i_%s"%(vfat,strStripOrChan))
-        grPlot.SetName("g_%s_vs_%s_VFAT%i_%s"%(options.branchName, strIndepVarNoBraces, vfat, strStripOrChan))
-        grPlot.SetMarkerStyle(20)
-        grPlot.SetLineWidth(2)
-        for idx in range(len(list_Data)):
-            grPlot.SetPoint(idx, list_Data[idx][0], list_Data[idx][1])
-            grPlot.SetPointError(idx, 0., list_Data[idx][2])
+        # Make the plot, either 2D or 1D
+        if options.make2D:
+            listData = arbitraryPlotter2D(
+                    options.anaType, 
+                    listDataPtTuples, 
+                    tree_names[options.anaType][0], 
+                    tree_names[options.anaType][1], 
+                    options.branchName, 
+                    vfat,
+                    not options.channels)
 
-        # Draw this plot on a canvas
-        canvPlot = r.TCanvas("canv_%s_vs_%s_VFAT%i_%s"%(options.branchName,strIndepVarNoBraces, vfat, strStripOrChan),
-                             "VFAT%i_%s: %s vs. %s"%(vfat,strStripOrChan,options.branchName,strIndepVarNoBraces),600,600)
-        canvPlot.cd()
-        grPlot.Draw("APE1")
-        grPlot.GetXaxis().SetTitle(strIndepVar)
-        grPlot.GetYaxis().SetDecimals(True)
-        grPlot.GetYaxis().SetTitle(options.branchName)
-        grPlot.GetYaxis().SetTitleOffset(1.2)
-        canvPlot.Update()
-        strCanvName = elogPath + "/canv_%s_vs_%s_VFAT%i_%s.png"%(options.branchName,strIndepVarNoBraces, vfat,strStripOrChan)
-        canvPlot.SaveAs(strCanvName)
+            # Print to the user
+            if options.printData:
+                print "===============Printing Data for VFAT%i==============="%(vfat)
+                print "[BEGIN_DATA]"
+                print "\tVAR_INDEP,VAR_DEP,VALUE"
+                for dataPt in listData:
+                    print "\t%f,%f,%f"%(dataPt[0],dataPt[1],dataPt[2])
+                print "[END_DATA]"
+                print ""
+            
+
+            # Make the plot
+            binsIndepVarLowEdge = array.array('d',listIndepVarLowEdge)
+            hPlot2D = r.TH2F("h_%s_vs_%s_Obs%s_VFAT%i"%(strStripOrChan, strIndepVarNoBraces, options.branchName, vfat),
+                            "VFAT%i"%(vfat),
+                            len(listIndepVarLowEdge)-1, binsIndepVarLowEdge,
+                            128, -0.5, 127.5)
+            hPlot2D.SetXTitle(strIndepVar)
+            hPlot2D.SetYTitle(strStripOrChan)
+            hPlot2D.SetZTitle(options.branchName)
+            
+            # Fill the plot
+            for idx in range(len(listData)):
+                hPlot2D.Fill(listData[idx][0],listData[idx][1],listData[idx][2])
+            
+            # Set the Stat Box Options
+            if options.showStat:
+                r.gStyle.SetOptStat(1111111)
+            else:
+                r.gStyle.SetOptStat(0000000)
+                
+            # Draw this plot on a canvas
+            strCanvName = elogPath + "/canv_%s_vs_%s_Obs%s_VFAT%i.png"%(strStripOrChan, strIndepVarNoBraces, options.branchName, vfat)
+            canvPlot.SetName("canv_%s_vs_%s_Obs%s_VFAT%i.png"%(strStripOrChan, strIndepVarNoBraces, options.branchName, vfat))
+            canvPlot.SetTitle("VFAT%i: %s vs. %s - Obs %s"%(vfat,strStripOrChan,strIndepVarNoBraces, options.branchName))
+            canvPlot.SetRightMargin(0.15)
+            canvPlot.cd()
+            hPlot2D.GetZaxis().SetRangeUser(options.axisMin, options.axisMax)
+            hPlot2D.Draw(strDrawOpt)
+            hPlot2D.GetYaxis().SetDecimals(True)
+            hPlot2D.GetYaxis().SetTitleOffset(1.2)
+            
+            # Store the plot
+            hPlot2D.Write()
+            listPlots.append(hPlot2D)
+        else:
+            listData = arbitraryPlotter(
+                    options.anaType, 
+                    listDataPtTuples, 
+                    tree_names[options.anaType][0], 
+                    tree_names[options.anaType][1], 
+                    options.branchName, 
+                    vfat, 
+                    vfatCH, 
+                    strip)
+
+            # Print to the user
+            # Using format compatible with: https://github.com/cms-gem-detqc-project/CMS_GEM_Analysis_Framework#4eiviii-header-parameters---data
+            if options.printData:
+                print "===============Printing Data for VFAT%i==============="%(vfat)
+                print "[BEGIN_DATA]"
+                print "\tVAR_INDEP,VAR_DEP,VAR_DEP_ERR"
+                for dataPt in listData:
+                    print "\t%f,%f,%f"%(dataPt[0],dataPt[1],dataPt[2])
+                print "[END_DATA]"
+                print ""
+
+            # Make the plot
+            grPlot = r.TGraphErrors(len(listData))
+            grPlot.SetTitle("VFAT%i_%s"%(vfat,strStripOrChan))
+            grPlot.SetName("g_%s_vs_%s_VFAT%i_%s"%(options.branchName, strIndepVarNoBraces, vfat, strStripOrChan))
+            grPlot.SetMarkerStyle(20)
+            grPlot.SetLineWidth(2)
+            for idx in range(len(listData)):
+                grPlot.SetPoint(idx, listData[idx][0], listData[idx][1])
+                grPlot.SetPointError(idx, 0., listData[idx][2])
+
+            # Draw this plot on a canvas
+            strCanvName = elogPath + "/canv_%s_vs_%s_VFAT%i_%s.png"%(options.branchName,strIndepVarNoBraces, vfat,strStripOrChan)
+            canvPlot.SetName("canv_%s_vs_%s_VFAT%i_%s"%(options.branchName,strIndepVarNoBraces, vfat, strStripOrChan))
+            canvPlot.SetTitle("VFAT%i_%s: %s vs. %s"%(vfat,strStripOrChan,options.branchName,strIndepVarNoBraces))
+            canvPlot.cd()
+            grPlot.Draw(strDrawOpt)
+            grPlot.GetXaxis().SetTitle(strIndepVar)
+            grPlot.GetYaxis().SetDecimals(True)
+            grPlot.GetYaxis().SetRangeUser(options.axisMin, options.axisMax)
+            grPlot.GetYaxis().SetTitle(options.branchName)
+            grPlot.GetYaxis().SetTitleOffset(1.2)
+        
+            # Store the plot
+            grPlot.Write()
+            listPlots.append(grPlot)
+            pass
         
         if not options.all_plots:
             print ""
@@ -200,18 +383,9 @@ if __name__ == '__main__':
             print ("eog " + strCanvName)
             print ""
 
-        # Store
-        list_Plots.append(grPlot)
-
-        dirVFAT = r.TDirectory()
-        if options.rootOpt.upper() == "UPDATE":
-            dirVFAT = outF.GetDirectory("VFAT%i"%vfat, False, "GetDirectory")
-        else:
-            dirVFAT = outF.mkdir("VFAT%i"%vfat)
-            pass
-
-        dirVFAT.cd()
-        grPlot.Write()
+        # Store the Canvas
+        canvPlot.Update()
+        canvPlot.SaveAs(strCanvName)
         canvPlot.Write()
         pass
 
@@ -219,7 +393,7 @@ if __name__ == '__main__':
     if options.all_plots:
         from anautilities import make3x8Canvas
         strSummaryName = "summary_%s_vs_%s_%s"%(options.branchName, strIndepVarNoBraces,strStripOrChan)
-        canv_summary = make3x8Canvas( strSummaryName, list_Plots, "APE1")
+        canv_summary = make3x8Canvas( strSummaryName, listPlots, strDrawOpt)
         
         strCanvName = "%s/%s.png"%(elogPath,strSummaryName)
         canv_summary.SaveAs(strCanvName)

--- a/macros/gemPlotter.py
+++ b/macros/gemPlotter.py
@@ -52,7 +52,8 @@ def arbitraryPlotter(anaType, listDataPtTuples, rootFileName, treeName, branchNa
         except Exception as e:
             print '%s may not exist in %s, please cross check'%(treeName,filename)
             print e
-            exit(os.EX_NOTFOUND)
+            #exit(os.EX_NOTFOUND) #Weird, not found but described in: https://docs.python.org/2/library/os.html#process-management
+            exit(os.EX_DATAERR)
             pass
 
         # Check to make sure listNames are present in dataTree
@@ -63,7 +64,8 @@ def arbitraryPlotter(anaType, listDataPtTuples, rootFileName, treeName, branchNa
                 for realBranch in knownBranches:
                     print realBranch
                 print "Please try again using one of the existing branches"
-                exit(os.EX_NOTFOUND)
+                #exit(os.EX_NOTFOUND) #Weird, not found but described in: https://docs.python.org/2/library/os.html#process-management
+                exit(os.EX_DATAERR)
 
         # Get dependent variable value
         arrayVFATData = rp.tree2array(dataTree,listNames)
@@ -139,7 +141,8 @@ def arbitraryPlotter2D(anaType, listDataPtTuples, rootFileName, treeName, branch
         except Exception as e:
             print '%s may not exist in %s, please cross check'%(treeName,filename)
             print e
-            exit(os.EX_NOTFOUND)
+            #exit(os.EX_NOTFOUND) #Weird, not found but described in: https://docs.python.org/2/library/os.html#process-management
+            exit(os.EX_DATAERR)
             pass
 
         # Check to make sure listNames are present in dataTree
@@ -150,7 +153,8 @@ def arbitraryPlotter2D(anaType, listDataPtTuples, rootFileName, treeName, branch
                 for realBranch in knownBranches:
                     print realBranch
                 print "Please try again using one of the existing branches"
-                exit(os.EX_NOTFOUND)
+                #exit(os.EX_NOTFOUND) #Weird, not found but described in: https://docs.python.org/2/library/os.html#process-management
+                exit(os.EX_DATAERR)
 
         # Get dependent variable value - VFAT Level
         arrayVFATData = rp.tree2array(dataTree,listNames)

--- a/macros/gemPlotterAllChannels.sh
+++ b/macros/gemPlotterAllChannels.sh
@@ -1,11 +1,27 @@
 #!/bin/bash
-# Usage:
-# ./gemPlotterAllChannels.sh <InFile> <anaType> <branchName>
+usage() {
+    echo 'Usage : ./gemPlotterAllChannels.sh <InFile> <anaType> <branchName>'
+    echo '          InFile: tab delimited input file, first line is "ChamberName\tscandate\tIndepVarName"'
+    echo '                  subseuqent lines are values for: "ChamberName\tscandate\tIndepVarValue", e.g.:'
+    echo '                  GE11-VI-L-CERN-0002 2017.09.04.20.12    1'
+    echo ''
+    echo '          anaType: type of analysis to perform, see tree_names.keys() of anaInfo.py'
+    echo ''
+    echo '          branchName: TName of the TBranch whose data will be plotted against IndepVarName,'
+    echo '                      note this TBranch must be in a TTree found in tree_names.keys() of anaInfo.py'
+    kill -INT $$;
+}
 
+# Check inputs
+if [ -z ${3+x} ] || [ -z ${2+x} ] || [ -z ${1+x} ]
+then
+    usage
+fi
+
+# Make plots
 INFILE=$1
 ANATYPE=$2
 BRANCHNAME=$3
-
 for chan in {0..127}
 do
     if [ $chan -eq 0 ]; then

--- a/macros/gemPlotterAllChannels.sh
+++ b/macros/gemPlotterAllChannels.sh
@@ -22,13 +22,28 @@ fi
 INFILE=$1
 ANATYPE=$2
 BRANCHNAME=$3
+
+if [ ! -f $INFILE ]; then
+   echo "Input file: ${INFILE} not found"
+   echo "Please cross-check, exiting"
+   kill -INT $$;
+fi
+
 for chan in {0..127}
 do
     if [ $chan -eq 0 ]; then
         echo gemPlotter.py -i$INFILE -s$chan -a --anaType=$ANATYPE --branchName=$BRANCHNAME --rootOpt=RECREATE
-        gemPlotter.py -i$INFILE -s$chan -a --anaType=$ANATYPE --branchName=$BRANCHNAME --rootOpt=RECREATE
+        if gemPlotter.py -i$INFILE -s$chan -a --anaType=$ANATYPE --branchName=$BRANCHNAME --rootOpt=RECREATE ; then
+            continue
+        else
+                break
+        fi
     else
         echo gemPlotter.py -i$INFILE -s$chan -a --anaType=$ANATYPE --branchName=$BRANCHNAME --rootOpt=UPDATE
-        gemPlotter.py -i$INFILE -s$chan -a --anaType=$ANATYPE --branchName=$BRANCHNAME --rootOpt=UPDATE
+        if gemPlotter.py -i$INFILE -s$chan -a --anaType=$ANATYPE --branchName=$BRANCHNAME --rootOpt=UPDATE ; then
+            continue
+        else
+            break
+        fi
     fi
 done

--- a/macros/gemPlotterAllChannels.sh
+++ b/macros/gemPlotterAllChannels.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Usage:
+# ./gemPlotterAllChannels.sh <InFile> <anaType> <branchName>
+
+INFILE=$1
+ANATYPE=$2
+BRANCHNAME=$3
+
+for chan in {0..127}
+do
+    if [ $chan -eq 0 ]; then
+        echo gemPlotter.py -i$INFILE -s$chan -a --anaType=$ANATYPE --branchName=$BRANCHNAME --rootOpt=RECREATE
+        gemPlotter.py -i$INFILE -s$chan -a --anaType=$ANATYPE --branchName=$BRANCHNAME --rootOpt=RECREATE
+    else
+        echo gemPlotter.py -i$INFILE -s$chan -a --anaType=$ANATYPE --branchName=$BRANCHNAME --rootOpt=UPDATE
+        gemPlotter.py -i$INFILE -s$chan -a --anaType=$ANATYPE --branchName=$BRANCHNAME --rootOpt=UPDATE
+    fi
+done

--- a/mapping/chamberInfo.py
+++ b/mapping/chamberInfo.py
@@ -1,55 +1,55 @@
 chamber_config = {
     #Coffin Setup
-    #0:"GE11-VI-L-CERN-0002"
+    0:"GE11-VI-L-CERN-0002"
     #Cosmic Stand
     #0:"GE11-VI-L-CERN-0001"
     #Point 5
-    0:"GEMINIm01L1",
-    1:"GEMINIm01L2",
-    2:"GEMINIm27L1",
-    3:"GEMINIm27L2",
-    4:"GEMINIm28L1",
-    5:"GEMINIm28L2",
-    6:"GEMINIm29L1",
-    7:"GEMINIm29L2",
-    8:"GEMINIm30L1",
-    9:"GEMINIm30L2"
+    #0:"GEMINIm01L1",
+    #1:"GEMINIm01L2",
+    #2:"GEMINIm27L1",
+    #3:"GEMINIm27L2",
+    #4:"GEMINIm28L1",
+    #5:"GEMINIm28L2",
+    #6:"GEMINIm29L1",
+    #7:"GEMINIm29L2",
+    #8:"GEMINIm30L1",
+    #9:"GEMINIm30L2"
     }
 
 GEBtype = {
     #Coffin Setup
-    #0:"long"
+    0:"long"
     #Cosmic Stand
     #0:"long"
     #Point 5
-    0:"short",
-    1:"short",
-    2:"short",
-    3:"short",
-    4:"long",
-    5:"long",
-    6:"short",
-    7:"short",
-    8:"long",
-    9:"long"
+    #0:"short",
+    #1:"short",
+    #2:"short",
+    #3:"short",
+    #4:"long",
+    #5:"long",
+    #6:"short",
+    #7:"short",
+    #8:"long",
+    #9:"long"
     }
 
 chamber_vfatMask = {
     #Coffin Setup
-    #0:0x"
+    0:0x0
     #Cosmic Stand
     #0:0xF40400
     #Point 5
-    0:0x0,
-    1:0x0,
-    2:0x0,
-    3:0x0,
-    4:0x0,
-    5:0x0,
-    6:0x0,
-    7:0x0,
-    8:0x0,
-    9:0x0
+    #0:0x0,
+    #1:0x0,
+    #2:0x0,
+    #3:0x0,
+    #4:0x0,
+    #5:0x0,
+    #6:0x0,
+    #7:0x0,
+    #8:0x0,
+    #9:0x0
     }
     
 chamber_vfatDACSettings = {    

--- a/mapping/chamberInfo.py
+++ b/mapping/chamberInfo.py
@@ -1,55 +1,55 @@
 chamber_config = {
     #Coffin Setup
-    0:"GE11-VI-L-CERN-0002"
+    #0:"GE11-VI-L-CERN-0002"
     #Cosmic Stand
     #0:"GE11-VI-L-CERN-0001"
     #Point 5
-    #0:"GEMINIm01L1",
-    #1:"GEMINIm01L2",
-    #2:"GEMINIm27L1",
-    #3:"GEMINIm27L2",
-    #4:"GEMINIm28L1",
-    #5:"GEMINIm28L2",
-    #6:"GEMINIm29L1",
-    #7:"GEMINIm29L2",
-    #8:"GEMINIm30L1",
-    #9:"GEMINIm30L2"
+    0:"GEMINIm01L1",
+    1:"GEMINIm01L2",
+    2:"GEMINIm27L1",
+    3:"GEMINIm27L2",
+    4:"GEMINIm28L1",
+    5:"GEMINIm28L2",
+    6:"GEMINIm29L1",
+    7:"GEMINIm29L2",
+    8:"GEMINIm30L1",
+    9:"GEMINIm30L2"
     }
 
 GEBtype = {
     #Coffin Setup
-    0:"long"
+    #0:"long"
     #Cosmic Stand
     #0:"long"
     #Point 5
-    #0:"short",
-    #1:"short",
-    #2:"short",
-    #3:"short",
-    #4:"long",
-    #5:"long",
-    #6:"short",
-    #7:"short",
-    #8:"long",
-    #9:"long"
+    0:"short",
+    1:"short",
+    2:"short",
+    3:"short",
+    4:"long",
+    5:"long",
+    6:"short",
+    7:"short",
+    8:"long",
+    9:"long"
     }
 
 chamber_vfatMask = {
     #Coffin Setup
-    0:0x0
+    #0:0x0
     #Cosmic Stand
     #0:0xF40400
     #Point 5
-    #0:0x0,
-    #1:0x0,
-    #2:0x0,
-    #3:0x0,
-    #4:0x0,
-    #5:0x0,
-    #6:0x0,
-    #7:0x0,
-    #8:0x0,
-    #9:0x0
+    0:0x0,
+    1:0x0,
+    2:0x0,
+    3:0x0,
+    4:0x0,
+    5:0x0,
+    6:0x0,
+    7:0x0,
+    8:0x0,
+    9:0x0
     }
     
 chamber_vfatDACSettings = {    

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-numpy>=1.10.4
+#numpy>=1.10.4
+numpy>=1.7.1
 root-numpy>=4.7.2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Starting to address: https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/33

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Right now if a particular plot of interest is desired a user has to make it by hand.  This feature seeks to address that.  The user provides a `tab` delimited text file `listOfScanDates.txt` of the form:

```
ChamberName scandate    <IndepVarName>
cName date    IndepVarVal1
cName date    IndepVarVal2
cName date    IndepVarVal3
...
...
cName date    IndepVarValN-1
cName date    IndepVarValN
```

And calls:

```
gemPlotter.py --anaType=trim --infilename=listOfScanDates.txt --vfatList=<comma separated list of integers> --strip=49 --branchName=<Name>
```

Then a plot of `branchName` vs `IndepVarName` from the scan dates specified, for each of the VFATs specified will be created.  Please note that `cName` need not be the same for each row (however then one would imagine that `IndepVar` is some expression derived from Layer & Slot...)!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By producing plots below.

### Screenshots (if appropriate):
Calling:
```
gemPlotter.py -ilistOfScanDates_Trim.txt -s10 -a --anaType=trimAna --branchName=trimDAC --axisMin=0 --axisMax=31
```
<img width="1077" alt="gemplotter_trimdac_vs_runno_vfat10_strip10_summary" src="https://user-images.githubusercontent.com/6432141/30335789-8aeb918e-97e3-11e7-990e-2d41d060c171.png">

Calling:
```
gemPlotter.py -ilistOfScanDates_Trim.txt -s10 -v10 --anaType=trimAna --branchName=trimDAC --axisMin=0 --axisMax=31
```
<img width="598" alt="gemplotter_trimdac_vs_runno_vfat10_strip10" src="https://user-images.githubusercontent.com/6432141/30335790-8aed25f8-97e3-11e7-991e-9301c4bfa101.png">

Calling:
```
gemPlotter.py -ilistOfScanDates_Trim.txt -a --anaType=trimAna --branchName=trimDAC --make2D --axisMin=-1 --axisMax=31
```
<img width="1435" alt="gemplotter_strip_vs_runno_obstrimdac_summary" src="https://user-images.githubusercontent.com/6432141/30335788-8aea56b6-97e3-11e7-8fb1-3588f123d10e.png">

Calling:
```
gemPlotter.py -ilistOfScanDates_Trim.txt -v10 --anaType=trimAna --branchName=trimDAC --make2D --axisMin=-1 --axisMax=31
```
<img width="598" alt="gemplotter_strip_vs_runno_obstrimdac_vfat10" src="https://user-images.githubusercontent.com/6432141/30335798-8f12b86e-97e3-11e7-88a2-b83de9bc8106.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->