### PR TITLE
New Feature & Bug Fix: anaUltraThreshold.py now makes output TTree and BugFix #45

### DIFF
--- a/anaInfo.py
+++ b/anaInfo.py
@@ -17,6 +17,7 @@ tree_names = {
         "scurve":("SCurveData.root","scurveTree"),
         "scurveAna":("SCurveData/SCurveFitData.root","scurveFitTree"),
         "threshold":("ThresholdScanData.root","thrTree"),
+        "thresholdAna":("ThresholdScanData/ThresholdPlots.root","thrAnaTree"),
         "trim":("SCurveData_Trimmed.root","scurveTree"),
         "trimAna":("SCurveData_Trimmed/SCurveFitData.root","scurveFitTree")
         }

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -20,7 +20,7 @@ parser.add_option("--IsTrimmed", action="store_true", dest="IsTrimmed",
                   help="If the data is from a trimmed scan, plot the value it tried aligning to", metavar="IsTrimmed")
 parser.add_option("--zscore", type="float", dest="zscore", default=3.5,
                   help="Z-Score for Outlier Identification in MAD Algo", metavar="zscore")
-parser.set_defaults(outfilename="SCurveData.root")
+parser.set_defaults(outfilename="SCurveFitData.root")
 
 (options, args) = parser.parse_args()
 filename = options.filename[:-5]

--- a/anaUltraThreshold.py
+++ b/anaUltraThreshold.py
@@ -80,13 +80,13 @@ hot_channels = []
 for vfat in range(0,24):
     hot_channels.append([])
     if not (options.channels or options.PanPin):
-        vSum[vfat] = r.TH2D('vSum%i'%vfat,'vSum%i;Strip;VThreshold1 [DAC units]'%vfat,128,-0.5,127.5,VT1_MAX+1,-0.5,VT1_MAX+0.5)
+        vSum[vfat] = r.TH2D('h_VT1_vs_ROBstr_VFAT%i'%vfat,'vSum%i;Strip;VThreshold1 [DAC units]'%vfat,128,-0.5,127.5,VT1_MAX+1,-0.5,VT1_MAX+0.5)
         pass
     elif options.channels:
-        vSum[vfat] = r.TH2D('vSum%i'%vfat,'vSum%i;Channel;VThreshold1 [DAC units]'%vfat,128,-0.5,127.5,VT1_MAX+1,-0.5,VT1_MAX+0.5)
+        vSum[vfat] = r.TH2D('h_VT1_vs_vfatCH_VFAT%i'%vfat,'vSum%i;Channel;VThreshold1 [DAC units]'%vfat,128,-0.5,127.5,VT1_MAX+1,-0.5,VT1_MAX+0.5)
         pass
     elif options.PanPin:
-        vSum[vfat] = r.TH2D('vSum%i'%vfat,'vSum%i;Panasonic Pin;VThreshold1 [DAC units]'%vfat,128,-0.5,127.5,VT1_MAX+1,-0.5,VT1_MAX+0.5)
+        vSum[vfat] = r.TH2D('h_VT1_vs_PanPin_VFAT%i'%vfat,'vSum%i;Panasonic Pin;VThreshold1 [DAC units]'%vfat,128,-0.5,127.5,VT1_MAX+1,-0.5,VT1_MAX+0.5)
         pass
     for chan in range(0,128):
         hot_channels[vfat].append(False)
@@ -252,7 +252,7 @@ for vfat in range(0,24):
     r.gStyle.SetOptStat(0)
     canv_pruned.cd(vfat+1)
     vSum[vfat].Draw('colz')
-    vSum[vfat].Write()
+    vSum[vfat].Clone("%s_Pruned"%(vSum[vfat].GetName())).Write()
     pass
 canv_pruned.SaveAs(filename+'/ThreshPrunedSummary.png')
 
@@ -265,7 +265,7 @@ for vfat in range(0,24):
     canv_proj.cd(vfat+1)
     r.gPad.SetLogy()
     vSum[vfat].ProjectionY().Draw()
-    vSum[vfat].ProjectionY().Write()
+    vSum[vfat].ProjectionY("h_VT1_VFAT%i"%vfat).Write()
     pass
 canv_proj.SaveAs(filename+'/VFATPrunedSummary.png')
 

--- a/anaUltraThreshold.py
+++ b/anaUltraThreshold.py
@@ -14,7 +14,7 @@ parser.add_option("--fileScurveFitTree", type="string", dest="fileScurveFitTree"
 parser.add_option("--zscore", type="float", dest="zscore", default=3.5,
                   help="Z-Score for Outlier Identification in MAD Algo", metavar="zscore")
 
-parser.set_defaults(outfilename="VThreshold1Data_Trimmed.root")
+parser.set_defaults(outfilename="ThresholdPlots.root")
 
 (options, args) = parser.parse_args()
 filename = options.filename[:-5]
@@ -280,19 +280,24 @@ for vfat in range(0,24):
             break
         pass
     pass
-outF.Close()
-txt_vfat = open(filename+"/vfatConfig.txt", 'w')
 
 print "trimRange:"
 print trimRange
 print "vt1:"
 print vt1
 
+txt_vfat = open(filename+"/vfatConfig.txt", 'w')
 txt_vfat.write("vfatN/I:vt1/I:trimRange/I\n")
 for vfat in range(0,24):
     txt_vfat.write('%i\t%i\t%i\n'%(vfat, vt1[vfat],trimRange[vfat]))
     pass
 txt_vfat.close()
+
+# Make output TTree
+myT = r.TTree('thrAnaTree','Tree Holding Analyzed Threshold Data')
+myT.ReadFile(filename+"/vfatConfig.txt")
+myT.Write()
+outF.Close()
 
 #Update channel registers configuration file
 if options.chConfigKnown:

--- a/ana_scans.py
+++ b/ana_scans.py
@@ -206,7 +206,7 @@ if __name__ == '__main__':
     for link in chamber_config.keys():
       chamber = chamber_config[link]
       GEB = GEBtype[link]
-      launchAna(options.anaType,
+      launchAnaArgs(options.anaType,
                 chamber,
                 GEB,
                 options.scandate,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Bug fix of https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/45
Now anaUltraThreshold.py now also makes an output `TTree` object called `thrAnaTree` which stores the trimRange and VT1 determined for each VFAT.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Running `ana_scans.py` with `--series` option caused a crash.

Now with `anaUltraThreshold.py` stores the trimRange and vt1 values it computes in an output `TTree` object which can be used with `gemPlotter.py` or `gemTreeDrawWrapper.py`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I re-ran an old analysis via `ana_scans.py` using the `--series` option.

### Screenshots (if appropriate):
<img width="265" alt="screen shot 2017-10-04 at 15 42 27" src="https://user-images.githubusercontent.com/6432141/31179008-05175090-a91b-11e7-8d7b-699279ff9424.png">
<img width="192" alt="screen shot 2017-10-04 at 15 42 17" src="https://user-images.githubusercontent.com/6432141/31179012-07e60a46-a91b-11e7-8d31-343946c11dcd.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
