### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 #numpy>=1.10.4
 numpy>=1.7.1
-root-numpy>=4.7.2
+root_numpy>=4.7.2


### PR DESCRIPTION
## Description
fix bug in `requirements.txt` where `root-numpy` was used instead of `root_numpy` failing pip installation step