### PR TITLE
New Feature: ChipID added to TTree's and Config Files

### DIFF
--- a/anaUltraLatency.py
+++ b/anaUltraLatency.py
@@ -50,6 +50,7 @@ latMin = 1000
 latMax = -1
 nTrig = -1
 dict_vfatID = {}
+listOfBranches = inF.latTree.GetListOfBranches()
 for event in inF.latTree:
     dict_hVFATHitsVsLat[int(event.vfatN)].Fill(event.lat,event.Nhits)
     if event.lat < latMin and event.Nhits > 0:
@@ -60,7 +61,10 @@ for event in inF.latTree:
         pass
 
     if int(event.vfatN) not in dict_vfatID.keys():
-        dict_vfatID[int(event.vfatN)] = int(event.vfatID)
+        if 'vfatID' in listOfBranches:
+            dict_vfatID[int(event.vfatN)] = int(event.vfatID)
+        else:
+            dict_vfatID[int(event.vfatN)] = 0
 
     if nTrig < 0:
         nTrig = event.Nev

--- a/anaUltraLatency.py
+++ b/anaUltraLatency.py
@@ -49,6 +49,7 @@ print 'Filling Histograms'
 latMin = 1000
 latMax = -1
 nTrig = -1
+dict_vfatID = {}
 for event in inF.latTree:
     dict_hVFATHitsVsLat[int(event.vfatN)].Fill(event.lat,event.Nhits)
     if event.lat < latMin and event.Nhits > 0:
@@ -57,6 +58,9 @@ for event in inF.latTree:
     elif event.lat > latMax:
         latMax = event.lat
         pass
+
+    if int(event.vfatN) not in dict_vfatID.keys():
+        dict_vfatID[int(event.vfatN)] = int(event.vfatID)
 
     if nTrig < 0:
         nTrig = event.Nev
@@ -97,6 +101,8 @@ dirVFATPlots = outF.mkdir("VFAT_Plots")
 myT = r.TTree('latFitTree','Tree Holding FitData')
 vfatN = array( 'i', [ 0 ] )
 myT.Branch( 'vfatN', vfatN, 'vfatN/I' )
+vfatID = array( 'i', [-1] )
+myT.Branch( 'vfatID', vfatID, 'vfatID/I' ) #Hex Chip ID of VFAT
 hitCountMaxLat = array( 'i', [ 0 ] )
 myT.Branch( 'hitCountMaxLat', hitCountMaxLat, 'hitCountMaxLat/I' )
 hitCountMaxLatErr = array( 'i', [ 0 ] )
@@ -132,6 +138,7 @@ if options.debug and options.performFit:
 for vfat in dict_hVFATHitsVsLat:
     # Store VFAT info
     vfatN[0] = vfat
+    vfatID[0] = dict_vfatID[vfat]
 
     # Store Max Info
     hitCountMaxLat[0] = dict_hVFATHitsVsLat[vfat].GetBinContent(dict_hVFATHitsVsLat[vfat].GetMaximumBin())

--- a/anaUltraLatency.py
+++ b/anaUltraLatency.py
@@ -49,7 +49,7 @@ print 'Filling Histograms'
 latMin = 1000
 latMax = -1
 nTrig = -1
-dict_vfatID = {}
+dict_vfatID = dict((vfat, 0) for vfat in range(0,24))
 listOfBranches = inF.latTree.GetListOfBranches()
 for event in inF.latTree:
     dict_hVFATHitsVsLat[int(event.vfatN)].Fill(event.lat,event.Nhits)
@@ -60,11 +60,11 @@ for event in inF.latTree:
         latMax = event.lat
         pass
 
-    if int(event.vfatN) not in dict_vfatID.keys():
+    if not (dict_vfatID[event.vfatN] > 0):
         if 'vfatID' in listOfBranches:
-            dict_vfatID[int(event.vfatN)] = int(event.vfatID)
+            dict_vfatID[event.vfatN] = event.vfatID
         else:
-            dict_vfatID[int(event.vfatN)] = 0
+            dict_vfatID[event.vfatN] = 0
 
     if nTrig < 0:
         nTrig = event.Nev

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -188,7 +188,7 @@ if options.SaveFile:
 
 # Fill
 print("Filling Histograms")
-dict_vfatID = {}
+dict_vfatID = dict((vfat, 0) for vfat in range(0,24))
 listOfBranches = inF.scurveTree.GetListOfBranches()
 for event in inF.scurveTree:
     strip = chanToStripLUT[event.vfatN][event.vfatCH]
