### PR TITLE
Adding threshold scan control to the analysis

### DIFF
--- a/anaInfo.py
+++ b/anaInfo.py
@@ -3,7 +3,9 @@ import string
 ana_config = {
         "latency":"anaUltraLatency.py",
         "scurve":"anaUltraScurve.py",
-        "threshold":"anaUltraThreshold.py",
+        "thresholdch":"anaUltraThreshold.py",
+        "thresholdvftrk":"anaUltraThreshold.py",
+        "thresholdvftrig":"anaUltraThreshold.py",
         "trim":"anaUltraScurve.py"
         }
 
@@ -17,6 +19,9 @@ tree_names = {
         "scurve":("SCurveData.root","scurveTree"),
         "scurveAna":("SCurveData/SCurveFitData.root","scurveFitTree"),
         "threshold":("ThresholdScanData.root","thrTree"),
+        "thresholdch":("ThresholdScanData.root","thrTree"),
+        "thresholdvftrig":("ThresholdScanData.root","thrTree"),
+        "thresholdvftrk":("ThresholdScanData.root","thrTree"),
         "thresholdAna":("ThresholdScanData/ThresholdPlots.root","thrAnaTree"),
         "trim":("SCurveData_Trimmed.root","scurveTree"),
         "trimAna":("SCurveData_Trimmed/SCurveFitData.root","scurveFitTree")

--- a/ana_scans.py
+++ b/ana_scans.py
@@ -74,7 +74,7 @@ def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0,
     postCmds.append(["cp","%s/SCurveData/chConfig.txt"%(dirPath),
                  "%s/chConfig_%s_ztrim%2.2f.txt"%(elogPath,cName,ztrim)])
     pass
-  elif "threshold" in anaType:
+  elif anaType == "threshold":
     dirPath = "%s/%s/"%(dirPath,scandate)
     filename = dirPath + "ThresholdScanData.root"
     if not os.path.isfile(filename):
@@ -83,7 +83,9 @@ def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0,
 
     cmd.append("--infilename=%s"%(filename))
     cmd.append("--outfilename=%s"%("ThresholdPlots.root"))
-   
+    if "thresholdvf" in anaType:
+      cmd.append("--pervfat")
+
     if chConfigKnown:
       cmd.append("--chConfigKnown")
       #dirPath_Trim = "%s/%s/trim/z%f/%s/SCurveData_Trimmed/"%(dataPath,cName,ztrim,scandatetrim)

--- a/ana_scans.py
+++ b/ana_scans.py
@@ -74,7 +74,7 @@ def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0,
     postCmds.append(["cp","%s/SCurveData/chConfig.txt"%(dirPath),
                  "%s/chConfig_%s_ztrim%2.2f.txt"%(elogPath,cName,ztrim)])
     pass
-  elif anaType == "threshold":
+  elif "threshold" in anaType:
     dirPath = "%s/%s/"%(dirPath,scandate)
     filename = dirPath + "ThresholdScanData.root"
     if not os.path.isfile(filename):
@@ -163,7 +163,7 @@ if __name__ == '__main__':
   from anaoptions import parser
 
   parser.add_option("--anaType", type="string", dest="anaType",
-                    help="Analysis type to be executed, from list {'latency','scurve','threshold','trim'}", metavar="anaType")
+                    help="Analysis type to be executed, from list {'latency','scurve','thresholdch','thresholdvftrig','thresholdvftrk','trim'}", metavar="anaType")
   parser.add_option("--latFit", action="store_true", dest="performLatFit",
                     help="Fit the latency distributions", metavar="performLatFit")
   parser.add_option("--latSigRange", type="string", dest="latSigRange", default=None,

--- a/ana_scans.py
+++ b/ana_scans.py
@@ -163,7 +163,7 @@ if __name__ == '__main__':
   from anaoptions import parser
 
   parser.add_option("--anaType", type="string", dest="anaType",
-                    help="Analysis type to be executed, from list {'latency','scurve','thresholdch','thresholdvftrig','thresholdvftrk','trim'}", metavar="anaType")
+                    help="Analysis type to be executed, from list: "+str(ana_config.keys()), metavar="anaType")
   parser.add_option("--latFit", action="store_true", dest="performLatFit",
                     help="Fit the latency distributions", metavar="performLatFit")
   parser.add_option("--latSigRange", type="string", dest="latSigRange", default=None,

--- a/ana_scans.py
+++ b/ana_scans.py
@@ -18,7 +18,7 @@ def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0,
   #dataPath  = os.getenv('DATA_PATH')
   dirPath   = getDirByAnaType(anaType, cName, ztrim)
   elogPath  = "%s/%s"%(os.getenv('ELOG_PATH'),scandate)
-    
+
   print "Analysis Requested: %s"%(anaType)
 
   #Build Commands
@@ -31,10 +31,10 @@ def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0,
     if not os.path.isfile(filename):
       print "No file to analyze. %s does not exist"%(filename)
       return os.EX_NOINPUT
-    
+
     cmd.append("--infilename=%s"%(filename))
     cmd.append("--outfilename=%s"%("latencyAna.root"))
-    
+
     if latFit:
         cmd.append("--fit")
         cmd.append("--latSigMaskRange=%s"%(latSigMaskRange))
@@ -74,7 +74,7 @@ def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0,
     postCmds.append(["cp","%s/SCurveData/chConfig.txt"%(dirPath),
                  "%s/chConfig_%s_ztrim%2.2f.txt"%(elogPath,cName,ztrim)])
     pass
-  elif anaType == "threshold":
+  elif "threshold" in anaType:
     dirPath = "%s/%s/"%(dirPath,scandate)
     filename = dirPath + "ThresholdScanData.root"
     if not os.path.isfile(filename):
@@ -88,13 +88,13 @@ def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0,
 
     if chConfigKnown:
       cmd.append("--chConfigKnown")
-      #dirPath_Trim = "%s/%s/trim/z%f/%s/SCurveData_Trimmed/"%(dataPath,cName,ztrim,scandatetrim)
+      # dirPath_Trim = "%s/%s/trim/z%f/%s/SCurveData_Trimmed/"%(dataPath,cName,ztrim,scandatetrim)
       dirPath_Trim = "%s/%s/SCurveData_Trimmed/"%(getDirByAnaType("trim", cName, ztrim),scandatetrim)
       filename_Trim = dirPath_Trim + "SCurveFitData.root"
       if not os.path.isfile(filename_Trim):
         print "No scurve fit data file to analyze. %s does not exist"%(filename_Trim)
         return os.EX_NOINPUT
-      
+
       cmd.append("--fileScurveFitTree=%s"%(filename_Trim))
       pass
 
@@ -126,7 +126,7 @@ def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0,
     if panasonic:
         cmd.append("--panasonic")
         pass
-        
+
     postCmds.append(["cp","%s/SCurveData_Trimmed/Summary.png"%(dirPath),
                  "%s/SCurveSummaryTrimmed_%s_ztrim%2.2f.png"%(elogPath,cName,ztrim)])
     postCmds.append(["cp","%s/SCurveData_Trimmed/chConfig.txt"%(dirPath),
@@ -136,7 +136,7 @@ def launchAnaArgs(anaType, cName, cType, scandate, scandatetrim=None, ztrim=4.0,
   #Execute Commands
   try:
     log = file("%s/anaLog.log"%(dirPath),"w")
- 
+
     returncode = runCommand(cmd,log)
     if returncode != 0:
       print "Error: command exited with non-zero code %d" % returncode
@@ -171,7 +171,7 @@ if __name__ == '__main__':
   parser.add_option("--latSigRange", type="string", dest="latSigRange", default=None,
                     help="Comma separated pair of values defining expected signal range, e.g. lat #epsilon [41,43] is signal", metavar="latSigRange")
   parser.add_option("--latSigMaskRange", type="string", dest="latSigMaskRange", default=None,
-                    help="Comma separated pair of values defining the region to be masked when trying to fit the noise, e.g. lat #notepsilon [40,44] is noise (lat < 40 || lat > 44)", 
+                    help="Comma separated pair of values defining the region to be masked when trying to fit the noise, e.g. lat #notepsilon [40,44] is noise (lat < 40 || lat > 44)",
                     metavar="latSigMaskRange")
   parser.add_option("--series", action="store_true", dest="series",
                     help="Run tests in series (default is false)", metavar="series")

--- a/anautilities.py
+++ b/anautilities.py
@@ -43,8 +43,12 @@ def getDirByAnaType(anaType, cName, ztrim=4):
         dirPath = "%s/%s/%s/trk/"%(dataPath,cName,anaType)
     elif anaType == "scurve":
         dirPath = "%s/%s/%s/"%(dataPath,cName,anaType)
-    elif anaType == "threshold":
-        dirPath = "%s/%s/%s/channel/"%(dataPath,cName,anaType)
+    elif anaType == "thresholdch":
+        dirPath = "%s/%s/%s/channel/"%(dataPath,cName,"threshold")
+    elif anaType == "thresholdvftrig":
+        dirPath = "%s/%s/%s/vfat/trig/"%(dataPath,cName,"threshold")
+    elif anaType == "thresholdvftrk":
+        dirPath = "%s/%s/%s/vfat/trk/"%(dataPath,cName,"threshold")
     elif anaType == "trim":
         dirPath = "%s/%s/%s/z%f/"%(dataPath,cName,anaType,ztrim)
 


### PR DESCRIPTION
## Description
Updates the analysis control to allow analysis of various different types of `VT1` scans

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Motivation and Context
The `ultraThreshold` module can be configured to take:
* VT1 scan vs channel using tracking data
* VT1 scan vs VFAT using tracking data
* VT1 scan vs VFAT using trigger data (s-bits), which allows much faster scanning of the high threshold tails

## How Has This Been Tested?
* http://cmsonline.cern.ch/cms-elog/1026783
* New configurations are being generated using analysis of both per-channel and per VFAT w/ trigger data

### Screenshots (if appropriate):
