### PR TITLE
Bug Fix: Addressing #37

### DIFF
--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -136,7 +136,7 @@ vthr_list = []
 trim_list = []
 trimrange_list = []
 lines = []
-def overlay_fit(VFAT, CHAN):
+def overlay_fit(VFAT, CHAN, NEVT=1000):
     Scurve = r.TH1D('Scurve','Scurve for VFAT %i channel %i;VCal [DAC units]'%(VFAT, CHAN),255,-0.5,254.5)
     strip = chanToStripLUT[VFAT][CHAN]
     pan_pin = chanToPanPinLUT[VFAT][CHAN]
@@ -148,7 +148,7 @@ def overlay_fit(VFAT, CHAN):
     param0 = scanFits[0][VFAT][CHAN]
     param1 = scanFits[1][VFAT][CHAN]
     param2 = scanFits[2][VFAT][CHAN]
-    fitTF1 =  r.TF1('myERF','500*TMath::Erf((TMath::Max([2],x)-[0])/(TMath::Sqrt(2)*[1]))+500',1,253)
+    fitTF1 = r.TF1('myERF','%f*TMath::Erf((TMath::Max([2],x)-[0])/(TMath::Sqrt(2)*[1]))+%f'%(NEVT/2.,NEVT/2.),1,253)
     fitTF1.SetParameter(0, param0)
     fitTF1.SetParameter(1, param1)
     fitTF1.SetParameter(2, param2)
@@ -341,9 +341,9 @@ if options.SaveFile:
             Nhigh[0] = int(scanFits[4][vfat][chan])
             #Filling the arrays for plotting later
             if options.drawbad:
-                if (Chi2 > 1000.0 or Chi2 < 1.0):
-                    overlay_fit(vfat, chan)
-                    print "Chi2 is, %d"%(Chi2)
+                if (chi2[0] > 1000.0 or chi2[0] < 1.0):
+                    overlay_fit(vfat, chan, fitter.Nev)
+                    print "Chi2 is, %d"%(chi2[0])
                     pass
                 pass
             myT.Fill()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addressing https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/37

Now the `overlay_fit()` function in `anaUltraScurve.py` will take the event count as an input and use it for the fit.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
If someone used the `-b` option the fit defined in `overlay_fit()` would not be correct for scurves taken with event counts different from the default.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I re-ran an old anaysis:

```
anaUltraScurve.py -i$DATA_PATH/GE11-VI-L-CERN-0001/scurve/current/SCurveData.root --ztrim=4 -b -f
```

### Screenshots (if appropriate):
<img width="1068" alt="screen shot 2017-09-14 at 15 23 53" src="https://user-images.githubusercontent.com/6432141/30432194-31a73a9a-9961-11e7-82fa-d9b31bdd83f2.png">
<img width="495" alt="screen shot 2017-09-14 at 11 36 35" src="https://user-images.githubusercontent.com/6432141/30432193-31995100-9961-11e7-8ecd-9aa4bad0a5c5.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