@@ -215,7 +215,7 @@ for event in inF.scurveTree:
     trim_list[event.vfatN][event.vfatCH] = event.trimDAC
     trimrange_list[event.vfatN][event.vfatCH] = event.trimRange
     
-    if event.vfatN not in dict_vfatID.keys():
+    if not (dict_vfatID[event.vfatN] > 0):
         if 'vfatID' in listOfBranches:
             dict_vfatID[event.vfatN] = event.vfatID
         else:

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -189,6 +189,7 @@ if options.SaveFile:
 # Fill
 print("Filling Histograms")
 dict_vfatID = {}
+listOfBranches = inF.scurveTree.GetListOfBranches()
 for event in inF.scurveTree:
     strip = chanToStripLUT[event.vfatN][event.vfatCH]
     pan_pin = chanToPanPinLUT[event.vfatN][event.vfatCH]
@@ -206,14 +207,20 @@ for event in inF.scurveTree:
             vSummaryPlotsPanPin2[event.vfatN].Fill(127-pan_pin,vToQm*event.vcal+vToQb,event.Nhits)
             pass
         pass
+    
     binVal = vScurves[event.vfatN][event.vfatCH].FindBin(event.vcal)
     vScurves[event.vfatN][event.vfatCH].SetBinContent(binVal, event.Nhits)
     r.gStyle.SetOptStat(1111111)
     vthr_list[event.vfatN][event.vfatCH] = event.vthr
     trim_list[event.vfatN][event.vfatCH] = event.trimDAC
     trimrange_list[event.vfatN][event.vfatCH] = event.trimRange
+    
     if event.vfatN not in dict_vfatID.keys():
