### PR TITLE
Update paths.sh

### DIFF
--- a/setup/paths.sh
+++ b/setup/paths.sh
@@ -1,9 +1,9 @@
 # Setup cmsgemos
-echo "Checking paths"
+# echo "Checking paths"
 
 #export BUILD_HOME=<your path>/cmsgemos/../
 if [[ -n "$BUILD_HOME" ]]; then
-    echo BUILD_HOME $BUILD_HOME
+    ; # echo BUILD_HOME $BUILD_HOME
 else
     echo "BUILD_HOME not set, please set BUILD_HOME to the directory above the root of your repository"
     echo " (export BUILD_HOME=<your path>/cmsgemos/../) and then rerun this script"
@@ -12,7 +12,7 @@ fi
 
 #export DATA_PATH=/<your>/<data>/<directory>
 if [[ -n "$DATA_PATH" ]]; then
-    echo DATA_PATH $DATA_PATH
+    ; # echo DATA_PATH $DATA_PATH
 else
     echo "DATA_PATH not set, please set DATA_PATH to a directory where data files created by scan applications will be written"
     echo " (export DATA_PATH=<your>/<data>/<directory>/) and then rerun this script"
@@ -21,7 +21,7 @@ fi
 
 #export ELOG_PATH=/<your>/<elog>/<directory>
 if [[ -n "$ELOG_PATH" ]]; then
-    echo ELOG_PATH $ELOG_PATH
+    ; # echo ELOG_PATH $ELOG_PATH
 else
     echo "ELOG_PATH not set, please set ELOG_PATH to a directory where data files created by scan applications will be written"
     echo " (export ELOG_PATH=<your>/<elog>/<directory>/) and then rerun this script"
@@ -30,7 +30,7 @@ fi
 
 # Checking GEM_PYTHON_PATH
 if [[ -n "$GEM_PYTHON_PATH" ]]; then
-    echo GEM_PYTHON_PATH $GEM_PYTHON_PATH
+    ; # echo GEM_PYTHON_PATH $GEM_PYTHON_PATH
 else
     echo "GEM_PYTHON_PATH not set, please source \$BUILD_HOME/cmsgemos/setup/paths.sh"
     return
@@ -47,12 +47,12 @@ export PATH=$PATH:$GEM_PLOTTING_PROJECT/macros
 export PYTHONPATH=$PYTHONPATH:$GEM_PLOTTING_PROJECT
 
 # Making detector channel maps
-echo "Checking Detector Channel Maps"
+# echo "Checking Detector Channel Maps"
 if [ ! -f $GEM_PLOTTING_PROJECT/mapping/longChannelMap.txt ]; then
-    echo "No channel maps found, making"
+    ; # echo "No channel maps found, making"
     python $GEM_PLOTTING_PROJECT/mapping/buildMapFiles.py 
 fi
 
 # Done
-echo GEM_PLOTTING_PROJECT $GEM_PLOTTING_PROJECT
-echo "Setup Complete"
+# echo GEM_PLOTTING_PROJECT $GEM_PLOTTING_PROJECT
+# echo "Setup Complete"


### PR DESCRIPTION
* `echo`s in environment setup scripts are often problematic, removing for now in favour of a shell function to print the environment
* `echo`s in cases of a failure will remain
