### PR TITLE
New Feature: gemPlotter.py now supports alphanumeric indep variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The following table shows the mandatory inputs that must be supplied to execute 
 | ---- | ---- | ----------- |
 | `--anaType` | string | Analysis type to be executed, see `tree_names.keys()` of [anaInfo.py](https://github.com/cms-gem-daq-project/gem-plotting-tools/blob/master/anaInfo.py) for possible inputs |
 | `--branchName` | string | Name of TBranch where dependent variable is found, note that this TBranch should be found in the `TTree` that corresponds to the value given to the `--anaType` argument |
-| `-i`, `--infilename` | string | physical filename of the input file to be passed to `gemPlotter.py`.  See [gemPlotter.py Input File](#gemPlotter.py-Input-File) for details on the format and contents of this file. |
+| `-i`, `--infilename` | string | physical filename of the input file to be passed to `gemPlotter.py`.  See [gemPlotter.py Input File](#gemplotterpy-input-file) for details on the format and contents of this file. |
 | `-v`, `--vfat` | int | Specify VFAT to plot |
 
 Note for those `anaType` values which have the substring `Ana` in their names it is expected that the user has already run `ana_scans.py` on the corresponding `scandate` to produce the necessary input file for `gemPlotter.py`.
@@ -72,7 +72,7 @@ The following table shows the optional inputs that can be supplied when executin
 | `-c`, `--channels` | none | When providing this flag the `--strip` option is interpreted as VFAT channel number instead of readout board (ROB) strip number. |
 | `-s`, `--strip` | int | Specific ROB strip number to plot for `--branchName`.  Note for ROB strip level `--branchName` values (e.g. `trimDAC`) if this option is *not* provided the data point (error bar) will represent the mean (standard deviation) of `--branchName` from all strips. |
 | `--make2D` | none| When providing this flag a 2D plot of ROB strip/vfat channel vs. independent variable will be plotted whose z-axis value is `--branchName`. |
-| `-p`, `--print` | none | Prints a comma separated table of the plot's data to the terminal.  The format of this table will be compatible with the `genericPlotter` executable of the [CMS_GEM_Analysis_Framework](https://github.com/cms-gem-detqc-project/CMS_GEM_Analysis_Framework#4eiviii-header-parameters---data). | 
+| `-p`, `--print` | none | Prints a comma separated table of the plot's data to the terminal.  The format of this table will be compatible with the `genericPlotter` executable of the [CMS_GEM_Analysis_Framework](https://github.com/cms-gem-detqc-project/CMS_GEM_Analysis_Framework#3b-genericplotter). | 
 | `--rootOpt` | string | Option for creating the output `TFile`, e.g. {'RECREATE','UPDATE'} |
 | `--showStat` | none | Causes the statistics box to be drawn on created plots. Note only applicable when used with `--make2D`. |
 | `--vfatList` | Comma separated list of int's | List of VFATs that should be plotted.  May be used instead of the `--vfat` option. |
@@ -194,7 +194,7 @@ The following table shows the mandatory inputs that must be supplied to execute 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | `--anaType` | string | Analysis type to be executed, see `tree_names.keys()` of [anaInfo.py](https://github.com/cms-gem-daq-project/gem-plotting-tools/blob/master/anaInfo.py) for possible inputs |
-| `-i`, `--infilename` | string | physical filename of the input file to be passed to `gemTreeDrawWrapper.py`.  See [gemTreeDrawWrapper.py Input File](#gemTreeDrawWrapper.py-Input-File) for details on the format and contents of this file. |
+| `-i`, `--infilename` | string | physical filename of the input file to be passed to `gemTreeDrawWrapper.py`.  See [gemTreeDrawWrapper.py Input File](#gemtreedrawwrapperpy-input-file) for details on the format and contents of this file. |
 | `--treeExpress` | string | Expression to be drawn, corresponds to the `varexp` argument of [TTree::Draw()](https://root.cern.ch/doc/master/classTTree.html#a73450649dc6e54b5b94516c468523e45). |
 
 Note for those `anaType` values which have the substring `Ana` in their names it is expected that the user has already run `ana_scans.py` on the corresponding `scandate` to produce the necessary input file for `gemTreeDrawWrapper.py`.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The following table shows the optional inputs that can be supplied when executin
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | `-a`, `--all` | none | When providing this flag data from all 24 VFATs will be plotted.  Additionally a summary plot in the typical 3x8 grid will be created showing the results of all 24 VFATs. May be used instead of the `--vfat` option. |
+| `--alphaLabels` | none | When providing this flag `gemPlotter.py` will interpret the **Indep. Variable** as a string and modify the output X axis accordingly |
 | `--axisMax` | float | Maximum value for the axis depicting `--branchName`. |
 | `--axisMin` | float | Minimum value for the axis depicting `--branchName`. |
 | `-c`, `--channels` | none | When providing this flag the `--strip` option is interpreted as VFAT channel number instead of readout board (ROB) strip number. |
@@ -85,7 +86,7 @@ This should be a `tab` deliminited text file.  The first line of this file shoul
 ChamberName scandate    <Indep. Variable Name>
 ```
 
-Subsequent lines of this file are the values that correspond to these column headings.  The value of the `ChamberName` column must correspond to the value of one entry in the `chamber_config` dictionary found in `mapping/chamberInfo.py`.  The **Indep. Variable Name** is the independent variable that `--branchName` will be plotted against and is assumed to be numeric.  Please note the `#` character is  understood as a comment, lines starting with a `#` will be skipped.
+Subsequent lines of this file are the values that correspond to these column headings.  The value of the `ChamberName` column must correspond to the value of one entry in the `chamber_config` dictionary found in `mapping/chamberInfo.py`.  The **Indep. Variable Name** is the independent variable that `--branchName` will be plotted against, if it is *not* numeric please use the `--alphaLabels` command line option.  Please note the `#` character is  understood as a comment, lines starting with a `#` will be skipped.
 
 A complete example for a single detector is given as:
 
@@ -104,17 +105,15 @@ A complete example for multiple detectors is given as:
 
 ```
 ChamberName scandate    Layer
-GEMINIm27L1 2019.09.04.20.12    -27.0
-GEMINIm27L2 2019.09.04.22.52    -27.5
-GEMINIm28L1 2019.09.05.01.33    -28.0
-GEMINIm28L2 2019.09.05.04.21    -28.5
-GEMINIp02L1 2019.09.05.07.11    2.0
-GEMINIp02L2 2019.09.05.07.11    2.5
+GEMINIm27L1 2019.09.04.20.12    GEMINIm27L1
+GEMINIm27L2 2019.09.04.22.52    GEMINIm27L2
+GEMINIm28L1 2019.09.05.01.33    GEMINIm28L1
+GEMINIm28L2 2019.09.05.04.21    GEMINIm28L2
+GEMINIp02L1 2019.09.05.07.11    GEMINIp02L1
+GEMINIp02L2 2019.09.05.07.11    GEMINIp02L2
 ```
 
-Here the `ChamberName` is different for each line and `--branchName` will be plotted against `Layer`.  Note we have provided a numerical equivalent for mXXLY and pXXLY:
-- minus (plus) given by m (p) corresponds to a negative (positive) number, and
-- L1(2) is a whole (half) integer number.
+Here the `ChamberName` is different for each line and `--branchName` will be plotted against `Layer`.  Note since the **Indep. Variable Name** is not numeric the command line option `--alphaLabels` must be used.
 
 #### gemPlotter.py Example: Making a 1D Plot - Channel Level
 To make a 1D plot for a given strip of a given VFAT execute:

--- a/macros/gemTreeDrawWrapper.py
+++ b/macros/gemTreeDrawWrapper.py
@@ -200,7 +200,7 @@ if __name__ == '__main__':
             print "I was expecting a tab-delimited file with each line having 2 entries"
             print "But I received:"
             print "\t%s"%(line)
-            print "Exitting"
+            print "Exiting"
             exit(os.EX_USAGE)
 
         # Setup the path
@@ -303,7 +303,7 @@ if __name__ == '__main__':
                     print "You must supply an initial guess for each parameter"
                     print "The initial guess values give:", listParams
                     print "Which has length %i, but I am expecting %i guesses"%(len(listParams), thisFit.GetNpar())
-                    print "Exitting"
+                    print "Exiting"
                     exit(os.EX_USAGE)
 
             # Perform the fit


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `gemPlotter.py` macro can now make arbitrary plots against alphanumeric independent variables.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Before if user wanted to plot against an alphanumeric independent variable (e.g. GEMINImXXLY, scandate, etc...) they had to convert it to a numeric value.  Now alphanumeric input is supported with the command line argument `--alphaLabels`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I re-ran some old analysis to confirm existing functionality was preserved and added functionality worked.  See screenshots.

### Screenshots (if appropriate):

With alphanumeric labels:
```
gemPlotter.py -ilistOfScanDates_Trim.txt -s10 -v10 --anaType=trimAna --branchName=trimDAC --axisMin=0 --axisMax=31 --alphaLabels
```
![image](https://user-images.githubusercontent.com/6432141/30593685-c560fd6e-9d4b-11e7-8969-356fd381ea21.png)

```
gemPlotter.py -ilistOfScanDates_Trim.txt -v10 --anaType=trimAna --branchName=trimDAC --make2D --axisMin=-1 --axisMax=31 --alphaLabels
```
![image](https://user-images.githubusercontent.com/6432141/30593674-bf6ee6aa-9d4b-11e7-9c9c-fd47b2eb651e.png)

With only numeric labels:

```
gemPlotter.py -ilistOfScanDates_Trim.txt -v10 --anaType=trimAna --branchName=trimDAC --make2D --axisMin=-1 --axisMax=31 
```
<img width="584" alt="screen shot 2017-09-19 at 15 03 03" src="https://user-images.githubusercontent.com/6432141/30593651-a9b15988-9d4b-11e7-88a6-19602fc99a46.png">

```
gemPlotter.py -ilistOfScanDates_Trim.txt -s10 -v10 --anaType=trimAna --branchName=trimDAC --axisMin=0 --axisMax=31
```
<img width="546" alt="screen shot 2017-09-19 at 15 02 53" src="https://user-images.githubusercontent.com/6432141/30593662-b3873342-9d4b-11e7-8e93-2dd1517cc609.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