-        dict_vfatID[event.vfatN] = event.vfatID
+        if 'vfatID' in listOfBranches:
+            dict_vfatID[event.vfatN] = event.vfatID
+        else:
+            dict_vfatID[event.vfatN] = 0
+
     if options.SaveFile:
         fitter.feed(event)
         pass

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -230,7 +230,7 @@ if options.SaveFile:
             fitSummary.write(
                     '%i\t%i\t%i\t%f\t%f\t%f\t%f\n'%(
                         vfat,
-                        hex(dict_vfatID[vfat]),
+                        dict_vfatID[vfat],
                         chan,
                         vScurveFits[vfat][chan].GetParameter(0),
                         vScurveFits[vfat][chan].GetParameter(1),
@@ -436,7 +436,12 @@ if options.SaveFile:
     confF.write('vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:mask/I\n')
     for vfat in range (0,24):
         for chan in range (0, 128):
-            confF.write('%i\t%i\t%i\t%i\t%i\n'%(vfat,hex(dict_vfatID[vfat]),chan,trim_list[vfat][chan],masks[vfat][chan]))
+            confF.write('%i\t%i\t%i\t%i\t%i\n'%(
+                vfat,
+                dict_vfatID[vfat],
+                chan,
+                trim_list[vfat][chan],
+                masks[vfat][chan]))
             pass
         pass
     confF.close()

--- a/anaUltraThreshold.py
+++ b/anaUltraThreshold.py
@@ -96,12 +96,16 @@ for vfat in range(0,24):
 print 'Filling Histograms'
 trimRange = dict((vfat,0) for vfat in range(0,24))
 dict_vfatID = {}
+listOfBranches = inF.thrTree.GetListOfBranches()
 for event in inF.thrTree :
     strip = lookup_table[event.vfatN][event.vfatCH]
     pan_pin = pan_lookup[event.vfatN][event.vfatCH]
     trimRange[int(event.vfatN)] = int(event.trimRange)
     if event.vfatN not in dict_vfatID.keys():
-        dict_vfatID[event.vfatN] = event.vfatID
+        if 'vfatID' in listOfBranches:
+            dict_vfatID[event.vfatN] = event.vfatID
+        else:
+            dict_vfatID[event.vfatN] = 0
 
     if options.channels:
         vSum[event.vfatN].Fill(event.vfatCH,event.vth1,event.Nhits)

--- a/anaUltraThreshold.py
+++ b/anaUltraThreshold.py
@@ -95,13 +95,14 @@ for vfat in range(0,24):
 
 print 'Filling Histograms'
 trimRange = dict((vfat,0) for vfat in range(0,24))
-dict_vfatID = {}
+dict_vfatID = dict((vfat, 0) for vfat in range(0,24))
 listOfBranches = inF.thrTree.GetListOfBranches()
 for event in inF.thrTree :
     strip = lookup_table[event.vfatN][event.vfatCH]
     pan_pin = pan_lookup[event.vfatN][event.vfatCH]
     trimRange[int(event.vfatN)] = int(event.trimRange)
-    if event.vfatN not in dict_vfatID.keys():
+    
+    if not (dict_vfatID[event.vfatN] > 0):
         if 'vfatID' in listOfBranches:
             dict_vfatID[event.vfatN] = event.vfatID
         else:

--- a/anaUltraThreshold.py
+++ b/anaUltraThreshold.py
@@ -95,10 +95,13 @@ for vfat in range(0,24):
 
 print 'Filling Histograms'
 trimRange = dict((vfat,0) for vfat in range(0,24))
+dict_vfatID = {}
 for event in inF.thrTree :
     strip = lookup_table[event.vfatN][event.vfatCH]
     pan_pin = pan_lookup[event.vfatN][event.vfatCH]
     trimRange[int(event.vfatN)] = int(event.trimRange)
+    if event.vfatN not in dict_vfatID.keys():
+        dict_vfatID[event.vfatN] = event.vfatID
 
     if options.channels:
         vSum[event.vfatN].Fill(event.vfatCH,event.vth1,event.Nhits)
@@ -287,9 +290,9 @@ print "vt1:"
 print vt1
 
 txt_vfat = open(filename+"/vfatConfig.txt", 'w')
-txt_vfat.write("vfatN/I:vt1/I:trimRange/I\n")
+txt_vfat.write("vfatN/I:vfatID/I:vt1/I:trimRange/I\n")
 for vfat in range(0,24):
-    txt_vfat.write('%i\t%i\t%i\n'%(vfat, vt1[vfat],trimRange[vfat]))
+    txt_vfat.write('%i\t%i\t%i\t%i\n'%(vfat,dict_vfatID[vfat],vt1[vfat],trimRange[vfat]))
     pass
 txt_vfat.close()
 
@@ -302,20 +305,20 @@ outF.Close()
 #Update channel registers configuration file
 if options.chConfigKnown:
     confF = open(filename+'/chConfig_MasksUpdated.txt','w')
-    confF.write('vfatN/I:vfatCH/I:trimDAC/I:mask/I\n')
+    confF.write('vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:mask/I\n')
 
     if options.debug:
-        print 'vfatN/I:vfatCH/I:trimDAC/I:mask/I\n'
+        print 'vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:mask/I\n'
         pass
 
     for vfat in range (0,24):
         for j in range (0, 128):
             chan = vfatCh_lookup[vfat][j]
             if options.debug:
-                print '%i\t%i\t%i\t%i\n'%(vfat,chan,dict_vfatTrimMaskData[vfat][j]['trimDAC'],int(hot_channels[vfat][j] or dict_vfatTrimMaskData[vfat][j]['mask']))
+                print '%i\t%i\t%i\t%i\t%i\n'%(vfat,dict_vfatID[vfat],chan,dict_vfatTrimMaskData[vfat][j]['trimDAC'],int(hot_channels[vfat][j] or dict_vfatTrimMaskData[vfat][j]['mask']))
                 pass
 
-            confF.write('%i\t%i\t%i\t%i\n'%(vfat,chan,dict_vfatTrimMaskData[vfat][j]['trimDAC'],int(hot_channels[vfat][j] or dict_vfatTrimMaskData[vfat][j]['mask'])))
+            confF.write('%i\t%i\t%i\t%i\t%i\n'%(vfat,dict_vfatID[vfat],chan,dict_vfatTrimMaskData[vfat][j]['trimDAC'],int(hot_channels[vfat][j] or dict_vfatTrimMaskData[vfat][j]['mask'])))
             pass
         pass
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Address: https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/50

The ChipID1 register will now be stored in output TTree and config files as the `vfatID` branch.  Note if the input file does *not* have the `vfatID` branch the output TTree will have a `vfatID` branch with all leaves equal to 0 (same for the output config files).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
As we move forward eventually we will be configuring with the information that will be stored in the database.  We should be able to cross-check that the info stored for a given VFAT in the database matches the VFAT that is being configured on the hardware.  The best way to do this is to compare the supplied `vfatID` with the `ChipID1` register on the VFAT since they should be identical.

Additionally in our calibration data there is no way to know which VFATs were used for a given run.  Now all produced TTree's by our calibration scans will include the `vfatID` branch which stores the value of the `ChipID1` register. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Took new measurements, analyzed them, and configured from the produced config files as shown:

http://cmsonline.cern.ch/cms-elog/1016357
http://cmsonline.cern.ch/cms-elog/1016594

Also re-analyzed old data.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
