### PR TITLE
New Feature: anaUltraLatency now also makes an output TTree

### DIFF
--- a/anaInfo.py
+++ b/anaInfo.py
@@ -7,12 +7,13 @@ ana_config = {
         "trim":"anaUltraScurve.py"
         }
 
-# key values match ana_config
+# key values match ana_config (mostly...)
 # stores a tuple where:
 #   [0] -> path of root file inside scandate/ 
 #   [1] -> name of TTree inside root file
 tree_names = {
         "latency":("LatencyScanData.root","latTree"),
+        "latencyAna":("LatencyScanData/latencyAna.root","latFitTree"),
         "scurve":("SCurveData.root","scurveTree"),
         "scurveAna":("SCurveData/SCurveFitData.root","scurveFitTree"),
         "threshold":("ThresholdScanData.root","thrTree"),

--- a/anaUltraLatency.py
+++ b/anaUltraLatency.py
@@ -11,6 +11,7 @@ import numpy as np
 import os
 
 from anaoptions import parser
+from anautilities import make3x8Canvas
 from array import array
 from gempython.utils.nesteddict import nesteddict as ndict
 
@@ -90,9 +91,34 @@ if options.latSigMaskRange is not None:
         latFitMin_Noise = min(listLatValues)
         latFitMax_Noise = max(listLatValues)
 
-#Make output plots
-from math import sqrt
+# Make output TFile and TTree
 outF = r.TFile(filename+"/"+options.outfilename,"RECREATE")
+dirVFATPlots = outF.mkdir("VFAT_Plots")
+myT = r.TTree('latFitTree','Tree Holding FitData')
+vfatN = array( 'i', [ 0 ] )
+myT.Branch( 'vfatN', vfatN, 'vfatN/I' )
+hitCountMaxLat = array( 'i', [ 0 ] )
+myT.Branch( 'hitCountMaxLat', hitCountMaxLat, 'hitCountMaxLat/I' )
+hitCountMaxLatErr = array( 'i', [ 0 ] )
+myT.Branch( 'hitCountMaxLatErr', hitCountMaxLatErr, 'hitCountMaxLatErr/I' )
+maxLatBin = array( 'i', [ 0 ] )
+myT.Branch( 'maxLatBin', maxLatBin, 'maxLatBin/I' )
+hitCountBkg = array( 'f', [ 0 ] )
+hitCountBkgErr = array( 'f', [ 0 ] )
+hitCountSig = array( 'f', [ 0 ] )
+hitCountSigErr = array( 'f', [ 0 ] )
+SigOverBkg = array( 'f', [ 0 ] )
+SigOverBkgErr = array( 'f', [ 0 ] )
+if options.performFit:
+    myT.Branch( 'hitCountBkg', hitCountBkg, 'hitCountBkg/F')
+    myT.Branch( 'hitCountBkgErr', hitCountBkgErr, 'hitCountBkgErr/F')
+    myT.Branch( 'hitCountSig', hitCountSig, 'hitCountSig/F')
+    myT.Branch( 'hitCountSigErr', hitCountSigErr, 'hitCountSigErr/F')
+    myT.Branch( 'SigOverBkg', SigOverBkg, 'SigOverBkg/F')
+    myT.Branch( 'SigOverBkgErr', SigOverBkgErr, 'SigOverBkgErr/F')
+
+# Make output plots
+from math import sqrt
 dict_grNHitsVFAT = ndict()
 dict_fitNHitsVFAT_Sig = ndict()
 dict_fitNHitsVFAT_Noise = ndict()
@@ -101,31 +127,34 @@ grMaxLatBinByVFAT = r.TGraphErrors(len(dict_hVFATHitsVsLat))
 grVFATSigOverBkg = r.TGraphErrors(len(dict_hVFATHitsVsLat))
 grVFATNSignalNoBkg = r.TGraphErrors(len(dict_hVFATHitsVsLat))
 r.gStyle.SetOptStat(0)
-canv_Summary = r.TCanvas("canv_Summary","Latency Summary",500*8,500*3)
-canv_Summary.Divide(8,3)
 if options.debug and options.performFit:
     print "VFAT\tSignalHits\tSignal/Noise"
 for vfat in dict_hVFATHitsVsLat:
-    #Store Max Info
-    NMaxLatBin = dict_hVFATHitsVsLat[vfat].GetBinContent(dict_hVFATHitsVsLat[vfat].GetMaximumBin())
-    grNMaxLatBinByVFAT.SetPoint(vfat, vfat, NMaxLatBin)
-    grNMaxLatBinByVFAT.SetPointError(vfat, 0, sqrt(NMaxLatBin))
+    # Store VFAT info
+    vfatN[0] = vfat
 
-    grMaxLatBinByVFAT.SetPoint(vfat, vfat, dict_hVFATHitsVsLat[vfat].GetBinCenter(dict_hVFATHitsVsLat[vfat].GetMaximumBin()))
+    # Store Max Info
+    hitCountMaxLat[0] = dict_hVFATHitsVsLat[vfat].GetBinContent(dict_hVFATHitsVsLat[vfat].GetMaximumBin())
+    hitCountMaxLatErr[0] = sqrt(hitCountMaxLat[0])
+    grNMaxLatBinByVFAT.SetPoint(vfat, vfat, hitCountMaxLat[0])
+    grNMaxLatBinByVFAT.SetPointError(vfat, 0, hitCountMaxLatErr[0])
+
+    maxLatBin[0] = dict_hVFATHitsVsLat[vfat].GetBinCenter(dict_hVFATHitsVsLat[vfat].GetMaximumBin())
+    grMaxLatBinByVFAT.SetPoint(vfat, vfat, maxLatBin[0])
     grMaxLatBinByVFAT.SetPointError(vfat, 0, 0.5) #could be improved upon
 
-    #Initialize
+    # Initialize
     dict_fitNHitsVFAT_Sig[vfat] = r.TF1("func_N_vs_Lat_VFAT%i_Sig"%vfat,"[0]",latFitMin_Sig,latFitMax_Sig)
     dict_fitNHitsVFAT_Noise[vfat] = r.TF1("func_N_vs_Lat_VFAT%i_Noise"%vfat,"[0]",latMin,latMax)
     dict_grNHitsVFAT[vfat] = r.TGraphAsymmErrors(dict_hVFATHitsVsLat[vfat])
     dict_grNHitsVFAT[vfat].SetName("g_N_vs_Lat_VFAT%i"%vfat)
     
-    #Fitting
+    # Fitting
     if options.performFit:
         # Fit Signal
-        dict_fitNHitsVFAT_Sig[vfat].SetParameter(0, NMaxLatBin)
+        dict_fitNHitsVFAT_Sig[vfat].SetParameter(0, hitCountMaxLat[0])
+        dict_fitNHitsVFAT_Sig[vfat].SetLineColor(r.kGreen+1)
         dict_grNHitsVFAT[vfat].Fit(dict_fitNHitsVFAT_Sig[vfat],"QR")
-        #dict_hVFATHitsVsLat[vfat].Fit(dict_fitNHitsVFAT_Sig[vfat],"QR")
 
         # Remove Signal Region
         latVal = r.Double()
@@ -138,31 +167,32 @@ for vfat in dict_hVFATHitsVsLat:
 
         # Fit Noise
         dict_fitNHitsVFAT_Noise[vfat].SetParameter(0, 0.)
+        dict_fitNHitsVFAT_Noise[vfat].SetLineColor(r.kRed+1)
         gTempDist.Fit(dict_fitNHitsVFAT_Noise[vfat],"QR")
 
         # Calc Signal & Signal/Noise
-        N_Bkg = dict_fitNHitsVFAT_Noise[vfat].GetParameter(0)
-        N_Bkg_Err = dict_fitNHitsVFAT_Noise[vfat].GetParError(0)
-        N_Sig = dict_fitNHitsVFAT_Sig[vfat].GetParameter(0) - N_Bkg
-        N_Sig_Err = sqrt( (dict_fitNHitsVFAT_Sig[vfat].GetParError(0))**2 + N_Bkg_Err**2)
+        hitCountBkg[0] = dict_fitNHitsVFAT_Noise[vfat].GetParameter(0)
+        hitCountBkgErr[0] = dict_fitNHitsVFAT_Noise[vfat].GetParError(0)
+        hitCountSig[0] = dict_fitNHitsVFAT_Sig[vfat].GetParameter(0) - hitCountBkg[0]
+        hitCountSigErr[0] = sqrt( (dict_fitNHitsVFAT_Sig[vfat].GetParError(0))**2 + hitCountBkgErr[0]**2)
 
-        Sig_Over_Bkg_Err = sqrt( (N_Sig_Err / N_Bkg)**2 + (N_Bkg_Err**2 * (N_Sig / N_Bkg**2)**2) )
+        SigOverBkg[0] = hitCountSig[0] / hitCountBkg[0]
+        SigOverBkgErr[0] = sqrt( (hitCountSigErr[0] / hitCountBkg[0])**2 + (hitCountBkgErr[0]**2 * (hitCountSig[0] / hitCountBkg[0]**2)**2) )
 
         # Add to Plot
-        grVFATSigOverBkg.SetPoint(vfat, vfat, N_Sig / N_Bkg )
-        grVFATSigOverBkg.SetPointError(vfat, 0, Sig_Over_Bkg_Err)
+        grVFATSigOverBkg.SetPoint(vfat, vfat, SigOverBkg[0] )
+        grVFATSigOverBkg.SetPointError(vfat, 0, SigOverBkgErr[0] )
 
-        grVFATNSignalNoBkg.SetPoint(vfat, vfat, N_Sig )
-        grVFATNSignalNoBkg.SetPointError(vfat, 0, N_Sig_Err )
+        grVFATNSignalNoBkg.SetPoint(vfat, vfat, hitCountSig[0] )
+        grVFATNSignalNoBkg.SetPointError(vfat, 0, hitCountSigErr[0] )
 
         # Print if requested
         if options.debug:
-            print "%i\t%f\t%f"%(vfat, N_Sig, N_Sig / N_Bkg)
+            print "%i\t%f\t%f"%(vfat, hitCountSig[0], SigOverBkg[0])
         pass
 
-    #Draw
+    # Format
     r.gStyle.SetOptStat(0)
-    canv_Summary.cd(vfat+1)
     dict_grNHitsVFAT[vfat].SetMarkerStyle(21)
     dict_grNHitsVFAT[vfat].SetMarkerSize(0.7)
     dict_grNHitsVFAT[vfat].SetLineWidth(2)
@@ -170,43 +200,45 @@ for vfat in dict_hVFATHitsVsLat:
     dict_grNHitsVFAT[vfat].GetXaxis().SetTitle("Lat")
     dict_grNHitsVFAT[vfat].GetYaxis().SetRangeUser(0, nTrig)
     dict_grNHitsVFAT[vfat].GetYaxis().SetTitle("N")
-    dict_grNHitsVFAT[vfat].Draw("APE1")
-    if options.performFit:
-        dict_fitNHitsVFAT_Sig[vfat].SetLineColor(r.kGreen+1)
-        dict_fitNHitsVFAT_Sig[vfat].Draw("same")
-        dict_fitNHitsVFAT_Noise[vfat].SetLineColor(r.kRed+1)
-        dict_fitNHitsVFAT_Noise[vfat].Draw("same")
 
-    #Write
-    dirVFAT = outF.mkdir("VFAT%i"%vfat)
+    # Write
+    dirVFAT = dirVFATPlots.mkdir("VFAT%i"%vfat)
     dirVFAT.cd()
     dict_grNHitsVFAT[vfat].Write()
     dict_hVFATHitsVsLat[vfat].Write()
     if options.performFit:
         dict_fitNHitsVFAT_Sig[vfat].Write()
         dict_fitNHitsVFAT_Noise[vfat].Write()
+    myT.Fill()
     pass
 
-#Store - Summary
-canv_Summary.SaveAs(filename+'/Summary.png')
+# Store - Summary
+if options.performFit:
+    canv_Summary = make3x8Canvas('canv_Summary', dict_grNHitsVFAT, 'APE1', dict_fitNHitsVFAT_Noise, '')
+    canv_Summary.SaveAs(filename+'/Summary.png')
+else:
+    canv_Summary = make3x8Canvas('canv_Summary', dict_grNHitsVFAT, 'APE1')
+    canv_Summary.SaveAs(filename+'/Summary.png')
 
-#Store - Sig Over Bkg
+# Store - Sig Over Bkg
 if options.performFit:
     canv_SigOverBkg = r.TCanvas("canv_SigOverBkg","canv_SigOverBkg",600,600)
     canv_SigOverBkg.cd()
+    canv_SigOverBkg.cd().SetLogy()
+    canv_SigOverBkg.cd().SetGridy()
     grVFATSigOverBkg.SetTitle("")
     grVFATSigOverBkg.SetMarkerStyle(21)
     grVFATSigOverBkg.SetMarkerSize(0.7)
     grVFATSigOverBkg.SetLineWidth(2)    
     grVFATSigOverBkg.GetXaxis().SetTitle("VFAT Pos")
     grVFATSigOverBkg.GetYaxis().SetTitle("Sig / Bkg)")
-    grVFATSigOverBkg.GetYaxis().SetTitleOffset(1.2)
-    grVFATSigOverBkg.GetYaxis().SetRangeUser(0,20)
+    grVFATSigOverBkg.GetYaxis().SetTitleOffset(1.25)
+    grVFATSigOverBkg.GetYaxis().SetRangeUser(1e-1,1e2)
     grVFATSigOverBkg.GetXaxis().SetRangeUser(-0.5,24.5)
     grVFATSigOverBkg.Draw("APE1")
     canv_SigOverBkg.SaveAs(filename+'/SignalOverBkg.png')
 
-#Store - Signal
+# Store - Signal
 if options.performFit:
     canv_Signal = r.TCanvas("canv_Signal","canv_Signal",600,600)
     canv_Signal.cd()
@@ -222,7 +254,7 @@ if options.performFit:
     grVFATNSignalNoBkg.Draw("APE1")
     canv_Signal.SaveAs(filename+'/SignalNoBkg.png')
 
-#Store - Max Hits By Lat Per VFAT
+# Store - Max Hits By Lat Per VFAT
 canv_MaxHitsPerLatByVFAT = r.TCanvas("canv_MaxHitsPerLatByVFAT","canv_MaxHitsPerLatByVFAT",1200,600)
 canv_MaxHitsPerLatByVFAT.Divide(2,1)
 canv_MaxHitsPerLatByVFAT.cd(1)
@@ -248,7 +280,7 @@ grMaxLatBinByVFAT.GetXaxis().SetRangeUser(-0.5,24.5)
 grMaxLatBinByVFAT.Draw("APE1")
 canv_MaxHitsPerLatByVFAT.SaveAs(filename+'/MaxHitsPerLatByVFAT.png')
 
-#Store - TObjects
+# Store - TObjects
 outF.cd()
 grNMaxLatBinByVFAT.SetName("grNMaxLatBinByVFAT")
 grNMaxLatBinByVFAT.Write()
@@ -259,4 +291,5 @@ if options.performFit:
     grVFATSigOverBkg.Write()
     grVFATNSignalNoBkg.SetName("grVFATNSignalNoBkg")
     grVFATNSignalNoBkg.Write()
+myT.Write()
 outF.Close()

--- a/anautilities.py
+++ b/anautilities.py
@@ -65,23 +65,29 @@ def initVFATArray(array_dtype, nstrips=128):
 
     return np.zeros(nstrips, dtype=list_dtypeTuple)
 
-def make3x8Canvas(name, initialContent = None, drawOption = ''):
+def make3x8Canvas(name, initialContent = None, initialDrawOpt = '', secondaryContent = None, secondaryDrawOpt = ''):
     """
     Creates a 3x8 canvas for summary plots.
 
-    initialContent should be None or an array of 24 (one per VFAT) TObject that
-    will be drawn on the canvas. drawOption will be passed to the Draw
-    function.
+    name - TName of output TCanvas
+    initialContent - either None or an array of 24 (one per VFAT) TObjects that will be drawn on the canvas.
+    initialDrawOpt - draw option to be used when drawing elements of initialContent
+    secondaryContent - either None or an array of 24 (one per VFAT) TObjects that will be drawn on top of the canvas.
+    secondaryDrawOpt - draw option to be used when drawing elements of secondaryContent
     """
 
     import ROOT as r
     
     canv = r.TCanvas(name,name,500*8,500*3)
     canv.Divide(8,3)
-    if initialContent != None:
+    if initialContent is not None:
         for vfat in range(24):
             canv.cd(vfat+1)
-            initialContent[vfat].Draw(drawOption)
+            initialContent[vfat].Draw(initialDrawOpt)
+    if secondaryContent is not None:
+        for vfat in range(24):
+            canv.cd(vfat+1)
+            secondaryContent[vfat].Draw("same%s"%secondaryDrawOpt)
     canv.Update()
     return canv
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The data that is plotted by `anaUltraLatency.py` is now also stored in an output `TTree` object.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Quality of life feature. This allows `gemPlotter.py` and `gemTreeDrawWrapper.py` to also plot this data in new ways.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I re-ran old analysis.  No changes to syntax.

### Screenshots (if appropriate):
<img width="1180" alt="screen shot 2017-09-21 at 15 29 04" src="https://user-images.githubusercontent.com/6432141/30698265-b86f1cc0-9ee1-11e7-8b89-d1c945059b09.png">
<img width="184" alt="screen shot 2017-09-21 at 15 29 45" src="https://user-images.githubusercontent.com/6432141/30698270-bc39c3a0-9ee1-11e7-937f-b8e3fe261b6c.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
