### PR TITLE
Better Fitting of Ultra Latency Scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc)
 ## Setup:
 The following `$SHELL` variables should be defined:
 
-- $BUILD_HOME
-- $DATA_PATH
-- $ELOG_PATH
+- `$BUILD_HOME`
+- `$DATA_PATH`
+- `$ELOG_PATH`
 
 Then execute:
 
@@ -39,7 +39,7 @@ The following table shows the mandatory inputs that must be supplied to execute 
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| --anaType | string | Analysis type to be executed, see `tree_names.keys()` of `anaInfo.py` for possible inputs |
+| --anaType | string | Analysis type to be executed, see `tree_names.keys()` of [anaInfo.py](https://github.com/cms-gem-daq-project/gem-plotting-tools/blob/master/anaInfo.py) for possible inputs |
 | --branchName | string | Name of TBranch where dependent variable is found, note that this TBranch should be found in the `TTree` that corresponds to the value given to the `--anaType` argument |
 | -i, --infilename | string | physical filename of the input file to be passed to `gemPlotter.py`.  See [Input File Structure](#input-file-structure) for details on the format and contents of this file. |
 | -v, --vfat | int | Specify VFAT to plot |
@@ -56,7 +56,7 @@ The following table shows the optional inputs that can be supplied when executin
 | -c, --channels | none | When providing this flag the `--strip` option is interpreted as VFAT channel number instead of readout board (ROB) strip number. |
 | -s, --strip | int | Specific ROB strip number to plot for `--branchName`.  Note for ROB strip level `--branchName` values (e.g. `trimDAC`) if this option is *not* provided the data point (error bar) will represent the mean (standard deviation) of `--branchName` from all strips. |
 | --make2D | none| When providing this flag a 2D plot of ROB strip/vfat channel vs. independent variable will be plotted whose z-axis value is `--branchName`. |
-| -p, --print | none | Prints a comma separated table of the plot's data to the terminal.  The format of this table will be compatible with the `genericPlotter` executable of the [CMS_GEM_Analysis_Framework](https://github.com/cms-gem-detqc-project/CMS_GEM_Analysis_Framework#4eiviii-header-parameters---data). | 
+| -p, --print | none | Prints a comma separated table of the plot's data to the terminal.  The format of this table will be compatible with the [genericPlotter](https://github.com/cms-gem-detqc-project/CMS_GEM_Analysis_Framework#3b-genericplotter) executable of the [CMS_GEM_Analysis_Framework](https://github.com/cms-gem-detqc-project/CMS_GEM_Analysis_Framework). | 
 | --rootOpt | string | Option for creating the output `TFile`, e.g. {'RECREATE','UPDATE'} |
 | --showStat | none | Causes the statistics box to be drawn on created plots. Note only applicable when used with `--make2D`. |
 | --vfatList | Comma separated list of int's | List of VFATs that should be plotted.  May be used instead of the `--vfat` option. |
@@ -68,7 +68,7 @@ This should be a `tab` deliminited text file.  The first line of this file shoul
 ChamberName scandate    <Indep. Variable Name>
 ```
 
-Subsequent lines of this file are the values that correspond to these column headings.  The value of the `ChamberName` column must correspond to the value of one entry in the `chamber_config` dictionary found in `mapping/chamberInfo.py`.  The **Indep. Variable Name** is the independent variable that `--branchName` will be plotted against and is assumed to be numeric.  Please note the `#` character is  understood as a comment, lines starting with a `#` will be skipped.
+Subsequent lines of this file are the values that correspond to these column headings.  The value of the `ChamberName` column must correspond to the value of one entry in the `chamber_config` dictionary found in [mapping/chamberInfo.py](https://github.com/cms-gem-daq-project/gem-plotting-tools/blob/master/mapping/chamberInfo.py).  The **Indep. Variable Name** is the independent variable that `--branchName` will be plotted against and is assumed to be numeric.  Please note the `#` character is  understood as a comment, lines starting with a `#` will be skipped.
 
 A complete example for a single detector is given as:
 
@@ -81,7 +81,7 @@ GE11-VI-L-CERN-0002 2017.09.05.04.21    40
 GE11-VI-L-CERN-0002 2017.09.05.07.11    50
 ```
 
-Here the `ChamberName` is always `GE11-VI-L-CERN-0002` and `--branchName` will be plotted against `VT_{1}` which is the **Indep. Variable Name** is `RunNo`.  Note the axis of interest will be assigned the label, with subscripts in this case, of `VT_{1}`.
+Here the `ChamberName` is always `GE11-VI-L-CERN-0002` and `--branchName` will be plotted against `VT_{1}` which is the **Indep. Variable Name**.  Note the axis of interest will be assigned the label, with subscripts in this case, of `VT_{1}`.
 
 A complete example for multiple detectors is given as:
 

--- a/anaUltraLatency.py
+++ b/anaUltraLatency.py
@@ -14,6 +14,14 @@ from anaoptions import parser
 from array import array
 from gempython.utils.nesteddict import nesteddict as ndict
 
+parser.add_option("-f", "--fit", action="store_true", dest="performFit",
+                  help="Fit the latency distributions", metavar="performFit")
+parser.add_option("--latSigRange", type="string", dest="latSigRange", default=None,
+                  help="Comma separated pair of values defining expected signal range, e.g. lat #epsilon [41,43] is signal", metavar="latSigRange")
+parser.add_option("--latNoiseRange", type="string", dest="latNoiseRange", default=None,
+                  help="Comma separated pair of values defining expected noise range, e.g. lat #notepsilon [40,44] is noise (lat < 40 || lat > 44)", 
+                  metavar="latNoiseRange")
+
 parser.set_defaults(outfilename="LatencyData.root")
 
 (options, args) = parser.parse_args()
@@ -39,6 +47,7 @@ for vfat in range(0,24):
 print 'Filling Histograms'
 latMin = 1000
 latMax = -1
+nTrig = -1
 for event in inF.latTree:
     dict_hVFATHitsVsLat[int(event.vfatN)].Fill(event.lat,event.Nhits)
     if event.lat < latMin and event.Nhits > 0:
@@ -47,41 +56,97 @@ for event in inF.latTree:
     elif event.lat > latMax:
         latMax = event.lat
         pass
+
+    if nTrig < 0:
+        nTrig = event.Nev
+        pass
     pass
 
+# Set Latency Fitting Bounds - Signal
+latFitMin_Sig = latMin
+latFitMax_Sig = latMax
+if options.latSigRange is not None:
+    listLatValues = map(lambda val: float(val), options.latSigRange.split(","))
+    latFitMin_Sig = min(listLatValues)
+    latFitMax_Sig = max(listLatValues)
+
+# Set Latency Fitting Bounds - Noise
+latFitMin_Noise = latFitMin_Sig - 1
+latFitMax_Noise = latFitMax_Sig + 1
+if options.latNoiseRange is not None:
+    listLatValues = map(lambda val: float(val), options.latNoiseRange.split(","))
+    latFitMin_Noise = min(listLatValues)
+    latFitMax_Noise = max(listLatValues)
+
+#Make output plots
 from math import sqrt
 outF = r.TFile(filename+"/"+options.outfilename,"RECREATE")
 dict_grNHitsVFAT = ndict()
-dict_fitNHitsVFAT = ndict()
-grNMaxLatBinByVFAT = r.TGraphAsymmErrors(len(dict_hVFATHitsVsLat))
-grMaxLatBinByVFAT = r.TGraphAsymmErrors(len(dict_hVFATHitsVsLat))
-grVFATSigOverSigPBkg = r.TGraphAsymmErrors(len(dict_hVFATHitsVsLat))
+dict_fitNHitsVFAT_Sig = ndict()
+dict_fitNHitsVFAT_Noise = ndict()
+grNMaxLatBinByVFAT = r.TGraphErrors(len(dict_hVFATHitsVsLat))
+grMaxLatBinByVFAT = r.TGraphErrors(len(dict_hVFATHitsVsLat))
+grVFATSigOverBkg = r.TGraphErrors(len(dict_hVFATHitsVsLat))
+grVFATNSignalNoBkg = r.TGraphErrors(len(dict_hVFATHitsVsLat))
 r.gStyle.SetOptStat(0)
 canv_Summary = r.TCanvas("canv_Summary","Latency Summary",500*8,500*3)
 canv_Summary.Divide(8,3)
+if options.debug and options.performFit:
+    print "VFAT\tSignalHits\tSignal/Noise"
 for vfat in dict_hVFATHitsVsLat:
     #Store Max Info
     NMaxLatBin = dict_hVFATHitsVsLat[vfat].GetBinContent(dict_hVFATHitsVsLat[vfat].GetMaximumBin())
     grNMaxLatBinByVFAT.SetPoint(vfat, vfat, NMaxLatBin)
-    grNMaxLatBinByVFAT.SetPointError(vfat, 0, 0, sqrt(NMaxLatBin), sqrt(NMaxLatBin))
+    grNMaxLatBinByVFAT.SetPointError(vfat, 0, sqrt(NMaxLatBin))
 
     grMaxLatBinByVFAT.SetPoint(vfat, vfat, dict_hVFATHitsVsLat[vfat].GetBinCenter(dict_hVFATHitsVsLat[vfat].GetMaximumBin()))
-    grMaxLatBinByVFAT.SetPointError(vfat, 0, 0, 0.5, 0.5) #could be improved upon
+    grMaxLatBinByVFAT.SetPointError(vfat, 0, 0.5) #could be improved upon
 
     #Initialize
-    dict_fitNHitsVFAT[vfat] = r.TF1("vfat%iFitHitsVsLat"%vfat,"[0]",latMin,latMax)
+    dict_fitNHitsVFAT_Sig[vfat] = r.TF1("func_N_vs_Lat_VFAT%i_Sig"%vfat,"[0]",latFitMin_Sig,latFitMax_Sig)
+    dict_fitNHitsVFAT_Noise[vfat] = r.TF1("func_N_vs_Lat_VFAT%i_Noise"%vfat,"[0]",latMin,latMax)
     dict_grNHitsVFAT[vfat] = r.TGraphAsymmErrors(dict_hVFATHitsVsLat[vfat])
-    dict_grNHitsVFAT[vfat].SetName("lat%i_ga"%vfat)
+    dict_grNHitsVFAT[vfat].SetName("g_N_vs_Lat_VFAT%i"%vfat)
     
-    #Fit
-    canv_fit = r.TCanvas("canv_fit%i"%vfat,"Fit VFAT%i"%vfat,500,500)
-    dict_fitNHitsVFAT[vfat].SetParameter(0, 0.0005)
-    dict_grNHitsVFAT[vfat].Fit(dict_fitNHitsVFAT[vfat],"QR")
-    dict_hVFATHitsVsLat[vfat].Fit(dict_fitNHitsVFAT[vfat],"QR")
+    #Fitting
+    if options.performFit:
+        # Fit Signal
+        dict_fitNHitsVFAT_Sig[vfat].SetParameter(0, NMaxLatBin)
+        dict_grNHitsVFAT[vfat].Fit(dict_fitNHitsVFAT_Sig[vfat],"QR")
+        #dict_hVFATHitsVsLat[vfat].Fit(dict_fitNHitsVFAT_Sig[vfat],"QR")
 
-    error_SigOverSigPBkg = sqrt( (sqrt(NMaxLatBin) / dict_fitNHitsVFAT[vfat].GetParameter(0) )**2 + ( (dict_fitNHitsVFAT[vfat].GetParError(0) * NMaxLatBin ) / dict_fitNHitsVFAT[vfat].GetParameter(0)**2 )**2)
-    grVFATSigOverSigPBkg.SetPoint(vfat, vfat, NMaxLatBin / dict_fitNHitsVFAT[vfat].GetParameter(0) )
-    grVFATSigOverSigPBkg.SetPointError(vfat, 0, 0, error_SigOverSigPBkg, error_SigOverSigPBkg)
+        # Remove Signal Region
+        latVal = r.Double()
+        hitVal = r.Double()
+        gTempDist = dict_grNHitsVFAT[vfat].Clone("g_N_vs_Lat_VFAT%i_NoSig"%vfat)
+        for idx in range(dict_grNHitsVFAT[vfat].GetN()-1,0,-1):
+            gTempDist.GetPoint(idx,latVal,hitVal)
+            if latFitMin_Noise < latVal and latVal < latFitMax_Noise:
+                gTempDist.RemovePoint(idx)
+
+        # Fit Noise
+        dict_fitNHitsVFAT_Noise[vfat].SetParameter(0, 0.)
+        gTempDist.Fit(dict_fitNHitsVFAT_Noise[vfat],"QR")
+
+        # Calc Signal & Signal/Noise
+        N_Bkg = dict_fitNHitsVFAT_Noise[vfat].GetParameter(0)
+        N_Bkg_Err = dict_fitNHitsVFAT_Noise[vfat].GetParError(0)
+        N_Sig = dict_fitNHitsVFAT_Sig[vfat].GetParameter(0) - N_Bkg
+        N_Sig_Err = sqrt( (dict_fitNHitsVFAT_Sig[vfat].GetParError(0))**2 + N_Bkg_Err**2)
+
+        Sig_Over_Bkg_Err = sqrt( (N_Sig_Err / N_Bkg)**2 + (N_Bkg_Err**2 * (N_Sig / N_Bkg**2)**2) )
+
+        # Add to Plot
+        grVFATSigOverBkg.SetPoint(vfat, vfat, N_Sig / N_Bkg )
+        grVFATSigOverBkg.SetPointError(vfat, 0, Sig_Over_Bkg_Err)
+
+        grVFATNSignalNoBkg.SetPoint(vfat, vfat, N_Sig )
+        grVFATNSignalNoBkg.SetPointError(vfat, 0, N_Sig_Err )
+
+        # Print if requested
+        if options.debug:
+            print "%i\t%f\t%f"%(vfat, N_Sig, N_Sig / N_Bkg)
+        pass
 
     #Draw
     r.gStyle.SetOptStat(0)
@@ -93,32 +158,56 @@ for vfat in dict_hVFATHitsVsLat:
     dict_grNHitsVFAT[vfat].GetXaxis().SetTitle("Lat")
     dict_grNHitsVFAT[vfat].GetYaxis().SetTitle("N")
     dict_grNHitsVFAT[vfat].Draw("APE1")
+    if options.performFit:
+        dict_fitNHitsVFAT_Sig[vfat].SetLineColor(r.kGreen+1)
+        dict_fitNHitsVFAT_Sig[vfat].Draw("same")
+        dict_fitNHitsVFAT_Noise[vfat].SetLineColor(r.kRed+1)
+        dict_fitNHitsVFAT_Noise[vfat].Draw("same")
 
     #Write
     dirVFAT = outF.mkdir("VFAT%i"%vfat)
     dirVFAT.cd()
     dict_grNHitsVFAT[vfat].Write()
     dict_hVFATHitsVsLat[vfat].Write()
-    dict_fitNHitsVFAT[vfat].Write()
+    if options.performFit:
+        dict_fitNHitsVFAT_Sig[vfat].Write()
+        dict_fitNHitsVFAT_Noise[vfat].Write()
     pass
 
 #Store - Summary
 canv_Summary.SaveAs(filename+'/Summary.png')
 
-#Store - Sig Over (Sig + Bkg)
-canv_SigOverSigPBkg = r.TCanvas("canv_SigOverSigPBkg","canv_SigOverSigPBkg",600,600)
-canv_SigOverSigPBkg.cd()
-grVFATSigOverSigPBkg.SetTitle("")
-grVFATSigOverSigPBkg.SetMarkerStyle(21)
-grVFATSigOverSigPBkg.SetMarkerSize(0.7)
-grVFATSigOverSigPBkg.SetLineWidth(2)    
-grVFATSigOverSigPBkg.GetXaxis().SetTitle("VFAT Pos")
-grVFATSigOverSigPBkg.GetYaxis().SetTitle("Sig / (Sig+Bkg)")
-grVFATSigOverSigPBkg.GetYaxis().SetTitleOffset(1.2)
-grVFATSigOverSigPBkg.GetYaxis().SetRangeUser(0,20)
-grVFATSigOverSigPBkg.GetXaxis().SetRangeUser(-0.5,24.5)
-grVFATSigOverSigPBkg.Draw("APE1")
-canv_SigOverSigPBkg.SaveAs(filename+'/SignalOverSigPBkg.png')
+#Store - Sig Over Bkg
+if options.performFit:
+    canv_SigOverBkg = r.TCanvas("canv_SigOverBkg","canv_SigOverBkg",600,600)
+    canv_SigOverBkg.cd()
+    grVFATSigOverBkg.SetTitle("")
+    grVFATSigOverBkg.SetMarkerStyle(21)
+    grVFATSigOverBkg.SetMarkerSize(0.7)
+    grVFATSigOverBkg.SetLineWidth(2)    
+    grVFATSigOverBkg.GetXaxis().SetTitle("VFAT Pos")
+    grVFATSigOverBkg.GetYaxis().SetTitle("Sig / Bkg)")
+    grVFATSigOverBkg.GetYaxis().SetTitleOffset(1.2)
+    grVFATSigOverBkg.GetYaxis().SetRangeUser(0,20)
+    grVFATSigOverBkg.GetXaxis().SetRangeUser(-0.5,24.5)
+    grVFATSigOverBkg.Draw("APE1")
+    canv_SigOverBkg.SaveAs(filename+'/SignalOverSigPBkg.png')
+
+#Store - Signal
+if options.performFit:
+    canv_Signal = r.TCanvas("canv_Signal","canv_Signal",600,600)
+    canv_Signal.cd()
+    grVFATNSignalNoBkg.SetTitle("")
+    grVFATNSignalNoBkg.SetMarkerStyle(21)
+    grVFATNSignalNoBkg.SetMarkerSize(0.7)
+    grVFATNSignalNoBkg.SetLineWidth(2)    
+    grVFATNSignalNoBkg.GetXaxis().SetTitle("VFAT Pos")
+    grVFATNSignalNoBkg.GetYaxis().SetTitle("Signal Hits")
+    grVFATNSignalNoBkg.GetYaxis().SetTitleOffset(1.5)
+    grVFATNSignalNoBkg.GetYaxis().SetRangeUser(0,nTrig)
+    grVFATNSignalNoBkg.GetXaxis().SetRangeUser(-0.5,24.5)
+    grVFATNSignalNoBkg.Draw("APE1")
+    canv_Signal.SaveAs(filename+'/SignalNoBkg.png')
 
 #Store - Max Hits By Lat Per VFAT
 canv_MaxHitsPerLatByVFAT = r.TCanvas("canv_MaxHitsPerLatByVFAT","canv_MaxHitsPerLatByVFAT",1200,600)
@@ -128,10 +217,11 @@ grNMaxLatBinByVFAT.SetTitle("")
 grNMaxLatBinByVFAT.SetMarkerStyle(21)
 grNMaxLatBinByVFAT.SetMarkerSize(0.7)
 grNMaxLatBinByVFAT.SetLineWidth(2)    
+grNMaxLatBinByVFAT.GetXaxis().SetRangeUser(-0.5,24.5)
 grNMaxLatBinByVFAT.GetXaxis().SetTitle("VFAT Pos")
+grNMaxLatBinByVFAT.GetYaxis().SetRangeUser(0,nTrig)
 grNMaxLatBinByVFAT.GetYaxis().SetTitle("Hit Count of Max Lat Bin")
 grNMaxLatBinByVFAT.GetYaxis().SetTitleOffset(1.7)
-grNMaxLatBinByVFAT.GetXaxis().SetRangeUser(-0.5,24.5)
 grNMaxLatBinByVFAT.Draw("APE1")
 canv_MaxHitsPerLatByVFAT.cd(2)
 grMaxLatBinByVFAT.SetTitle("")
@@ -151,6 +241,9 @@ grNMaxLatBinByVFAT.SetName("grNMaxLatBinByVFAT")
 grNMaxLatBinByVFAT.Write()
 grMaxLatBinByVFAT.SetName("grMaxLatBinByVFAT")
 grMaxLatBinByVFAT.Write()
-grVFATSigOverSigPBkg.SetName("grVFATSigOverSigPBkg")
-grVFATSigOverSigPBkg.Write()
+if options.performFit:
+    grVFATSigOverBkg.SetName("grVFATSigOverBkg")
+    grVFATSigOverBkg.Write()
+    grVFATNSignalNoBkg.SetName("grVFATNSignalNoBkg")
+    grVFATNSignalNoBkg.Write()
 outF.Close()

--- a/anaUltraLatency.py
+++ b/anaUltraLatency.py
@@ -67,16 +67,28 @@ latFitMin_Sig = latMin
 latFitMax_Sig = latMax
 if options.latSigRange is not None:
     listLatValues = map(lambda val: float(val), options.latSigRange.split(","))
-    latFitMin_Sig = min(listLatValues)
-    latFitMax_Sig = max(listLatValues)
+    if len(listLatValues) != 2:
+        print "You must specify exactly two values for determining the latency signal range"
+        print "I was given:", listLatValues
+        print "Please cross-check"
+        exit(os.EX_USAGE)
+    else: 
+        latFitMin_Sig = min(listLatValues)
+        latFitMax_Sig = max(listLatValues)
 
 # Set Latency Fitting Bounds - Noise
 latFitMin_Noise = latFitMin_Sig - 1
 latFitMax_Noise = latFitMax_Sig + 1
 if options.latNoiseRange is not None:
     listLatValues = map(lambda val: float(val), options.latNoiseRange.split(","))
-    latFitMin_Noise = min(listLatValues)
-    latFitMax_Noise = max(listLatValues)
+    if len(listLatValues) != 2:
+        print "You must specify exactly two values for determining the latency noise range"
+        print "I was given:", listLatValues
+        print "Please cross-check"
+        exit(os.EX_USAGE)
+    else: 
+        latFitMin_Noise = min(listLatValues)
+        latFitMax_Noise = max(listLatValues)
 
 #Make output plots
 from math import sqrt

--- a/anaUltraLatency.py
+++ b/anaUltraLatency.py
@@ -18,9 +18,9 @@ parser.add_option("-f", "--fit", action="store_true", dest="performFit",
                   help="Fit the latency distributions", metavar="performFit")
 parser.add_option("--latSigRange", type="string", dest="latSigRange", default=None,
                   help="Comma separated pair of values defining expected signal range, e.g. lat #epsilon [41,43] is signal", metavar="latSigRange")
-parser.add_option("--latNoiseRange", type="string", dest="latNoiseRange", default=None,
-                  help="Comma separated pair of values defining expected noise range, e.g. lat #notepsilon [40,44] is noise (lat < 40 || lat > 44)", 
-                  metavar="latNoiseRange")
+parser.add_option("--latSigMaskRange", type="string", dest="latSigMaskRange", default=None,
+                  help="Comma separated pair of values defining the region to be masked when trying to fit the noise, e.g. lat #notepsilon [40,44] is noise (lat < 40 || lat > 44)", 
+                  metavar="latSigMaskRange")
 
 parser.set_defaults(outfilename="latencyAna.root")
 
@@ -79,8 +79,8 @@ if options.latSigRange is not None:
 # Set Latency Fitting Bounds - Noise
 latFitMin_Noise = latFitMin_Sig - 1
 latFitMax_Noise = latFitMax_Sig + 1
-if options.latNoiseRange is not None:
-    listLatValues = map(lambda val: float(val), options.latNoiseRange.split(","))
+if options.latSigMaskRange is not None:
+    listLatValues = map(lambda val: float(val), options.latSigMaskRange.split(","))
     if len(listLatValues) != 2:
         print "You must specify exactly two values for determining the latency noise range"
         print "I was given:", listLatValues

--- a/anaUltraLatency.py
+++ b/anaUltraLatency.py
@@ -168,6 +168,7 @@ for vfat in dict_hVFATHitsVsLat:
     dict_grNHitsVFAT[vfat].SetLineWidth(2)
     dict_grNHitsVFAT[vfat].GetXaxis().SetRangeUser(latMin, latMax)
     dict_grNHitsVFAT[vfat].GetXaxis().SetTitle("Lat")
+    dict_grNHitsVFAT[vfat].GetYaxis().SetRangeUser(0, nTrig)
     dict_grNHitsVFAT[vfat].GetYaxis().SetTitle("N")
     dict_grNHitsVFAT[vfat].Draw("APE1")
     if options.performFit:

--- a/anaUltraLatency.py
+++ b/anaUltraLatency.py
@@ -22,7 +22,7 @@ parser.add_option("--latNoiseRange", type="string", dest="latNoiseRange", defaul
                   help="Comma separated pair of values defining expected noise range, e.g. lat #notepsilon [40,44] is noise (lat < 40 || lat > 44)", 
                   metavar="latNoiseRange")
 
-parser.set_defaults(outfilename="LatencyData.root")
+parser.set_defaults(outfilename="latencyAna.root")
 
 (options, args) = parser.parse_args()
 filename = options.filename[:-5]

--- a/anaUltraLatency.py
+++ b/anaUltraLatency.py
@@ -203,7 +203,7 @@ if options.performFit:
     grVFATSigOverBkg.GetYaxis().SetRangeUser(0,20)
     grVFATSigOverBkg.GetXaxis().SetRangeUser(-0.5,24.5)
     grVFATSigOverBkg.Draw("APE1")
-    canv_SigOverBkg.SaveAs(filename+'/SignalOverSigPBkg.png')
+    canv_SigOverBkg.SaveAs(filename+'/SignalOverBkg.png')
 
 #Store - Signal
 if options.performFit:

--- a/ana_scans.py
+++ b/ana_scans.py
@@ -7,7 +7,7 @@
 def launchAna(args):
   return launchAnaArgs(*args)
 
-def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0, chConfigKnown=False, channels=False, panasonic=False, latFit=False, latSigRange=None, latNoiseRange=None):
+def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0, chConfigKnown=False, channels=False, panasonic=False, latFit=False, latSigRange=None, latSigMaskRange=None):
   import os
   import subprocess
   from subprocess import CalledProcessError
@@ -37,7 +37,7 @@ def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0,
     
     if latFit:
         cmd.append("--fit")
-        cmd.append("--latNoiseRange=%s"%(latNoiseRange))
+        cmd.append("--latSigMaskRange=%s"%(latSigMaskRange))
         cmd.append("--latSigRange=%s"%(latSigRange))
 
     postCmds.append(["cp","%s/LatencyScanData/Summary.png"%(dirPath),
@@ -168,9 +168,9 @@ if __name__ == '__main__':
                     help="Fit the latency distributions", metavar="performLatFit")
   parser.add_option("--latSigRange", type="string", dest="latSigRange", default=None,
                     help="Comma separated pair of values defining expected signal range, e.g. lat #epsilon [41,43] is signal", metavar="latSigRange")
-  parser.add_option("--latNoiseRange", type="string", dest="latNoiseRange", default=None,
-                    help="Comma separated pair of values defining expected noise range, e.g. lat #notepsilon [40,44] is noise (lat < 40 || lat > 44)", 
-                    metavar="latNoiseRange")
+  parser.add_option("--latSigMaskRange", type="string", dest="latSigMaskRange", default=None,
+                    help="Comma separated pair of values defining the region to be masked when trying to fit the noise, e.g. lat #notepsilon [40,44] is noise (lat < 40 || lat > 44)", 
+                    metavar="latSigMaskRange")
   parser.add_option("--series", action="store_true", dest="series",
                     help="Run tests in series (default is false)", metavar="series")
 
@@ -197,7 +197,7 @@ if __name__ == '__main__':
                          [options.PanPin   for x in range(len(chamber_config))],
                          [options.performLatFit for x in range(len(chamber_config))],
                          [options.latSigRange for x in range(len(chamber_config))],
-                         [options.latNoiseRange for x in range(len(chamber_config))]
+                         [options.latSigMaskRange for x in range(len(chamber_config))]
                          )
               )
 
@@ -217,7 +217,7 @@ if __name__ == '__main__':
                 options.PanPin,
                 options.performLatFit,
                 options.latSigRange,
-                options.latNoiseRange
+                options.latSigMaskRange
                )
       pass
     pass
@@ -241,7 +241,7 @@ if __name__ == '__main__':
                                           [options.PanPin   for x in range(len(chamber_config))],
                                           [options.performLatFit for x in range(len(chamber_config))],
                                           [options.latSigRange for x in range(len(chamber_config))],
-                                          [options.latNoiseRange for x in range(len(chamber_config))]
+                                          [options.latSigMaskRange for x in range(len(chamber_config))]
                                           )
                            )
       # timeout must be properly set, otherwise tasks will crash

--- a/ana_scans.py
+++ b/ana_scans.py
@@ -45,8 +45,8 @@ def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0,
     postCmds.append(["cp","%s/LatencyScanData/MaxHitsPerLatByVFAT.png"%(dirPath),
                  "%s/MaxHitsPerLatByVFAT_%s.png"%(elogPath,cName)])
     if latFit:
-        postCmds.append(["cp","%s/LatencyScanData/SignalOverSigPBkg.png"%(dirPath),
-                 "%s/SignalOverSigPBkg_%s.png"%(elogPath,cName)])
+        postCmds.append(["cp","%s/LatencyScanData/SignalOverBkg.png"%(dirPath),
+                 "%s/SignalOverBkg_%s.png"%(elogPath,cName)])
         postCmds.append(["cp","%s/LatencyScanData/SignalNoBkg.png"%(dirPath),
                  "%s/SignalNoBkg_%s.png"%(elogPath,cName)])
 

--- a/ana_scans.py
+++ b/ana_scans.py
@@ -7,7 +7,7 @@
 def launchAna(args):
   return launchAnaArgs(*args)
 
-def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0, chConfigKnown=False, channels=False, panasonic=False):
+def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0, chConfigKnown=False, channels=False, panasonic=False, latFit=False, latSigRange=None, latNoiseRange=None):
   import os
   import subprocess
   from subprocess import CalledProcessError
@@ -30,25 +30,33 @@ def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0,
     filename = dirPath + "LatencyScanData.root"
     if not os.path.isfile(filename):
       print "No file to analyze. %s does not exist"%(filename)
-      return
+      return os.EX_NOINPUT
     
     cmd.append("--infilename=%s"%(filename))
     cmd.append("--outfilename=%s"%("latencyAna.root"))
     
+    if latFit:
+        cmd.append("--fit")
+        cmd.append("--latNoiseRange=%s"%(latNoiseRange))
+        cmd.append("--latSigRange=%s"%(latSigRange))
+
     postCmds.append(["cp","%s/LatencyScanData/Summary.png"%(dirPath),
                  "%s/LatencySumary_%s.png"%(elogPath,cName)])
     postCmds.append(["cp","%s/LatencyScanData/MaxHitsPerLatByVFAT.png"%(dirPath),
                  "%s/MaxHitsPerLatByVFAT_%s.png"%(elogPath,cName)])
-    postCmds.append(["cp","%s/LatencyScanData/SignalOverSigPBkg.png"%(dirPath),
+    if latFit:
+        postCmds.append(["cp","%s/LatencyScanData/SignalOverSigPBkg.png"%(dirPath),
                  "%s/SignalOverSigPBkg_%s.png"%(elogPath,cName)])
-    
+        postCmds.append(["cp","%s/LatencyScanData/SignalNoBkg.png"%(dirPath),
+                 "%s/SignalNoBkg_%s.png"%(elogPath,cName)])
+
     pass
   elif anaType == "scurve":
     dirPath = "%s/%s/"%(dirPath,scandate)
     filename = dirPath + "SCurveData.root"
     if not os.path.isfile(filename):
       print "No file to analyze. %s does not exist"%(filename)
-      return
+      return os.EX_NOINPUT
 
     cmd.append("--infilename=%s"%(filename))
     cmd.append("--outfilename=%s"%("SCurveFitData.root"))
@@ -71,7 +79,7 @@ def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0,
     filename = dirPath + "ThresholdScanData.root"
     if not os.path.isfile(filename):
       print "No threshold file to analyze. %s does not exist"%(filename)
-      return
+      return os.EX_NOINPUT
 
     cmd.append("--infilename=%s"%(filename))
     cmd.append("--outfilename=%s"%("ThresholdPlots.root"))
@@ -83,7 +91,7 @@ def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0,
       filename_Trim = dirPath_Trim + "SCurveFitData.root"
       if not os.path.isfile(filename_Trim):
         print "No scurve fit data file to analyze. %s does not exist"%(filename_Trim)
-        return
+        return os.EX_NOINPUT
       
       cmd.append("--fileScurveFitTree=%s"%(filename_Trim))
       pass
@@ -104,7 +112,7 @@ def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0,
     filename = dirPath + "SCurveData_Trimmed.root"
     if not os.path.isfile(filename):
       print "No file to analyze. %s does not exist"%(filename)
-      return
+      return os.EX_NOINPUT
 
     cmd.append("--infilename=%s"%(filename))
     cmd.append("--outfilename=%s"%("SCurveFitData.root"))
@@ -127,8 +135,7 @@ def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0,
   try:
     log = file("%s/anaLog.log"%(dirPath),"w")
  
-    #returncode = runCommand(cmd,log)
-    returncode = runCommand(cmd)
+    returncode = runCommand(cmd,log)
     if returncode != 0:
       print "Error: command exited with non-zero code %d" % returncode
       return returncode
@@ -155,10 +162,17 @@ if __name__ == '__main__':
 
   from anaoptions import parser
 
+  parser.add_option("--anaType", type="string", dest="anaType",
+                    help="Analysis type to be executed, from list {'latency','scurve','threshold','trim'}", metavar="anaType")
+  parser.add_option("--latFit", action="store_true", dest="performLatFit",
+                    help="Fit the latency distributions", metavar="performLatFit")
+  parser.add_option("--latSigRange", type="string", dest="latSigRange", default=None,
+                    help="Comma separated pair of values defining expected signal range, e.g. lat #epsilon [41,43] is signal", metavar="latSigRange")
+  parser.add_option("--latNoiseRange", type="string", dest="latNoiseRange", default=None,
+                    help="Comma separated pair of values defining expected noise range, e.g. lat #notepsilon [40,44] is noise (lat < 40 || lat > 44)", 
+                    metavar="latNoiseRange")
   parser.add_option("--series", action="store_true", dest="series",
                     help="Run tests in series (default is false)", metavar="series")
-  parser.add_option("--anaType", type="string", dest="anaType",
-                     help="Analysis type to be executed, from list {'latency','scurve','threshold','trim'}", metavar="anaType")
 
   (options, args) = parser.parse_args()
 
@@ -169,8 +183,7 @@ if __name__ == '__main__':
   if options.anaType not in ana_config.keys():
     print "Invalid analysis specificed, please select only from the list:"
     print ana_config.keys()
-    exit(1)
-    pass
+    exit(os.EX_USAGE)
 
   if options.debug:
     print list(itertools.izip([options.anaType for x in range(len(chamber_config))],
@@ -181,7 +194,10 @@ if __name__ == '__main__':
                          [options.ztrim   for x in range(len(chamber_config))],
                          [options.chConfigKnown   for x in range(len(chamber_config))],
                          [options.channels   for x in range(len(chamber_config))],
-                         [options.PanPin   for x in range(len(chamber_config))]
+                         [options.PanPin   for x in range(len(chamber_config))],
+                         [options.performLatFit for x in range(len(chamber_config))],
+                         [options.latSigRange for x in range(len(chamber_config))],
+                         [options.latNoiseRange for x in range(len(chamber_config))]
                          )
               )
 
@@ -189,15 +205,19 @@ if __name__ == '__main__':
     print "Running jobs in serial mode"
     for link in chamber_config.keys():
       chamber = chamber_config[link]
-      launchAna([options.anaType for x in range(len(chamber_config))],
-                 chamber_config.values(),
-                 [GEBtype[x]        for x in chamber_config.keys()],
-                 [options.scandate  for x in range(len(chamber_config))],
-                 [options.scandatetrim  for x in range(len(chamber_config))],
-                 [options.ztrim   for x in range(len(chamber_config))],
-                 [options.chConfigKnown   for x in range(len(chamber_config))],
-                 [options.channels   for x in range(len(chamber_config))],
-                 [options.PanPin   for x in range(len(chamber_config))]
+      GEB = GEBtype[link]
+      launchAna(options.anaType,
+                chamber,
+                GEB,
+                options.scandate,
+                options.scandatetrim,
+                options.ztrim,
+                options.chConfigKnown,
+                options.channels,
+                options.PanPin,
+                options.performLatFit,
+                options.latSigRange,
+                options.latNoiseRange
                )
       pass
     pass
@@ -218,7 +238,10 @@ if __name__ == '__main__':
                                           [options.ztrim   for x in range(len(chamber_config))],
                                           [options.chConfigKnown   for x in range(len(chamber_config))],
                                           [options.channels   for x in range(len(chamber_config))],
-                                          [options.PanPin   for x in range(len(chamber_config))]
+                                          [options.PanPin   for x in range(len(chamber_config))],
+                                          [options.performLatFit for x in range(len(chamber_config))],
+                                          [options.latSigRange for x in range(len(chamber_config))],
+                                          [options.latNoiseRange for x in range(len(chamber_config))]
                                           )
                            )
       # timeout must be properly set, otherwise tasks will crash

--- a/macros/plot_eff.py
+++ b/macros/plot_eff.py
@@ -6,33 +6,57 @@ def calcEffErr(eff, nTriggers):
     return math.sqrt( (eff * ( 1. - eff) ) / nTriggers )
 
 # Returns a tuple of (eff, sigma_eff)
-def calcEff(cName, scandate, vfatList, latBin):
+def calcEff(cName, scandate, vfatList, latBin, bkgSub=False):
+    from anautilities import getDirByAnaType
+
     import os
 
     # Setup paths
-    dataPath  = os.getenv('DATA_PATH')
-    dirPath = "%s/%s/latency/trk/%s/"%(dataPath,cName,scandate)
-    filename = dirPath + "LatencyScanData.root"
+    dirPath = "%s/%s"%(getDirByAnaType("latency",cName), scandate)
+    filename_RAW = dirPath + "/LatencyScanData.root"
+    filename_ANA = dirPath + "/LatencyScanData/latencyAna.root"
 
-    # Load data
+    # Load data - RAW
     import root_numpy as rp
     import numpy as np
     list_bNames = ["vfatN","lat","Nhits","Nev"]
     try:
-        array_VFATData = rp.root2array(filename,"latTree",list_bNames)
+        array_VFATData = rp.root2array(filename_RAW,"latTree",list_bNames)
         pass
     except Exception as e:
-        print '%s does not seem to exist'%filename
+        print '%s does not seem to exist'%filename_RAW
         print e
-        pass
+        exit(os.EX_NOINPUT)
+
+    # Load data - ANA
+    import ROOT as r
+    try:
+        anaFile = r.TFile(filename_ANA,"READ")
+    except Exception as e:
+        print '%s does not seem to exist'%filename_ANA
+        print e
+        exit(os.EX_NOINPUT)
 
     # Determine hits and triggers
     nTriggers = np.asscalar(np.unique(array_VFATData['Nev']))
     nHits = 0.0
     for vfat in vfatList:
-        vfatData = array_VFATData[ array_VFATData['vfatN'] == vfat]
-        latData = vfatData[vfatData['lat'] == latBin]
-        nHits += np.asscalar(latData['Nhits'])
+        if bkgSub:
+            try:
+                gSignalNoBkg = anaFile.Get("grVFATNSignalNoBkg")
+                vfatHits = r.Double()
+                vfatPos = r.Double()
+                gSignalNoBkg.GetPoint(vfat,vfatPos,vfatHits)
+                nHits += vfatHits
+            except Exception as e:
+                print "grVFATNSignalNoBkg not present in TFile %s"%filename_ANA
+                print "Maybe you forgot to analyze with the --fit, --latSigRange, and --latNoiseRange options?"
+                print e
+                exit(os.EX_DATAERR)
+        else:
+            vfatData = array_VFATData[ array_VFATData['vfatN'] == vfat]
+            latData = vfatData[vfatData['lat'] == latBin]
+            nHits += np.asscalar(latData['Nhits'])
 
     # Calc Eff & Error
     return (nHits / nTriggers, calcEffErr(nHits / nTriggers, nTriggers) )
@@ -56,6 +80,8 @@ if __name__ == '__main__':
     
     import os
     
+    parser.add_option("--bkgSub", action="store_true", dest="bkgSub",
+                      help="Use Background Subtracted info from fit analysis in anaUltraLatency.py", metavar="bkgSub")
     parser.add_option("--latSig", type="int", dest="latSig", default=None,
                       help="Latency bin where signal is found", metavar="latSig")
     parser.add_option("-p","--print", action="store_true", dest="printData",
@@ -81,15 +107,22 @@ if __name__ == '__main__':
         list_VFATs.append(options.vfat)
     else:
         print "You must specify at least one VFAT to be considered"
-        exit(-1)
+        exit(os.EX_USAGE)
 
     # Check that the user supplied a latency value
-    if options.latSig == None:
-        print "You must specify the latency bin of the signal peak"
-        exit(-1)
+    if options.latSig is None and not options.bkgSub:
+        print "You must specify the latency bin of the signal peak (--latSig) or ask for background subtracted analysis (--bkgSub)"
+        exit(os.EX_USAGE)
     
+    # Load inpt file
+    try:
+        fileScanDates = open(options.filename, 'r') #tab '\t' delimited file, first line column headings, subsequent lines data: cName\tscandate\tindepvar
+    except Exception as e:
+        print '%s does not seem to exist'%options.filename
+        print e
+        exit(os.EX_NOINPUT)
+
     # Loop Over inputs
-    fileScanDates = open(options.filename, 'r') #tab '\t' delimited file, first line column headings, subsequent lines data: cName\tscandate\tindepvar
     list_EffData = []
     strIndepVar = ""
     strChamberName = ""
@@ -107,7 +140,7 @@ if __name__ == '__main__':
         if len(strChamberName) == 0 and i > 0:
             strChamberName = analysisList[0]
         
-        tuple_eff = calcEff(analysisList[0], analysisList[1], list_VFATs, options.latSig)
+        tuple_eff = calcEff(analysisList[0], analysisList[1], list_VFATs, options.latSig, options.bkgSub)
         list_EffData.append((float(analysisList[2]), tuple_eff[0], tuple_eff[1]))
 
     # Print to the user

--- a/macros/plot_eff.py
+++ b/macros/plot_eff.py
@@ -127,6 +127,9 @@ if __name__ == '__main__':
     strIndepVar = ""
     strChamberName = ""
     for i,line in enumerate(fileScanDates):
+        if line[0] == "#":
+            continue
+        
         # Split the line
         line = line.strip('\n')
         analysisList = line.rsplit('\t') #chamber name, scandate, independent var


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

### Changes to anaUltraLatency.py
The fitting performed in `anaUltraLatency.py` leaves something to be desired.  In this PR the functionality is changed such that the latency distributions are not fit by default.  Instead three new options are added to `anaUltraLatency.py`:

- `-f`, `--fit` flag to perform fit,
- `--latSigRange` comma separated pair of integers specifying the range of the signal in an N vs. Latency distribution, and
- `--latSigMaskRange` comma separated pair of integers specifying the portion of an N vs. Latency distribution to not consider as noise

If an example signal range is given as  `--latSigRange=41,42` and  `--latSigMaskRange` is not specified the default behavior is then treated as latSigRange_Min-1 and latSigRange_Max+1, so [40,43] in this case.

These parameters will then be used to fit the latency distributions for the purpose of determining:

- True signal count in the lat range specified, and 
- Signal over noise ratios.

Example workflow is now:
1. Analyze an ultraLatency.py output file,
2. Look where the muon peak is in the output distributions,
3. Re-analyze the ultraLatency.py output file using the `--fit`, `--latSigRange`, and `--latSigMaskRange` options to perform the fitting.

Example syntax for steps 1 & 3:
```
anaUltraLatency.py -iLatencyScanData.root
anaUltraLatency.py -iLatencyScanData.root --fit --latSigRange=43,46 --latSigMaskRange=40,48 --debug
```

Note using the `--debug` with the `--fit` flag will cause a table of `VFAT\tSignal\tSignalOverNoise` to be printed to the terminal.

### Changes to ana_scans.py
Subsequent parameters have been added to `ana_scans.py` to extend the new functionality of `anaUltraLatency.py`.  In this case they are:

- `--latFit`
- `--latSigRange`, and
- `--latSigMaskRange`.

Again one should first analyze a latency scan, look at the output to determine the fit ranges, and then re-analyze the scan.  Example calling syntax:

```
ana_scans.py --anaType=latency --scandate=2017.08.31.15.46
ana_scans.py --anaType=latency --scandate=2017.08.31.15.46 --latFit --latSigRange=43,45 --latSigMaskRange=40,48
```

### Changes to plot_eff.py
The possibility to use the true signal count obtained from the latency fitting in calculation of efficiency with `plot_eff.py` has also been added.

The previous functionality still exists using syntax:

```
plot_eff.py --infilename=listOfScanDates_eff_vt1bump0.txt --vfatList=4,12 --latSig=44 --print                      
```

But to now use the true signal counts to measure the efficiency first analyze the latency ultra scans of interest, then use the `--bkgSub` argument in place of the `--latSig` argument:
 
```
[dorney@cosmicstandtif]~/scratch0/CMS_GEM/CMS_GEM_DAQ/gem-plotting-tools% plot_eff.py --infilename=listOfScanDates_eff_vt1bump0.txt --vfatList=4,12 --bkgSub --print 
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Fitting in `anaUltraLatency.py` could not accurately determine signal to noise ratios. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I performed the analysis.

### Screenshots (if appropriate):
From using `ana_scans.py` to re-analyze data.  Note in `Summary.png` the green line is a fit to the defined signal region (argument of `--latSigRange`) and the red line is a fit to the noise region with the defined signal region masked (argument of `--latSigMaskRange`).
<img width="1179" alt="summary" src="https://user-images.githubusercontent.com/6432141/30373200-c8bea260-9880-11e7-96d3-f908faa406ef.png">
<img width="543" alt="signaloverbkg" src="https://user-images.githubusercontent.com/6432141/30373201-c8bff160-9880-11e7-90a8-a03ca491025b.png">
<img width="550" alt="signalnobkg" src="https://user-images.githubusercontent.com/6432141/30373203-c8c32e02-9880-11e7-9e01-c34ce820da07.png">
<img width="1196" alt="maxhitsperlatbyvfat" src="https://user-images.githubusercontent.com/6432141/30373202-c8c135e8-9880-11e7-8c71-d94ebf4550e0.png">

From `plot_eff.py` using the `--bkgSub` flag.
<img width="550" alt="ge11-vi-l-cern-0001_eff_vs_vmon" src="https://user-images.githubusercontent.com/6432141/30373254-f47e54cc-9880-11e7-8800-811dfdc3e3d4.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
