### PR TITLE
Refactoring of anaUltraScurve.py and additional output distributions

### DIFF
--- a/anaInfo.py
+++ b/anaInfo.py
@@ -29,7 +29,8 @@ tree_names = {
 
 mappingNames = [
         "Strip",
-        "PanPin"
+        "PanPin",
+        "vfatCH"
         ]
 
 class MaskReason:

--- a/anaInfo.py
+++ b/anaInfo.py
@@ -27,6 +27,11 @@ tree_names = {
         "trimAna":("SCurveData_Trimmed/SCurveFitData.root","scurveFitTree")
         }
 
+mappingNames = [
+        "Strip",
+        "PanPin"
+        ]
+
 class MaskReason:
     """Enum-like class to represent the reasons for which a channel was masked.
     Reasons are bitmasks. Example usage:

--- a/anaInfo.py
+++ b/anaInfo.py
@@ -33,6 +33,11 @@ mappingNames = [
         "vfatCH"
         ]
 
+# Cal scale factor (e.g. CFG_CAL_FS)
+# Required for determining charge when using 
+# Current pulse cal mode of VFAT3
+dict_calSF = dict((calSF, 0.25*calSF+0.25) for calSF in range(0,4))
+
 class MaskReason:
     """Enum-like class to represent the reasons for which a channel was masked.
     Reasons are bitmasks. Example usage:

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -76,6 +76,8 @@ def plotAllSCurvesOnCanvas(vfatHistos, vfatHistosPanPin2=None, obsName="canvScur
     vfatHistosPanPin2 - As vfatHistos but for the other side of the readout board connector if lutType is "PanPin"
     obsName           - String to append the TCanvas created for each VFAT
     """
+    import ROOT as r
+
     canv_dict = {}
 
     for vfat,histo in vfatHistos.iteritems():
@@ -83,21 +85,25 @@ def plotAllSCurvesOnCanvas(vfatHistos, vfatHistosPanPin2=None, obsName="canvScur
         canv_dict[vfat].cd()
         for binX in range(1,histo.GetNbinsX()+1):
             h_scurve = histo.ProjectionY("h_scurve",binX,binX,"")
-            h_scurve.SetLineColor(kBlue+2)
+            h_scurve.SetLineColor(r.kBlue+2)
             h_scurve.SetLineWidth(2)
+            
+            g_scurve = r.TGraph(h_scurve)
             if binX == 1:
-                h_scurve.Draw()
+                g_scurve.Draw("AP")
             else:
-                h_scurve.Draw("same")
+                g_scurve.Draw("sameP")
         canv_dict[vfat].Update()
     if vfatHistosPanPin2 is not None:
         for vfat,histo in vfatHistosPanPin2.iteritems():
             canv_dict[vfat].cd()
             for binX in range(1,histo.GetNbinsX()+1):
                 h_scurve = histo.ProjectionY("h_scurve",binX,binX,"")
-                h_scurve.SetLineColor(kBlue+2)
+                h_scurve.SetLineColor(r.kBlue+2)
                 h_scurve.SetLineWidth(2)
-                h_scurve.Draw("same")
+                
+                g_scurve = r.TGraph(h_scurve)
+                g_scurve.Draw("sameP")
             canv_dict[vfat].Update()
 
     return canv_dict
@@ -522,13 +528,13 @@ if __name__ == '__main__':
         pass
     
     # Save the summary plots and channel config file
-    if options.panPin:
+    if options.PanPin:
         saveSummary(vSummaryPlots, vSummaryPlotsPanPin2, '%s/Summary.png'%filename, trimVcal) 
     else: 
         saveSummary(vSummaryPlots, None, '%s/Summary.png'%filename, trimVcal)
 
     if options.performFit:
-        if options.panPin:
+        if options.PanPin:
             saveSummary(vSummaryPlotsNoHotChan, vSummaryPlotsNoHotChanPanPin2, '%s/PrunedSummary.png'%filename, trimVcal)
         else:
             saveSummary(vSummaryPlotsNoHotChan, None, '%s/PrunedSummary.png'%filename, trimVcal)
@@ -553,16 +559,16 @@ if __name__ == '__main__':
 
     # Make 1D Plot for each VFAT showing all scurves
     # Don't use the ones stored in fitter since this may not exist (e.g. options.performFit = false)
-    if options.panPin:
-        canvOfScurveHistos = canvOfScurves(vSummaryPlots,vSummaryPlotsPanPin2,"canvScurves")
+    if options.PanPin:
+        canvOfScurveHistos = plotAllSCurvesOnCanvas(vSummaryPlots,vSummaryPlotsPanPin2,"canvScurves")
     else:
-        canvOfScurveHistos = canvOfScurves(vSummaryPlots,None,"canvScurves")
+        canvOfScurveHistos = plotAllSCurvesOnCanvas(vSummaryPlots,None,"canvScurves")
 
     if options.performFit:
-        if options.panPin:
-            canvOfScurveHistosNoHotChan = canvOfScurves(vSummaryPlotsNoHotChan,vSummaryPlotsNoHotChanPanPin2,"canvScurvesNotHotChan")
+        if options.PanPin:
+            canvOfScurveHistosNoHotChan = plotAllSCurvesOnCanvas(vSummaryPlotsNoHotChan,vSummaryPlotsNoHotChanPanPin2,"canvScurvesNotHotChan")
         else:
-            canvOfScurveHistosNoHotChan = canvOfScurves(vSummaryPlotsNoHotChan,None,"canvScurvesNoHotChan")
+            canvOfScurveHistosNoHotChan = plotAllSCurvesOnCanvas(vSummaryPlotsNoHotChan,None,"canvScurvesNoHotChan")
         
         canvOfScurveFits = {}
         for vfat in range(0,24):
@@ -577,17 +583,18 @@ if __name__ == '__main__':
 
     # Save TObjects
     outF.cd()
-    myT.Write()
+    if options.performFit:
+        myT.Write()
     for vfat in range(0,23):
         dirVFAT = outF.mkdir("VFAT%i"%vfat)
         dirVFAT.cd()
         vSummaryPlots[vfat].Write()
-        if options.panPin:
+        if options.PanPin:
             vSummaryPlotsPanPin2.Write()
         canvOfScurveHistos[vfat].Write()
         if options.performFit:
             vSummaryPlotsNoHotChan.Write()
-            if options.panPin:
+            if options.PanPin:
                 vSummaryPlotsNoHotChanPanPin2.Write()
             fitSummaryPlots[vfat].Write()
             threshSummaryPlots[vfat].Write()

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -1,114 +1,91 @@
 #!/bin/env python
 
-import os
-import numpy as np
-import root_numpy as rp #note need root_numpy-4.7.2 (may need to run 'pip install root_numpy --upgrade')
-from optparse import OptionParser
-from array import array
-from anautilities import *
-from anaInfo import *
-from fitting.fitScanData import *
-from mapping.channelMaps import *
-from mapping.PanChannelMaps import *
-from gempython.utils.nesteddict import nesteddict as ndict
+if __name__ = '__main__':
+    import os
+    import numpy as np
+    import root_numpy as rp #note need root_numpy-4.7.2 (may need to run 'pip install root_numpy --upgrade')
+    import ROOT as r
+    
+    from array import array
+    from anautilities import getMapping
+    from anaInfo import maskReason
+    from fitting.fitScanData import ScanDataFitter
+    from gempython.utils.nesteddict import nesteddict as ndict
+    from gempython.utils.wrappers import envCheck
+    
+    from anaoptions import parser
+    parser.add_option("-b", "--drawbad", action="store_true", dest="drawbad",
+                      help="Draw fit overlays for Chi2 > 10000", metavar="drawbad")
+    parser.add_option("--calFile", type="string", dest="calFile", default=None,
+                      help="File specifying CAL_DAC/VCAL to fC equations per VFAT",
+                      metavar="calFile")
+    parser.add_option("-f", "--fit", action="store_true", dest="performFit",
+                      help="Fit scurves and save fit information to output TFile", metavar="performFit")
+    parser.add_option("--IsTrimmed", action="store_true", dest="IsTrimmed",
+                      help="If the data is from a trimmed scan, plot the value it tried aligning to", metavar="IsTrimmed")
+    parser.add_option("--zscore", type="float", dest="zscore", default=3.5,
+                      help="Z-Score for Outlier Identification in MAD Algo", metavar="zscore")
+    parser.add_option("--extChanMapping", type="string", dest="extChanMapping", default=None,
+                      help="Physical filename of a custom, non-default, channel mapping (optional)", metavar="extChanMapping")
+    parser.set_defaults(outfilename="SCurveFitData.root")
+    (options, args) = parser.parse_args()
+    
+    print("Analyzing: '%s'"%filename)
+    filename = options.filename[:-5]
+    os.system("mkdir " + filename)
+    
+    outfilename = options.outfilename
+    GEBtype = options.GEBtype
+   
+    # Set default histogram behavior
+    r.TH1.SetDefaultSumw2(False)
+    r.gROOT.SetBatch(True)
+    r.gStyle.SetOptStat(1111111)
 
-from anaoptions import parser
-
-parser.add_option("-b", "--drawbad", action="store_true", dest="drawbad",
-                  help="Draw fit overlays for Chi2 > 10000", metavar="drawbad")
-parser.add_option("--calFile", type="string", dest="calFile", default=None,
-                  help="File specifying CAL_DAC/VCAL to fC equations per VFAT",
-                  metavar="calFile")
-parser.add_option("-f", "--fit", action="store_true", dest="SaveFile",
-                  help="Save the Fit values to Root file", metavar="SaveFile")
-parser.add_option("--IsTrimmed", action="store_true", dest="IsTrimmed",
-                  help="If the data is from a trimmed scan, plot the value it tried aligning to", metavar="IsTrimmed")
-parser.add_option("--zscore", type="float", dest="zscore", default=3.5,
-                  help="Z-Score for Outlier Identification in MAD Algo", metavar="zscore")
-parser.set_defaults(outfilename="SCurveFitData.root")
-
-(options, args) = parser.parse_args()
-filename = options.filename[:-5]
-os.system("mkdir " + filename)
-
-print filename
-outfilename = options.outfilename
-
-import ROOT as r
-r.TH1.SetDefaultSumw2(False)
-r.gROOT.SetBatch(True)
-r.gStyle.SetOptStat(1111111)
-GEBtype = options.GEBtype
-inF = r.TFile(filename+'.root')
-if options.SaveFile:
+    # Build the channel to strip mapping from the text file
+    envCheck('GEM_PLOTTING_PROJECT')
+    projectHome = os.getenv('GEM_PLOTTING_PROJECT')
+    dict_vfatChanLUT = ndict()
+    if options.extChanMapping is not None:
+        dict_vfatChanLUT = getMapping(options.extChanMapping)
+    elif GEBtype == 'long':
+        dict_vfatChanLUT = getMapping(projectHome+'/mapping/longChannelMap.txt', 'r')
+    if GEBtype == 'short':
+        dict_vfatChanLUT = getMapping(projectHome+'/mapping/shortChannelMap.txt', 'r')
+   
+    # Set the CAL DAC to fC conversion
+    calDAC2Q_Intercept = np.zeros(24)
+    calDAC2Q_Slope = np.zeros(24)
+    if options.calFile is not None:
+        list_bNames = ["vfatN","slope","intercept"]
+        calTree = r.TTree('calTree','Tree holding VFAT Calibration Info')
+        calTree.ReadFile(options.calFile)
+        array_CalData = rp.tree2array(tree=calTree, branches=list_bNames)
+    
+        for dataPt in array_CalData:
+            calDAC2Q_Intercept[dataPt['vfatN']] = dataPt['intercept']
+            calDAC2Q_Slope[dataPt['vfatN']] = dataPt['slope']
+    else:
+        calDAC2Q_Intercept = -0.8 * np.ones(24)
+        calDAC2Q_Slope = 0.05 * np.ones(24)
+    
+    if options.IsTrimmed:
+        trimmed_text = open('scanInfo.txt', 'r')
+        trimVcal = []
+        for vfat in range(0,24):
+            trimVcal.append(0)
+            pass
+        for n, line in enumerate(trimmed_text):
+            if n == 0: continue
+            print line
+            scanInfo = line.rsplit('  ')
+            trimVcal[int(scanInfo[0])] = float(scanInfo[4])
+            pass
+        pass
+    
+    # Create the output File
     outF = r.TFile(filename+'/'+outfilename, 'recreate')
     myT = r.TTree('scurveFitTree','Tree Holding FitData')
-    pass
-
-#Build the channel to strip mapping from the text file
-chanToStripLUT = []
-stripToChanLUT = []
-chanToPanPinLUT = []
-for vfat in range(0,24):
-    chanToStripLUT.append([])
-    stripToChanLUT.append([])
-    chanToPanPinLUT.append([])
-    for channel in range(0,128):
-        chanToStripLUT[vfat].append(0)
-        stripToChanLUT[vfat].append(0)
-        chanToPanPinLUT[vfat].append(0)
-        pass
-    pass
-
-calDAC2Q_Intercept = np.zeros(24)
-calDAC2Q_Slope = np.zeros(24)
-if options.calFile is not None:
-    list_bNames = ["vfatN","slope","intercept"]
-    calTree = r.TTree('calTree','Tree holding VFAT Calibration Info')
-    calTree.ReadFile(options.calFile)
-    array_CalData = rp.tree2array(tree=calTree, branches=list_bNames)
-
-    for dataPt in array_CalData:
-        calDAC2Q_Intercept[dataPt['vfatN']] = dataPt['intercept']
-        calDAC2Q_Slope[dataPt['vfatN']] = dataPt['slope']
-else:
-    calDAC2Q_Intercept = -0.8 * np.ones(24)
-    calDAC2Q_Slope = 0.05 * np.ones(24)
-
-from gempython.utils.wrappers import envCheck
-envCheck('GEM_PLOTTING_PROJECT')
-
-projectHome = os.environ.get('GEM_PLOTTING_PROJECT')
-if GEBtype == 'long':
-    intext = open(projectHome+'/mapping/longChannelMap.txt', 'r')
-    pass
-if GEBtype == 'short':
-    intext = open(projectHome+'/mapping/shortChannelMap.txt', 'r')
-    pass
-
-for i, line in enumerate(intext):
-    if i == 0: continue
-    mapping = line.rsplit('\t')
-    chanToStripLUT[int(mapping[0])][int(mapping[2]) - 1] = int(mapping[1])
-    stripToChanLUT[int(mapping[0])][int(mapping[1])] = int(mapping[2]) - 1
-    chanToPanPinLUT[int(mapping[0])][int(mapping[2]) -1] = int(mapping[3])
-    pass
-
-if options.IsTrimmed:
-    trimmed_text = open('scanInfo.txt', 'r')
-    trimVcal = []
-    for vfat in range(0,24):
-        trimVcal.append(0)
-        pass
-    for n, line in enumerate(trimmed_text):
-        if n == 0: continue
-        print line
-        scanInfo = line.rsplit('  ')
-        trimVcal[int(scanInfo[0])] = float(scanInfo[4])
-        pass
-    pass
-
-if options.SaveFile:
     vfatN = array( 'i', [ 0 ] )
     myT.Branch( 'vfatN', vfatN, 'vfatN/I' )
     vfatID = array( 'i', [-1] )
@@ -150,215 +127,102 @@ if options.SaveFile:
     ztrim = array( 'f', [ 0 ] )
     ztrim[0] = options.ztrim
     myT.Branch( 'ztrim', ztrim, 'ztrim/F')
-    pass
-
-vSummaryPlots = ndict()
-vSummaryPlotsPanPin2 = ndict()
-vSummaryPlotsPruned = ndict()
-vSummaryPlotsPrunedPanPin2 = ndict()
-vScurves = []
-vScurveFits = []
-vthr_list = []
-trim_list = []
-trimrange_list = []
-lines = []
-
-for vfat in range(0,24):
-    vScurves.append([])
-    vScurveFits.append([])
-    vthr_list.append([])
-    trim_list.append([])
-    trimrange_list.append([])
-    if options.IsTrimmed:
-        lines.append(r.TLine(-0.5, trimVcal[vfat], 127.5, trimVcal[vfat]))
-        pass
-    if not (options.channels or options.PanPin):
-        vSummaryPlots[vfat] = r.TH2D('vSummaryPlots%i'%vfat,
-                'VFAT %i;Strip;VCal [fC]'%vfat,
-                128,-0.5,127.5,256,
-                calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
-                calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
-        vSummaryPlots[vfat].GetYaxis().SetTitleOffset(1.5)
-        vSummaryPlotsPruned[vfat] = r.TH2D('vSummaryPlotsPruned%i'%vfat,
-                'VFAT %i;Strip;VCal [fC]'%vfat,
-                128,-0.5,127.5,256,
-                calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
-                calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
-        vSummaryPlotsPruned[vfat].GetYaxis().SetTitleOffset(1.5)
-        pass
-    if options.channels:
-        vSummaryPlots[vfat] = r.TH2D('vSummaryPlots%i'%vfat,
-                'VFAT %i;Channels;VCal [fC]'%vfat,
-                128,-0.5,127.5,256,
-                calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
-                calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
-        vSummaryPlots[vfat].GetYaxis().SetTitleOffset(1.5)
-        vSummaryPlotsPruned[vfat] = r.TH2D('vSummaryPlotsPruned%i'%vfat,
-                'VFAT %i;Channels;VCal [fC]'%vfat,
-                128,-0.5,127.5,256,
-                calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
-                calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
-        vSummaryPlotsPruned[vfat].GetYaxis().SetTitleOffset(1.5)
-        pass
-    if options.PanPin:
-        vSummaryPlots[vfat] = r.TH2D('vSummaryPlots%i'%vfat,
-                'VFAT %i_0-63;63 - Panasonic Pin;VCal [fC]'%vfat,
-                64,-0.5,63.5,256,
-                calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
-                calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
-        vSummaryPlots[vfat].GetYaxis().SetTitleOffset(1.5)
-        vSummaryPlotsPruned[vfat] = r.TH2D('vSummaryPlotsPruned%i'%vfat,
-                'VFAT %i_0-63;63 - Panasonic Pin;VCal [fC]'%vfat,
-                64,-0.5,63.5,256,
-                calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
-                calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
-        vSummaryPlotsPruned[vfat].GetYaxis().SetTitleOffset(1.5)
-        vSummaryPlotsPanPin2[vfat] = r.TH2D('vSummaryPlotsPanPin2_%i'%vfat,
-                'vSummaryPlots%i_64-127;127 - Panasonic Pin;VCal [fC]'%vfat,
-                64,-0.5,63.5,256,
-                calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
-                calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
-        vSummaryPlotsPanPin2[vfat].GetYaxis().SetTitleOffset(1.5)
-        vSummaryPlotsPrunedPanPin2[vfat] = r.TH2D('vSummaryPlotsPrunedPanPin2_%i'%vfat,
-                'vSummaryPlots%i_64-127;127 - Panasonic Pin;VCal [fC]'%vfat,
-                64,-0.5,63.5,256,
-                calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
-                calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
-        vSummaryPlotsPrunedPanPin2[vfat].GetYaxis().SetTitleOffset(1.5)
-        pass
-    for chan in range (0,128):
-        vScurves[vfat].append(r.TH1D('Scurve_%i_%i'%(vfat,chan),'Scurve_%i_%i;VCal [DAC units]'%(vfat,chan),256,-0.5,255.5))
-        vScurveFits[vfat].append(r.TH1F())
-        vthr_list[vfat].append(0)
-        trim_list[vfat].append(0)
-        trimrange_list[vfat].append(0)
-        pass
-    pass
-
-if options.SaveFile:
-    fitter = ScanDataFitter()
-    pass
-
-# Fill
-print("Filling Histograms")
-checkCurrentPulse = ("isCurrentPulse" in inF.scurveTree.GetListOfBranches())
-dict_calSF = dict((calSF, 0.25*calSF+0.25) for calSF in range(0,4))
-dict_vfatID = dict((vfat, 0) for vfat in range(0,24))
-listOfBranches = inF.scurveTree.GetListOfBranches()
-for event in inF.scurveTree:
-    strip = chanToStripLUT[event.vfatN][event.vfatCH]
-    pan_pin = chanToPanPinLUT[event.vfatN][event.vfatCH]
-    charge = calDAC2Q_Slope[event.vfatN]*event.vcal+calDAC2Q_Intercept[event.vfatN]
-    if checkCurrentPulse:
-        if event.isCurrentPulse:
-            #Q = CAL_DUR * CAL_DAC * 10nA * CAL_FS
-            charge = (1./ 40079000) * event.vcal * (10 * 1e-9) * dict_calSF[event.calSF] * 1e15
-    if not (options.channels or options.PanPin):
-        vSummaryPlots[event.vfatN].Fill(strip,charge,event.Nhits)
-        pass
-    if options.channels:
-        vSummaryPlots[event.vfatN].Fill(event.vfatCH,charge,event.Nhits)
-        pass
-    if options.PanPin:
-        if (pan_pin < 64):
-            vSummaryPlots[event.vfatN].Fill(63-pan_pin,charge,event.Nhits)
-            pass
-        else:
-            vSummaryPlotsPanPin2[event.vfatN].Fill(127-pan_pin,charge,event.Nhits)
-            pass
-        pass
     
-    binVal = vScurves[event.vfatN][event.vfatCH].FindBin(event.vcal)
-    vScurves[event.vfatN][event.vfatCH].SetBinContent(binVal, event.Nhits)
-    r.gStyle.SetOptStat(1111111)
-    vthr_list[event.vfatN][event.vfatCH] = event.vthr
-    trim_list[event.vfatN][event.vfatCH] = event.trimDAC
-    trimrange_list[event.vfatN][event.vfatCH] = event.trimRange
+    vSummaryPlots = ndict()
+    vSummaryPlotsPanPin2 = ndict()
+    vSummaryPlotsPruned = ndict()
+    vSummaryPlotsPrunedPanPin2 = ndict()
+    vScurves = []
+    vScurveFits = []
+    vthr_list = []
+    trim_list = []
+    trimrange_list = []
+    lines = []
     
-    if not (dict_vfatID[event.vfatN] > 0):
-        if 'vfatID' in listOfBranches:
-            dict_vfatID[event.vfatN] = event.vfatID
-        else:
-            dict_vfatID[event.vfatN] = 0
-
-    if options.SaveFile:
-        fitter.feed(event)
-        pass
-    pass
-
-if options.SaveFile:
-    print("Fitting Histograms")
-    fitSummary = open(filename+'/fitSummary.txt','w')
-    fitSummary.write('vfatN/I:vfatID/I:vfatCH/I:fitP0/F:fitP1/F:fitP2/F:fitP3/F\n')
-    scanFits = fitter.fit()
     for vfat in range(0,24):
-        for chan in range(0,128):
-            vScurveFits[vfat][chan]=fitter.getFunc(vfat,chan)
-            fitSummary.write(
-                    '%i\t%i\t%i\t%f\t%f\t%f\t%f\n'%(
-                        vfat,
-                        dict_vfatID[vfat],
-                        chan,
-                        vScurveFits[vfat][chan].GetParameter(0),
-                        vScurveFits[vfat][chan].GetParameter(1),
-                        vScurveFits[vfat][chan].GetParameter(2),
-                        vScurveFits[vfat][chan].GetParameter(3)
-                        )
-                    )
-    fitSummary.close()
-    pass
-
-# Determine hot channels
-if options.SaveFile:
-    print("Determining hot channels")
-    masks = []
-    maskReasons = []
-    effectivePedestals = [ np.zeros(128) for vfat in range(24) ]
-    for vfat in range(0, 24):
-        trimValue = np.zeros(128)
-        channelNoise = np.zeros(128)
-        fitFailed = np.zeros(128, dtype=bool)
-        for chan in range(0, 128):
-            # Get fit results
-            threshold[0] = scanFits[0][vfat][chan]
-            noise[0] = scanFits[1][vfat][chan]
-            pedestal[0] = scanFits[2][vfat][chan]
-            
-            # Compute values for cuts
-            channelNoise[chan] = noise[0]
-            effectivePedestals[vfat][chan] = vScurveFits[vfat][chan].Eval(0.0)
-            
-            # Compute the value to apply MAD on for each channel
-            trimValue[chan] = threshold[0] - ztrim[0] * noise[0]
+        vScurves.append([])
+        vScurveFits.append([])
+        vthr_list.append([])
+        trim_list.append([])
+        trimrange_list.append([])
+        if options.IsTrimmed:
+            lines.append(r.TLine(-0.5, trimVcal[vfat], 127.5, trimVcal[vfat]))
             pass
-        fitFailed = np.logical_not(fitter.fitValid[vfat])
-        
-        # Determine outliers
-        hot = isOutlierMADOneSided(trimValue, thresh=options.zscore,
-                                   rejectHighTail=False)
-        
-        # Create reason array
-        reason = np.zeros(128, dtype=int) # Not masked
-        reason[hot] |= MaskReason.HotChannel
-        reason[fitFailed] |= MaskReason.FitFailed
-        reason[fitter.isDead[vfat]] |= MaskReason.DeadChannel
-        reason[channelNoise > 20] |= MaskReason.HighNoise
-        reason[effectivePedestals[vfat] > 50] |= MaskReason.HighEffPed
-        maskReasons.append(reason)
-        masks.append(reason != MaskReason.NotMasked)
-        print 'VFAT %2d: %d dead, %d hot channels, %d failed fits, %d high noise, %d high eff.ped.' % (vfat,
-                np.count_nonzero(fitter.isDead[vfat]),
-                np.count_nonzero(hot),
-                np.count_nonzero(fitFailed),
-                np.count_nonzero(channelNoise > 20),
-                np.count_nonzero(effectivePedestals[vfat] > 50))
-
-# Fill pruned
-if options.SaveFile:
-    print("Pruning Hot Channels from Output Histograms")
+        if not (options.channels or options.PanPin):
+            vSummaryPlots[vfat] = r.TH2D('vSummaryPlots%i'%vfat,
+                    'VFAT %i;Strip;VCal [fC]'%vfat,
+                    128,-0.5,127.5,256,
+                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
+                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
+            vSummaryPlots[vfat].GetYaxis().SetTitleOffset(1.5)
+            vSummaryPlotsPruned[vfat] = r.TH2D('vSummaryPlotsPruned%i'%vfat,
+                    'VFAT %i;Strip;VCal [fC]'%vfat,
+                    128,-0.5,127.5,256,
+                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
+                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
+            vSummaryPlotsPruned[vfat].GetYaxis().SetTitleOffset(1.5)
+            pass
+        if options.channels:
+            vSummaryPlots[vfat] = r.TH2D('vSummaryPlots%i'%vfat,
+                    'VFAT %i;Channels;VCal [fC]'%vfat,
+                    128,-0.5,127.5,256,
+                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
+                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
+            vSummaryPlots[vfat].GetYaxis().SetTitleOffset(1.5)
+            vSummaryPlotsPruned[vfat] = r.TH2D('vSummaryPlotsPruned%i'%vfat,
+                    'VFAT %i;Channels;VCal [fC]'%vfat,
+                    128,-0.5,127.5,256,
+                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
+                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
+            vSummaryPlotsPruned[vfat].GetYaxis().SetTitleOffset(1.5)
+            pass
+        if options.PanPin:
+            vSummaryPlots[vfat] = r.TH2D('vSummaryPlots%i'%vfat,
+                    'VFAT %i_0-63;63 - Panasonic Pin;VCal [fC]'%vfat,
+                    64,-0.5,63.5,256,
+                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
+                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
+            vSummaryPlots[vfat].GetYaxis().SetTitleOffset(1.5)
+            vSummaryPlotsPruned[vfat] = r.TH2D('vSummaryPlotsPruned%i'%vfat,
+                    'VFAT %i_0-63;63 - Panasonic Pin;VCal [fC]'%vfat,
+                    64,-0.5,63.5,256,
+                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
+                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
+            vSummaryPlotsPruned[vfat].GetYaxis().SetTitleOffset(1.5)
+            vSummaryPlotsPanPin2[vfat] = r.TH2D('vSummaryPlotsPanPin2_%i'%vfat,
+                    'vSummaryPlots%i_64-127;127 - Panasonic Pin;VCal [fC]'%vfat,
+                    64,-0.5,63.5,256,
+                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
+                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
+            vSummaryPlotsPanPin2[vfat].GetYaxis().SetTitleOffset(1.5)
+            vSummaryPlotsPrunedPanPin2[vfat] = r.TH2D('vSummaryPlotsPrunedPanPin2_%i'%vfat,
+                    'vSummaryPlots%i_64-127;127 - Panasonic Pin;VCal [fC]'%vfat,
+                    64,-0.5,63.5,256,
+                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
+                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
+            vSummaryPlotsPrunedPanPin2[vfat].GetYaxis().SetTitleOffset(1.5)
+            pass
+        for chan in range (0,128):
+            vScurves[vfat].append(r.TH1D('Scurve_%i_%i'%(vfat,chan),'Scurve_%i_%i;VCal [DAC units]'%(vfat,chan),256,-0.5,255.5))
+            vScurveFits[vfat].append(r.TH1F())
+            vthr_list[vfat].append(0)
+            trim_list[vfat].append(0)
+            trimrange_list[vfat].append(0)
+            pass
+        pass
+    
+    if options.SaveFile:
+        fitter = ScanDataFitter()
+        pass
+    
+    # Fill
+    print("Filling Histograms")
+    inF = r.TFile(filename+'.root')
+    checkCurrentPulse = ("isCurrentPulse" in inF.scurveTree.GetListOfBranches())
+    dict_calSF = dict((calSF, 0.25*calSF+0.25) for calSF in range(0,4))
+    dict_vfatID = dict((vfat, 0) for vfat in range(0,24))
+    listOfBranches = inF.scurveTree.GetListOfBranches()
     for event in inF.scurveTree:
-        if masks[event.vfatN][event.vfatCH]:
-            continue
         strip = chanToStripLUT[event.vfatN][event.vfatCH]
         pan_pin = chanToPanPinLUT[event.vfatN][event.vfatCH]
         charge = calDAC2Q_Slope[event.vfatN]*event.vcal+calDAC2Q_Intercept[event.vfatN]
@@ -367,159 +231,272 @@ if options.SaveFile:
                 #Q = CAL_DUR * CAL_DAC * 10nA * CAL_FS
                 charge = (1./ 40079000) * event.vcal * (10 * 1e-9) * dict_calSF[event.calSF] * 1e15
         if not (options.channels or options.PanPin):
-            vSummaryPlotsPruned[event.vfatN].Fill(strip,charge,event.Nhits)
+            vSummaryPlots[event.vfatN].Fill(strip,charge,event.Nhits)
+            pass
         if options.channels:
-            vSummaryPlotsPruned[event.vfatN].Fill(event.vfatCH,charge,event.Nhits)
+            vSummaryPlots[event.vfatN].Fill(event.vfatCH,charge,event.Nhits)
+            pass
         if options.PanPin:
             if (pan_pin < 64):
-                vSummaryPlotsPruned[event.vfatN].Fill(63-pan_pin,charge,event.Nhits)
-            else:
-                vSummaryPlotsPrunedPanPin2[event.vfatN].Fill(127-pan_pin,charge,event.Nhits)
-
-# Store values in ROOT file
-if options.SaveFile:
-    print("Storing Output Data")
-    fitSums = {}
-    for vfat in range (0,24):
-        fitThr = []        
-        fitENC = []
-        stripList = []
-        panList = []
-        chanList = []
-        for chan in range (0, 128):
-            # Get strip and pan pin
-            strip = chanToStripLUT[vfat][chan]
-            pan_pin = chanToPanPinLUT[vfat][chan]
-            
-            # Store strip, chan and pan pin
-            stripList.append(float(strip))
-            panList.append(float(pan_pin))
-            chanList.append(float(chan))
-            
-            # Filling the Branches
-            param0 = scanFits[0][vfat][chan]
-            param1 = scanFits[1][vfat][chan]
-            param2 = scanFits[2][vfat][chan]
-            ped_eff[0] = effectivePedestals[vfat][chan]
-            vfatN[0] = vfat
-            vfatID[0] = dict_vfatID[vfat]
-            vfatCH[0] = chan
-            ROBstr[0] = strip
-            panPin[0] = pan_pin
-            trimRange[0] = trimrange_list[vfat][chan] 
-            vthr[0] = vthr_list[vfat][chan]
-            trimDAC[0] = trim_list[vfat][chan]
-            threshold[0] = calDAC2Q_Slope[vfat]*param0+calDAC2Q_Intercept[vfat]
-            fitThr.append(calDAC2Q_Slope[vfat]*param0+calDAC2Q_Intercept[vfat])
-            noise[0] = calDAC2Q_Slope[vfat]*param1
-            fitENC.append(calDAC2Q_Slope[vfat]*param1*ztrim[0])
-            pedestal[0] = param2
-            mask[0] = masks[vfat][chan]
-            maskReason[0] = maskReasons[vfat][chan]
-            chi2[0] = scanFits[3][vfat][chan]
-            ndf[0] = int(scanFits[5][vfat][chan])
-            holder_curve = vScurves[vfat][chan]
-            holder_curve.Copy(scurve_h)
-            scurve_fit = fitter.getFunc(vfat,chan).Clone('scurveFit_vfat%i_chan%i'%(vfat,chan))
-            Nhigh[0] = int(scanFits[4][vfat][chan])
-            
-            # Filling the arrays for plotting later
-            if options.drawbad:
-                if (chi2[0] > 1000.0 or chi2[0] < 1.0):
-                    canvas = r.TCanvas('canvas', 'canvas', 500, 500)
-                    r.gStyle.SetOptStat(1111111)
-                    scurve_h.Draw()
-                    scurve_fit.Draw('SAME')
-                    canvas.Update()
-                    canvas.SaveAs('Fit_Overlay_vfat%i_vfatCH%i.png'%(VFAT, chan))
-                    pass
+                vSummaryPlots[event.vfatN].Fill(63-pan_pin,charge,event.Nhits)
                 pass
-            myT.Fill()
-            pass
-        if not (options.channels or options.PanPin):
-            fitSums[vfat] = r.TGraphErrors(len(fitThr),np.array(stripList),np.array(fitThr),np.zeros(len(fitThr)),np.array(fitENC))
-            fitSums[vfat].SetTitle("VFAT %i Fit Summary;Strip;Threshold [fC]"%vfat)
-            pass
-        elif options.channels:
-            fitSums[vfat] = r.TGraphErrors(len(fitThr),np.array(chanList),np.array(fitThr),np.zeros(len(fitThr)),np.array(fitENC))
-            fitSums[vfat].SetTitle("VFAT %i Fit Summary;Channel;Threshold [fC]"%vfat)
-            pass
-        elif options.PanPin:
-            fitSums[vfat] = r.TGraphErrors(len(fitThr),np.array(panList),np.array(fitThr),np.zeros(len(fitThr)),np.array(fitENC))
-            fitSums[vfat].SetTitle("VFAT %i Fit Summary;Panasonic Pin;Threshold [fC]"%vfat)
+            else:
+                vSummaryPlotsPanPin2[event.vfatN].Fill(127-pan_pin,charge,event.Nhits)
+                pass
             pass
         
-        fitSums[vfat].SetName("gFitSummary_VFAT%i"%(vfat))
-        fitSums[vfat].SetMarkerStyle(2)
+        binVal = vScurves[event.vfatN][event.vfatCH].FindBin(event.vcal)
+        vScurves[event.vfatN][event.vfatCH].SetBinContent(binVal, event.Nhits)
+        r.gStyle.SetOptStat(1111111)
+        vthr_list[event.vfatN][event.vfatCH] = event.vthr
+        trim_list[event.vfatN][event.vfatCH] = event.trimDAC
+        trimrange_list[event.vfatN][event.vfatCH] = event.trimRange
+        
+        if not (dict_vfatID[event.vfatN] > 0):
+            if 'vfatID' in listOfBranches:
+                dict_vfatID[event.vfatN] = event.vfatID
+            else:
+                dict_vfatID[event.vfatN] = 0
+    
+        if options.SaveFile:
+            fitter.feed(event)
+            pass
         pass
-    pass
-
-def saveSummary(vSummaryPlots, vSummaryPlotsPanPin2, name='Summary'):
-    legend = r.TLegend(0.75,0.7,0.88,0.88)
-    r.gStyle.SetOptStat(0)
-    if not options.PanPin:
-        canv = make3x8Canvas('canv', vSummaryPlots, 'colz')
+    
+    if options.SaveFile:
+        print("Fitting Histograms")
+        fitSummary = open(filename+'/fitSummary.txt','w')
+        fitSummary.write('vfatN/I:vfatID/I:vfatCH/I:fitP0/F:fitP1/F:fitP2/F:fitP3/F\n')
+        scanFits = fitter.fit()
         for vfat in range(0,24):
-            canv.cd(vfat+1)
-            if options.IsTrimmed:
-                legend.Clear()
-                legend.AddEntry(line, 'trimVCal is %f'%(trimVcal[vfat]))
-                legend.Draw('SAME')
-                print trimVcal[vfat]
-                lines[vfat].SetLineColor(1)
-                lines[vfat].SetLineWidth(3)
-                lines[vfat].Draw('SAME')
+            for chan in range(0,128):
+                vScurveFits[vfat][chan]=fitter.getFunc(vfat,chan)
+                fitSummary.write(
+                        '%i\t%i\t%i\t%f\t%f\t%f\t%f\n'%(
+                            vfat,
+                            dict_vfatID[vfat],
+                            chan,
+                            vScurveFits[vfat][chan].GetParameter(0),
+                            vScurveFits[vfat][chan].GetParameter(1),
+                            vScurveFits[vfat][chan].GetParameter(2),
+                            vScurveFits[vfat][chan].GetParameter(3)
+                            )
+                        )
+        fitSummary.close()
+        pass
+    
+    # Determine hot channels
+    if options.SaveFile:
+        print("Determining hot channels")
+        masks = []
+        maskReasons = []
+        effectivePedestals = [ np.zeros(128) for vfat in range(24) ]
+        for vfat in range(0, 24):
+            trimValue = np.zeros(128)
+            channelNoise = np.zeros(128)
+            fitFailed = np.zeros(128, dtype=bool)
+            for chan in range(0, 128):
+                # Get fit results
+                threshold[0] = scanFits[0][vfat][chan]
+                noise[0] = scanFits[1][vfat][chan]
+                pedestal[0] = scanFits[2][vfat][chan]
+                
+                # Compute values for cuts
+                channelNoise[chan] = noise[0]
+                effectivePedestals[vfat][chan] = vScurveFits[vfat][chan].Eval(0.0)
+                
+                # Compute the value to apply MAD on for each channel
+                trimValue[chan] = threshold[0] - ztrim[0] * noise[0]
                 pass
-            canv.Update()
+            fitFailed = np.logical_not(fitter.fitValid[vfat])
+            
+            # Determine outliers
+            hot = isOutlierMADOneSided(trimValue, thresh=options.zscore,
+                                       rejectHighTail=False)
+            
+            # Create reason array
+            reason = np.zeros(128, dtype=int) # Not masked
+            reason[hot] |= MaskReason.HotChannel
+            reason[fitFailed] |= MaskReason.FitFailed
+            reason[fitter.isDead[vfat]] |= MaskReason.DeadChannel
+            reason[channelNoise > 20] |= MaskReason.HighNoise
+            reason[effectivePedestals[vfat] > 50] |= MaskReason.HighEffPed
+            maskReasons.append(reason)
+            masks.append(reason != MaskReason.NotMasked)
+            print 'VFAT %2d: %d dead, %d hot channels, %d failed fits, %d high noise, %d high eff.ped.' % (vfat,
+                    np.count_nonzero(fitter.isDead[vfat]),
+                    np.count_nonzero(hot),
+                    np.count_nonzero(fitFailed),
+                    np.count_nonzero(channelNoise > 20),
+                    np.count_nonzero(effectivePedestals[vfat] > 50))
+    
+    # Fill pruned
+    if options.SaveFile:
+        print("Pruning Hot Channels from Output Histograms")
+        for event in inF.scurveTree:
+            if masks[event.vfatN][event.vfatCH]:
+                continue
+            strip = chanToStripLUT[event.vfatN][event.vfatCH]
+            pan_pin = chanToPanPinLUT[event.vfatN][event.vfatCH]
+            charge = calDAC2Q_Slope[event.vfatN]*event.vcal+calDAC2Q_Intercept[event.vfatN]
+            if checkCurrentPulse:
+                if event.isCurrentPulse:
+                    #Q = CAL_DUR * CAL_DAC * 10nA * CAL_FS
+                    charge = (1./ 40079000) * event.vcal * (10 * 1e-9) * dict_calSF[event.calSF] * 1e15
+            if not (options.channels or options.PanPin):
+                vSummaryPlotsPruned[event.vfatN].Fill(strip,charge,event.Nhits)
+            if options.channels:
+                vSummaryPlotsPruned[event.vfatN].Fill(event.vfatCH,charge,event.Nhits)
+            if options.PanPin:
+                if (pan_pin < 64):
+                    vSummaryPlotsPruned[event.vfatN].Fill(63-pan_pin,charge,event.Nhits)
+                else:
+                    vSummaryPlotsPrunedPanPin2[event.vfatN].Fill(127-pan_pin,charge,event.Nhits)
+    
+    # Store values in ROOT file
+    if options.SaveFile:
+        print("Storing Output Data")
+        fitSums = {}
+        for vfat in range (0,24):
+            fitThr = []        
+            fitENC = []
+            stripList = []
+            panList = []
+            chanList = []
+            for chan in range (0, 128):
+                # Get strip and pan pin
+                strip = chanToStripLUT[vfat][chan]
+                pan_pin = chanToPanPinLUT[vfat][chan]
+                
+                # Store strip, chan and pan pin
+                stripList.append(float(strip))
+                panList.append(float(pan_pin))
+                chanList.append(float(chan))
+                
+                # Filling the Branches
+                param0 = scanFits[0][vfat][chan]
+                param1 = scanFits[1][vfat][chan]
+                param2 = scanFits[2][vfat][chan]
+                ped_eff[0] = effectivePedestals[vfat][chan]
+                vfatN[0] = vfat
+                vfatID[0] = dict_vfatID[vfat]
+                vfatCH[0] = chan
+                ROBstr[0] = strip
+                panPin[0] = pan_pin
+                trimRange[0] = trimrange_list[vfat][chan] 
+                vthr[0] = vthr_list[vfat][chan]
+                trimDAC[0] = trim_list[vfat][chan]
+                threshold[0] = calDAC2Q_Slope[vfat]*param0+calDAC2Q_Intercept[vfat]
+                fitThr.append(calDAC2Q_Slope[vfat]*param0+calDAC2Q_Intercept[vfat])
+                noise[0] = calDAC2Q_Slope[vfat]*param1
+                fitENC.append(calDAC2Q_Slope[vfat]*param1*ztrim[0])
+                pedestal[0] = param2
+                mask[0] = masks[vfat][chan]
+                maskReason[0] = maskReasons[vfat][chan]
+                chi2[0] = scanFits[3][vfat][chan]
+                ndf[0] = int(scanFits[5][vfat][chan])
+                holder_curve = vScurves[vfat][chan]
+                holder_curve.Copy(scurve_h)
+                scurve_fit = fitter.getFunc(vfat,chan).Clone('scurveFit_vfat%i_chan%i'%(vfat,chan))
+                Nhigh[0] = int(scanFits[4][vfat][chan])
+                
+                # Filling the arrays for plotting later
+                if options.drawbad:
+                    if (chi2[0] > 1000.0 or chi2[0] < 1.0):
+                        canvas = r.TCanvas('canvas', 'canvas', 500, 500)
+                        r.gStyle.SetOptStat(1111111)
+                        scurve_h.Draw()
+                        scurve_fit.Draw('SAME')
+                        canvas.Update()
+                        canvas.SaveAs('Fit_Overlay_vfat%i_vfatCH%i.png'%(VFAT, chan))
+                        pass
+                    pass
+                myT.Fill()
+                pass
+            if not (options.channels or options.PanPin):
+                fitSums[vfat] = r.TGraphErrors(len(fitThr),np.array(stripList),np.array(fitThr),np.zeros(len(fitThr)),np.array(fitENC))
+                fitSums[vfat].SetTitle("VFAT %i Fit Summary;Strip;Threshold [fC]"%vfat)
+                pass
+            elif options.channels:
+                fitSums[vfat] = r.TGraphErrors(len(fitThr),np.array(chanList),np.array(fitThr),np.zeros(len(fitThr)),np.array(fitENC))
+                fitSums[vfat].SetTitle("VFAT %i Fit Summary;Channel;Threshold [fC]"%vfat)
+                pass
+            elif options.PanPin:
+                fitSums[vfat] = r.TGraphErrors(len(fitThr),np.array(panList),np.array(fitThr),np.zeros(len(fitThr)),np.array(fitENC))
+                fitSums[vfat].SetTitle("VFAT %i Fit Summary;Panasonic Pin;Threshold [fC]"%vfat)
+                pass
+            
+            fitSums[vfat].SetName("gFitSummary_VFAT%i"%(vfat))
+            fitSums[vfat].SetMarkerStyle(2)
             pass
         pass
-    else:
-        canv = r.TCanvas('canv','canv',500*8,500*3)
-        canv.Divide(8,6)
+    
+    def saveSummary(vSummaryPlots, vSummaryPlotsPanPin2, name='Summary'):
+        legend = r.TLegend(0.75,0.7,0.88,0.88)
         r.gStyle.SetOptStat(0)
-        for ieta in range(0,8):
-            for iphi in range (0,3):
-                r.gStyle.SetOptStat(0)
-                canv.cd((ieta+1 + iphi*16)%48 + 16)
-                vSummaryPlots[ieta+(8*iphi)].Draw('colz')
-                canv.Update()
-                canv.cd((ieta+9 + iphi*16)%48 + 16)
-                vSummaryPlotsPanPin2[ieta+(8*iphi)].Draw('colz')
+        if not options.PanPin:
+            canv = make3x8Canvas('canv', vSummaryPlots, 'colz')
+            for vfat in range(0,24):
+                canv.cd(vfat+1)
+                if options.IsTrimmed:
+                    legend.Clear()
+                    legend.AddEntry(line, 'trimVCal is %f'%(trimVcal[vfat]))
+                    legend.Draw('SAME')
+                    print trimVcal[vfat]
+                    lines[vfat].SetLineColor(1)
+                    lines[vfat].SetLineWidth(3)
+                    lines[vfat].Draw('SAME')
+                    pass
                 canv.Update()
                 pass
             pass
-        pass
-
-    canv.SaveAs(filename+'/%s.png' % name)
-
-saveSummary(vSummaryPlots, vSummaryPlotsPanPin2)
-if options.SaveFile:
-    saveSummary(vSummaryPlotsPruned, vSummaryPlotsPrunedPanPin2, name='PrunedSummary')
-
-if options.SaveFile:
-    r.gStyle.SetOptStat(0)
-    canv = make3x8Canvas('canv', fitSums, 'ap')
-    canv.SaveAs(filename+'/fitSummary.png')
-    pass
-
-if options.SaveFile:
-    confF = open(filename+'/chConfig.txt','w')
-    confF.write('vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:mask/I\n')
-    for vfat in range (0,24):
-        for chan in range (0, 128):
-            confF.write('%i\t%i\t%i\t%i\t%i\n'%(
-                vfat,
-                dict_vfatID[vfat],
-                chan,
-                trim_list[vfat][chan],
-                masks[vfat][chan]))
+        else:
+            canv = r.TCanvas('canv','canv',500*8,500*3)
+            canv.Divide(8,6)
+            r.gStyle.SetOptStat(0)
+            for ieta in range(0,8):
+                for iphi in range (0,3):
+                    r.gStyle.SetOptStat(0)
+                    canv.cd((ieta+1 + iphi*16)%48 + 16)
+                    vSummaryPlots[ieta+(8*iphi)].Draw('colz')
+                    canv.Update()
+                    canv.cd((ieta+9 + iphi*16)%48 + 16)
+                    vSummaryPlotsPanPin2[ieta+(8*iphi)].Draw('colz')
+                    canv.Update()
+                    pass
+                pass
             pass
+    
+        canv.SaveAs(filename+'/%s.png' % name)
+    
+    saveSummary(vSummaryPlots, vSummaryPlotsPanPin2)
+    if options.SaveFile:
+        saveSummary(vSummaryPlotsPruned, vSummaryPlotsPrunedPanPin2, name='PrunedSummary')
+    
+    if options.SaveFile:
+        r.gStyle.SetOptStat(0)
+        canv = make3x8Canvas('canv', fitSums, 'ap')
+        canv.SaveAs(filename+'/fitSummary.png')
         pass
-    confF.close()
-    outF.cd()
-    for vfat in fitSums.keys():
-        fitSums[vfat].Write()
+    
+    if options.SaveFile:
+        confF = open(filename+'/chConfig.txt','w')
+        confF.write('vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:mask/I\n')
+        for vfat in range (0,24):
+            for chan in range (0, 128):
+                confF.write('%i\t%i\t%i\t%i\t%i\n'%(
+                    vfat,
+                    dict_vfatID[vfat],
+                    chan,
+                    trim_list[vfat][chan],
+                    masks[vfat][chan]))
+                pass
+            pass
+        confF.close()
+        outF.cd()
+        for vfat in fitSums.keys():
+            fitSums[vfat].Write()
+            pass
+        myT.Write()
+        outF.Close()
         pass
-    myT.Write()
-    outF.Close()
-    pass

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -553,11 +553,11 @@ if __name__ == '__main__':
         detThresh_Mean = np.mean(allThresh[allThresh != 0]) #Don't consider intial values
         detThresh_Std = np.std(allThresh[allThresh != 0]) #Don't consider intial values
         hDetThresh_All = r.TH1F("hScurveMeanDist_All","All VFATs;S-Curve Mean #left(fC#right);N",
-                            40, detThresh_Mean - 5. * detThresh_Std, detThresh_Mean + 5. * detThresh_Std )
+                            100, detThresh_Mean - 5. * detThresh_Std, detThresh_Mean + 5. * detThresh_Std )
         for thresh in allThresh[allThresh != 0]:
             hDetThresh_All.Fill(thresh)
         hDetThresh_All.GetXaxis().SetTitle("scurve mean pos #left(fC#right)")
-        hDetThresh_All.GetYaxis().SetTitle("Entries / %f fC"%(detThresh_Std/4.))
+        hDetThresh_All.GetYaxis().SetTitle("Entries / %f fC"%(detThresh_Std/10.))
         gDetThresh_All = r.TGraphErrors(hDetThresh_All)
         gDetThresh_All.SetName("gScurveMeanDist_All")
 
@@ -565,11 +565,11 @@ if __name__ == '__main__':
         detENC_Mean = np.mean(allENC[allENC != 0]) #Don't consider intial values
         detENC_Std = np.std(allENC[allENC != 0]) #Don't consider intial values
         hDetENC_All = r.TH1F("hScurveSigmaDist_All","All VFATs;S-Curve Mean #left(fC#right);N",
-                            40, detENC_Mean - 5. * detENC_Std, detENC_Mean + 5. * detENC_Std )
+                            100, detENC_Mean - 5. * detENC_Std, detENC_Mean + 5. * detENC_Std )
         for thresh in allENC[allENC != 0]:
             hDetENC_All.Fill(thresh)
         hDetENC_All.GetXaxis().SetTitle("scurve width #left(fC#right)")
-        hDetENC_All.GetYaxis().SetTitle("Entries / %f fC"%(detENC_Std/4.))
+        hDetENC_All.GetYaxis().SetTitle("Entries / %f fC"%(detENC_Std/10.))
         gDetENC_All = r.TGraphErrors(hDetENC_All)
         gDetENC_All.SetName("gScurveSigmaDist_All")
         pass

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -194,8 +194,8 @@ if __name__ == '__main__':
     # Create output plot containers
     vSummaryPlots = ndict()
     vSummaryPlotsPanPin2 = ndict()
-    vSummaryPlotsNoHotChan = ndict()
-    vSummaryPlotsNoHotChanPanPin2 = ndict()
+    vSummaryPlotsNoMaskedChan = ndict()
+    vSummaryPlotsNoMaskedChanPanPin2 = ndict()
     vthr_list = getEmptyPerVFATList() 
     trim_list = getEmptyPerVFATList() 
     trimrange_list = getEmptyPerVFATList()
@@ -213,15 +213,15 @@ if __name__ == '__main__':
                 calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
                 calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
         vSummaryPlots[vfat].GetYaxis().SetTitleOffset(1.5)
-        vSummaryPlotsNoHotChan[vfat] = r.TH2D('vSummaryPlotsNoHotChan%i'%vfat,
+        vSummaryPlotsNoMaskedChan[vfat] = r.TH2D('vSummaryPlotsNoMaskedChan%i'%vfat,
                 'VFAT %i;Channels;VCal [fC]'%vfat,
                 128,-0.5,127.5,256,
                 calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
                 calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
-        vSummaryPlotsNoHotChan[vfat].GetYaxis().SetTitleOffset(1.5)
+        vSummaryPlotsNoMaskedChan[vfat].GetYaxis().SetTitleOffset(1.5)
         if not (options.channels or options.PanPin):
             vSummaryPlots[vfat].SetXTitle('Strip')
-            vSummaryPlotsNoHotChan[vfat].SetXTitle('Strip')
+            vSummaryPlotsNoMaskedChan[vfat].SetXTitle('Strip')
             pass
         if options.PanPin:
             vSummaryPlots[vfat] = r.TH2D('vSummaryPlots%i'%vfat,
@@ -230,24 +230,24 @@ if __name__ == '__main__':
                     calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
                     calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
             vSummaryPlots[vfat].GetYaxis().SetTitleOffset(1.5)
-            vSummaryPlotsNoHotChan[vfat] = r.TH2D('vSummaryPlotsNoHotChan%i'%vfat,
+            vSummaryPlotsNoMaskedChan[vfat] = r.TH2D('vSummaryPlotsNoMaskedChan%i'%vfat,
                     'VFAT %i_0-63;63 - Panasonic Pin;VCal [fC]'%vfat,
                     64,-0.5,63.5,256,
                     calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
                     calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
-            vSummaryPlotsNoHotChan[vfat].GetYaxis().SetTitleOffset(1.5)
+            vSummaryPlotsNoMaskedChan[vfat].GetYaxis().SetTitleOffset(1.5)
             vSummaryPlotsPanPin2[vfat] = r.TH2D('vSummaryPlotsPanPin2_%i'%vfat,
                     'vSummaryPlots%i_64-127;127 - Panasonic Pin;VCal [fC]'%vfat,
                     64,-0.5,63.5,256,
                     calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
                     calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
             vSummaryPlotsPanPin2[vfat].GetYaxis().SetTitleOffset(1.5)
-            vSummaryPlotsNoHotChanPanPin2[vfat] = r.TH2D('vSummaryPlotsNoHotChanPanPin2_%i'%vfat,
+            vSummaryPlotsNoMaskedChanPanPin2[vfat] = r.TH2D('vSummaryPlotsNoMaskedChanPanPin2_%i'%vfat,
                     'vSummaryPlots%i_64-127;127 - Panasonic Pin;VCal [fC]'%vfat,
                     64,-0.5,63.5,256,
                     calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
                     calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
-            vSummaryPlotsNoHotChanPanPin2[vfat].GetYaxis().SetTitleOffset(1.5)
+            vSummaryPlotsNoMaskedChanPanPin2[vfat].GetYaxis().SetTitleOffset(1.5)
             pass
         for chan in range (0,128):
             vthr_list[vfat].append(0)
@@ -387,9 +387,9 @@ if __name__ == '__main__':
         print("Removing Hot Channels from Output Histograms")
         fill2DScurveSummaryPlots(
                 scurveTree=inF.scurveTree, 
-                vfatHistos=vSummaryPlotsNoHotChan, 
+                vfatHistos=vSummaryPlotsNoMaskedChan, 
                 vfatChanLUT=dict_vfatChanLUT, 
-                vfatHistosPanPin2=vSummaryPlotsNoHotChanPanPin2, 
+                vfatHistosPanPin2=vSummaryPlotsNoMaskedChanPanPin2, 
                 lutType=stripChanOrPinType, 
                 chanMasks=masks, 
                 calDAC2Q_m=calDAC2Q_Slope, 
@@ -566,9 +566,9 @@ if __name__ == '__main__':
 
     if options.performFit:
         if options.PanPin:
-            saveSummary(vSummaryPlotsNoHotChan, vSummaryPlotsNoHotChanPanPin2, '%s/PrunedSummary.png'%filename, trimVcal)
+            saveSummary(vSummaryPlotsNoMaskedChan, vSummaryPlotsNoMaskedChanPanPin2, '%s/PrunedSummary.png'%filename, trimVcal)
         else:
-            saveSummary(vSummaryPlotsNoHotChan, None, '%s/PrunedSummary.png'%filename, trimVcal)
+            saveSummary(vSummaryPlotsNoMaskedChan, None, '%s/PrunedSummary.png'%filename, trimVcal)
         saveSummary(fitSummaryPlots, None, '%s/fitSummary.png'%filename, None, drawOpt="APE1")
         saveSummary(threshSummaryPlots, None, '%s/ScurveMeanSummary.png'%filename, None, drawOpt="AP")
         saveSummary(encSummaryPlots, None, '%s/ScurveWidthSummary.png'%filename, None, drawOpt="AP")
@@ -590,7 +590,7 @@ if __name__ == '__main__':
 
     # Make 1D Plot for each VFAT showing all scurves
     # Don't use the ones stored in fitter since this may not exist (e.g. options.performFit = false)
-    canvOfScurveHistosNoHotChan = {}
+    canvOfScurveHistosNoMaskedChan = {}
     if options.PanPin:
         canvOfScurveHistos = plotAllSCurvesOnCanvas(vSummaryPlots,vSummaryPlotsPanPin2,"scurves")
     else:
@@ -598,9 +598,9 @@ if __name__ == '__main__':
 
     if options.performFit:
         if options.PanPin:
-            canvOfScurveHistosNoHotChan = plotAllSCurvesOnCanvas(vSummaryPlotsNoHotChan,vSummaryPlotsNoHotChanPanPin2,"scurvesNoHotChan")
+            canvOfScurveHistosNoMaskedChan = plotAllSCurvesOnCanvas(vSummaryPlotsNoMaskedChan,vSummaryPlotsNoMaskedChanPanPin2,"scurvesNoMaskedChan")
         else:
-            canvOfScurveHistosNoHotChan = plotAllSCurvesOnCanvas(vSummaryPlotsNoHotChan,None,"scurvesNoHotChan")
+            canvOfScurveHistosNoMaskedChan = plotAllSCurvesOnCanvas(vSummaryPlotsNoMaskedChan,None,"scurvesNoMaskedChan")
         
         canvOfScurveFits = {}
         for vfat in range(0,24):
@@ -628,13 +628,13 @@ if __name__ == '__main__':
             vSummaryPlotsPanPin2[vfat].Write()
         canvOfScurveHistos[vfat].Write()
         if options.performFit:
-            vSummaryPlotsNoHotChan[vfat].Write()
+            vSummaryPlotsNoMaskedChan[vfat].Write()
             if options.PanPin:
-                vSummaryPlotsNoHotChanPanPin2[vfat].Write()
+                vSummaryPlotsNoMaskedChanPanPin2[vfat].Write()
             fitSummaryPlots[vfat].Write()
             threshSummaryPlots[vfat].Write()
             encSummaryPlots[vfat].Write()
-            canvOfScurveHistosNoHotChan[vfat].Write()
+            canvOfScurveHistosNoMaskedChan[vfat].Write()
             canvOfScurveFits[vfat].Write()
             pass
     

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -7,7 +7,7 @@ if __name__ = '__main__':
     import ROOT as r
     
     from array import array
-    from anautilities import getMapping
+    from anautilities import getEmptyPerVFATList, getMapping
     from anaInfo import maskReason
     from fitting.fitScanData import ScanDataFitter
     from gempython.utils.nesteddict import nesteddict as ndict
@@ -131,51 +131,36 @@ if __name__ = '__main__':
     # Create output plot containers
     vSummaryPlots = ndict()
     vSummaryPlotsPanPin2 = ndict()
-    vSummaryPlotsPruned = ndict()
-    vSummaryPlotsPrunedPanPin2 = ndict()
-    vScurves = [ [] for x in range(0,24)]
-    vScurveFits = []
-    vthr_list = []
-    trim_list = []
-    trimrange_list = []
+    vSummaryPlotsNoHotChan = ndict()
+    vSummaryPlotsNoHotChanPanPin2 = ndict()
+    vScurves = getEmptyPerVFATList()
+    vScurveFits = getEmptyPerVFATList()
+    vthr_list = getEmptyPerVFATList() 
+    trim_list = getEmptyPerVFATList() 
+    trimrange_list = getEmptyPerVFATList()
     lines = []
     
+    # Initialize distributions
     for vfat in range(0,24):
-        vScurves.append([])
-        vScurveFits.append([])
-        vthr_list.append([])
-        trim_list.append([])
-        trimrange_list.append([])
         if options.IsTrimmed:
             lines.append(r.TLine(-0.5, trimVcal[vfat], 127.5, trimVcal[vfat]))
             pass
+        # vfat summary plots
+        vSummaryPlots[vfat] = r.TH2D('vSummaryPlots%i'%vfat,
+                'VFAT %i;Channels;VCal [fC]'%vfat,
+                128,-0.5,127.5,256,
+                calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
+                calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
+        vSummaryPlots[vfat].GetYaxis().SetTitleOffset(1.5)
+        vSummaryPlotsNoHotChan[vfat] = r.TH2D('vSummaryPlotsNoHotChan%i'%vfat,
+                'VFAT %i;Channels;VCal [fC]'%vfat,
+                128,-0.5,127.5,256,
+                calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
+                calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
+        vSummaryPlotsNoHotChan[vfat].GetYaxis().SetTitleOffset(1.5)
         if not (options.channels or options.PanPin):
-            vSummaryPlots[vfat] = r.TH2D('vSummaryPlots%i'%vfat,
-                    'VFAT %i;Strip;VCal [fC]'%vfat,
-                    128,-0.5,127.5,256,
-                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
-                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
-            vSummaryPlots[vfat].GetYaxis().SetTitleOffset(1.5)
-            vSummaryPlotsPruned[vfat] = r.TH2D('vSummaryPlotsPruned%i'%vfat,
-                    'VFAT %i;Strip;VCal [fC]'%vfat,
-                    128,-0.5,127.5,256,
-                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
-                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
-            vSummaryPlotsPruned[vfat].GetYaxis().SetTitleOffset(1.5)
-            pass
-        if options.channels:
-            vSummaryPlots[vfat] = r.TH2D('vSummaryPlots%i'%vfat,
-                    'VFAT %i;Channels;VCal [fC]'%vfat,
-                    128,-0.5,127.5,256,
-                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
-                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
-            vSummaryPlots[vfat].GetYaxis().SetTitleOffset(1.5)
-            vSummaryPlotsPruned[vfat] = r.TH2D('vSummaryPlotsPruned%i'%vfat,
-                    'VFAT %i;Channels;VCal [fC]'%vfat,
-                    128,-0.5,127.5,256,
-                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
-                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
-            vSummaryPlotsPruned[vfat].GetYaxis().SetTitleOffset(1.5)
+            vSummaryPlots[vfat].SetXTitle('Strip')
+            vSummaryPlotsNoHotChan[vfat].SetXTitle('Strip')
             pass
         if options.PanPin:
             vSummaryPlots[vfat] = r.TH2D('vSummaryPlots%i'%vfat,
@@ -184,24 +169,24 @@ if __name__ = '__main__':
                     calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
                     calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
             vSummaryPlots[vfat].GetYaxis().SetTitleOffset(1.5)
-            vSummaryPlotsPruned[vfat] = r.TH2D('vSummaryPlotsPruned%i'%vfat,
+            vSummaryPlotsNoHotChan[vfat] = r.TH2D('vSummaryPlotsNoHotChan%i'%vfat,
                     'VFAT %i_0-63;63 - Panasonic Pin;VCal [fC]'%vfat,
                     64,-0.5,63.5,256,
                     calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
                     calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
-            vSummaryPlotsPruned[vfat].GetYaxis().SetTitleOffset(1.5)
+            vSummaryPlotsNoHotChan[vfat].GetYaxis().SetTitleOffset(1.5)
             vSummaryPlotsPanPin2[vfat] = r.TH2D('vSummaryPlotsPanPin2_%i'%vfat,
                     'vSummaryPlots%i_64-127;127 - Panasonic Pin;VCal [fC]'%vfat,
                     64,-0.5,63.5,256,
                     calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
                     calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
             vSummaryPlotsPanPin2[vfat].GetYaxis().SetTitleOffset(1.5)
-            vSummaryPlotsPrunedPanPin2[vfat] = r.TH2D('vSummaryPlotsPrunedPanPin2_%i'%vfat,
+            vSummaryPlotsNoHotChanPanPin2[vfat] = r.TH2D('vSummaryPlotsNoHotChanPanPin2_%i'%vfat,
                     'vSummaryPlots%i_64-127;127 - Panasonic Pin;VCal [fC]'%vfat,
                     64,-0.5,63.5,256,
                     calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
                     calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
-            vSummaryPlotsPrunedPanPin2[vfat].GetYaxis().SetTitleOffset(1.5)
+            vSummaryPlotsNoHotChanPanPin2[vfat].GetYaxis().SetTitleOffset(1.5)
             pass
         for chan in range (0,128):
             vScurves[vfat].append(r.TH1D('Scurve_%i_%i'%(vfat,chan),'Scurve_%i_%i;VCal [DAC units]'%(vfat,chan),256,-0.5,255.5))
@@ -345,14 +330,14 @@ if __name__ = '__main__':
                     #Q = CAL_DUR * CAL_DAC * 10nA * CAL_FS
                     charge = (1./ 40079000) * event.vcal * (10 * 1e-9) * dict_calSF[event.calSF] * 1e15
             if not (options.channels or options.PanPin):
-                vSummaryPlotsPruned[event.vfatN].Fill(strip,charge,event.Nhits)
+                vSummaryPlotsNoHotChan[event.vfatN].Fill(strip,charge,event.Nhits)
             if options.channels:
-                vSummaryPlotsPruned[event.vfatN].Fill(event.vfatCH,charge,event.Nhits)
+                vSummaryPlotsNoHotChan[event.vfatN].Fill(event.vfatCH,charge,event.Nhits)
             if options.PanPin:
                 if (pan_pin < 64):
-                    vSummaryPlotsPruned[event.vfatN].Fill(63-pan_pin,charge,event.Nhits)
+                    vSummaryPlotsNoHotChan[event.vfatN].Fill(63-pan_pin,charge,event.Nhits)
                 else:
-                    vSummaryPlotsPrunedPanPin2[event.vfatN].Fill(127-pan_pin,charge,event.Nhits)
+                    vSummaryPlotsNoHotChanPanPin2[event.vfatN].Fill(127-pan_pin,charge,event.Nhits)
     
     # Store values in ROOT file
     if options.SaveFile:
@@ -472,7 +457,7 @@ if __name__ = '__main__':
     
     saveSummary(vSummaryPlots, vSummaryPlotsPanPin2)
     if options.SaveFile:
-        saveSummary(vSummaryPlotsPruned, vSummaryPlotsPrunedPanPin2, name='PrunedSummary')
+        saveSummary(vSummaryPlotsNoHotChan, vSummaryPlotsNoHotChanPanPin2, name='PrunedSummary')
     
     if options.SaveFile:
         r.gStyle.SetOptStat(0)

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -128,11 +128,12 @@ if __name__ = '__main__':
     ztrim[0] = options.ztrim
     myT.Branch( 'ztrim', ztrim, 'ztrim/F')
     
+    # Create output plot containers
     vSummaryPlots = ndict()
     vSummaryPlotsPanPin2 = ndict()
     vSummaryPlotsPruned = ndict()
     vSummaryPlotsPrunedPanPin2 = ndict()
-    vScurves = []
+    vScurves = [ [] for x in range(0,24)]
     vScurveFits = []
     vthr_list = []
     trim_list = []

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -449,8 +449,6 @@ if __name__ == '__main__':
         allThresh = np.zeros(3072)
         allENC = np.zeros(3072)
         for vfat in range(0,24):
-            #fitThr = np.zeros(128)        
-            #fitENC = np.zeros(128)
             stripPinOrChanArray = np.zeros(128)
             for chan in range (0, 128):
                 # Store stripChanOrPinType to use as x-axis of fit summary plots
@@ -459,8 +457,6 @@ if __name__ == '__main__':
                 # Store Values for making fit summary plots
                 allThresh[vfat*128 + chan] = scanFitResults[0][vfat][chan]
                 allENC[vfat*128 + chan] =  scanFitResults[1][vfat][chan]
-                #fitThr[stripPinOrChan] = scanFitResults[0][vfat][chan]
-                #fitENC[stripPinOrChan] = scanFitResults[1][vfat][chan]
                 stripPinOrChanArray[stripPinOrChan] = float(stripPinOrChan)
 
 
@@ -521,19 +517,13 @@ if __name__ == '__main__':
             
             fitSummaryPlots[vfat].SetName("gFitSummary_VFAT%i"%(vfat))
             fitSummaryPlots[vfat].SetMarkerStyle(2)
-            #fitSummaryPlots[vfat].GetYaxis().SetRangeUser(0,50)
             
             # Make thresh summary plot - bin size is variable
             thisVFAT_ThreshMean = np.mean(allThresh[(vfat*128):((vfat+1)*128)])
             thisVFAT_ThreshStd = np.std(allThresh[(vfat*128):((vfat+1)*128)])
-            #histThresh = r.TH1F("scurveMean_vfat%i"%vfat,"VFAT %i;S-Curve Mean #left(fC#right);N"%vfat,
-            #                    40, np.mean(fitThr) - 5. * np.std(fitThr), np.mean(fitThr) + 5. * np.std(fitThr) )
             histThresh = r.TH1F("scurveMean_vfat%i"%vfat,"VFAT %i;S-Curve Mean #left(fC#right);N"%vfat,
                                 40, thisVFAT_ThreshMean - 5. * thisVFAT_ThreshStd, thisVFAT_ThreshMean + 5. * thisVFAT_ThreshStd )
             histThresh.Sumw2()
-            #if np.std(fitThr) != 0: # Don't fill if we are still at initial values
-            #    for thresh in fitThr:
-            #        histThresh.Fill(thresh)
             if thisVFAT_ThreshStd != 0: # Don't fill if we still at initial values
                 for thresh in allThresh[(vfat*128):((vfat+1)*128)]:
                     histThresh.Fill(thresh)
@@ -546,14 +536,9 @@ if __name__ == '__main__':
             # Make enc summary plot - bin size is variable
             thisVFAT_ENCMean = np.mean(allENC[(vfat*128):((vfat+1)*128)])
             thisVFAT_ENCStd = np.std(allENC[(vfat*128):((vfat+1)*128)])
-            #histENC = r.TH1F("scurveSigma_vfat%i"%vfat,"VFAT %i;S-Curve Sigma #left(fC#right);N"%vfat,
-            #                    40, np.mean(fitENC) - 5. * np.std(fitENC), np.mean(fitENC) + 5. * np.std(fitENC) )
             histENC = r.TH1F("scurveSigma_vfat%i"%vfat,"VFAT %i;S-Curve Sigma #left(fC#right);N"%vfat,
                                 40, thisVFAT_ENCMean - 5. * thisVFAT_ENCStd, thisVFAT_ENCMean + 5. * thisVFAT_ENCStd )
             histENC.Sumw2()
-            #if np.std(fitENC) != 0: # Don't fill if we are still at initial values
-            #    for enc in fitENC:
-            #        histENC.Fill(enc)
             if thisVFAT_ENCStd != 0: # Don't fill if we are still at initial values
                 for enc in allENC[(vfat*128):((vfat+1)*128)]:
                     histENC.Fill(enc)

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -121,9 +121,9 @@ if __name__ == '__main__':
     from gempython.utils.nesteddict import nesteddict as ndict
     from gempython.utils.wrappers import envCheck
   
-    defaultVFATList='0'
-    for vfat in range(1,24):
-        defaultVFATList+=(',%i'%vfat)
+    #defaultVFATList='0'
+    #for vfat in range(1,24):
+    #    defaultVFATList+=(',%i'%vfat)
 
     from anaoptions import parser
     parser.add_option("-b", "--drawbad", action="store_true", dest="drawbad",
@@ -137,8 +137,8 @@ if __name__ == '__main__':
                       help="Fit scurves and save fit information to output TFile", metavar="performFit")
     parser.add_option("--IsTrimmed", action="store_true", dest="IsTrimmed",
                       help="If the data is from a trimmed scan, plot the value it tried aligning to", metavar="IsTrimmed")
-    parser.add_option("--vfatList", type="string", dest="vfatList", default=defaultVFATList,
-                      help="Comma separated list of vfats positions to analyze", metavar="vfatList")
+    #parser.add_option("--vfatList", type="string", dest="vfatList", default=",".join([str(x) for x in range(0,24)]),
+    #                  help="Comma separated list of vfats positions to analyze", metavar="vfatList")
     parser.add_option("--zscore", type="float", dest="zscore", default=3.5,
                       help="Z-Score for Outlier Identification in MAD Algo", metavar="zscore")
     parser.set_defaults(outfilename="SCurveFitData.root")
@@ -148,8 +148,8 @@ if __name__ == '__main__':
     filename = options.filename[:-5]
     os.system("mkdir " + filename)
     
-    listOfVFATs = options.vfatList.split(',')
-    listOfVFATs = [int(vfat) for vfat in listOfVFATs]
+    #listOfVFATs = options.vfatList.split(',')
+    #listOfVFATs = [int(vfat) for vfat in range(0,24)]
     outfilename = options.outfilename
     GEBtype = options.GEBtype
    
@@ -189,7 +189,7 @@ if __name__ == '__main__':
     r.gStyle.SetOptStat(1111111)
 
     # Initialize distributions
-    for vfat in listOfVFATs:
+    for vfat in range(0,24):
         vSummaryPlots[vfat] = r.TH2D('vSummaryPlots%i'%vfat,
                 'VFAT %i;Channels;VCal [fC]'%vfat,
                 128,-0.5,127.5,256,
@@ -272,7 +272,7 @@ if __name__ == '__main__':
 
     # Get some of the operational settings of the ASIC
     # Refactor this using root_numpy???
-    dict_vfatID = dict((vfat, 0) for vfat in listOfVFATs)
+    dict_vfatID = dict((vfat, 0) for vfat in range(0,24))
     listOfBranches = inF.scurveTree.GetListOfBranches()
     for event in inF.scurveTree:
         vthr_list[event.vfatN][event.vfatCH] = event.vthr
@@ -308,7 +308,7 @@ if __name__ == '__main__':
         fitSummary = open(filename+'/fitSummary.txt','w')
         fitSummary.write('vfatN/I:vfatID/I:vfatCH/I:fitP0/F:fitP1/F:fitP2/F:fitP3/F\n')
         scanFitResults = fitter.fit()
-        for vfat in listOfVFATs:
+        for vfat in range(0,24):
             for chan in range(0,128):
                 fitSummary.write(
                         '%i\t%i\t%i\t%f\t%f\t%f\t%f\n'%(
@@ -327,10 +327,10 @@ if __name__ == '__main__':
         print("Determining hot channels")
         masks = []
         maskReasons = []
-        effectivePedestals = [ np.zeros(128) for vfat in listOfVFATs ]
+        effectivePedestals = [ np.zeros(128) for vfat in range(0,24) ]
         print "| vfatN | Dead Chan | Hot Chan | Failed Fits | High Noise | High Eff Ped |"
         print "| :---: | :-------: | :------: | :---------: | :--------: | :----------: |"
-        for vfat in listOfVFATs:
+        for vfat in range(0,24):
             trimValue = np.zeros(128)
             channelNoise = np.zeros(128)
             fitFailed = np.zeros(128, dtype=bool)
@@ -429,7 +429,7 @@ if __name__ == '__main__':
         fitSummaryPlots = {}
         threshSummaryPlots = {}
         encSummaryPlots = {}
-        for vfat in listOfVFATs:
+        for vfat in range(0,24):
             fitThr = np.zeros(128)        
             fitENC = np.zeros(128)
             stripPinOrChanArray = np.zeros(128)
@@ -529,7 +529,7 @@ if __name__ == '__main__':
     if options.IsTrimmed:
         trimmed_text = open('scanInfo.txt', 'r')
         trimVcal = []
-        for vfat in listOfVFATs:
+        for vfat in range(0,24):
             trimVcal.append(0)
             pass
         for n, line in enumerate(trimmed_text):
@@ -557,7 +557,7 @@ if __name__ == '__main__':
 
         confF = open(filename+'/chConfig.txt','w')
         confF.write('vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:mask/I\n')
-        for vfat in listOfVFATs:
+        for vfat in range(0,24):
             for chan in range (0, 128):
                 confF.write('%i\t%i\t%i\t%i\t%i\n'%(
                     vfat,
@@ -584,10 +584,13 @@ if __name__ == '__main__':
             canvOfScurveHistosNoHotChan = plotAllSCurvesOnCanvas(vSummaryPlotsNoHotChan,None,"canvScurvesNoHotChan")
         
         canvOfScurveFits = {}
-        for vfat in listOfVFATs:
+        for vfat in range(0,24):
             canvOfScurveFits[vfat] = r.TCanvas("canvScurveFits_vfat%i"%vfat,"Scurve Fits from VFAT%i"%vfat,600,600)
             canvOfScurveFits[vfat].cd()
             for chan in range (0,128):
+                if masks[vfat][chan]: # Do not draw fit for masked channels
+                    continue
+
                 if chan == 0:
                     fitter.scanFuncs[vfat][chan].Draw()
                 else:
@@ -598,7 +601,7 @@ if __name__ == '__main__':
     outF.cd()
     if options.performFit:
         myT.Write()
-    for vfat in listOfVFATs:
+    for vfat in range(0,24):
         dirVFAT = outF.mkdir("VFAT%i"%vfat)
         dirVFAT.cd()
         vSummaryPlots[vfat].Write()

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -504,11 +504,11 @@ if __name__ == '__main__':
 
             # Make fit Summary plot
             fitSummaryPlots[vfat] = r.TGraphErrors(
-                    len(fitThr),
+                    128,
                     stripPinOrChanArray,
-                    fitThr,
-                    np.zeros(len(fitThr)),
-                    fitENC
+                    allThresh[(vfat*128):((vfat+1)*128)],
+                    np.zeros(128),
+                    allENC[(vfat*128):((vfat+1)*128)]
                     )
             fitSummaryPlots[vfat].SetTitle("VFAT %i Fit Summary;Channel;Threshold [fC]"%vfat)
             
@@ -559,7 +559,7 @@ if __name__ == '__main__':
                     histENC.Fill(enc)
             gENC = r.TGraphErrors(histENC)
             gENC.SetName("gScurveSigmaDist_vfat%i"%vfat)
-            gENC.GetXaxis().SetTitle("scurve mean pos #left(fC#right)")
+            gENC.GetXaxis().SetTitle("scurve width #left(fC#right)")
             gENC.GetYaxis().SetTitle("Entries / %f fC"%(thisVFAT_ENCStd/4.))
             encSummaryPlots[vfat] = gENC
             pass
@@ -567,26 +567,26 @@ if __name__ == '__main__':
         # Make a Thresh Summary Dist For the entire Detector
         detThresh_Mean = np.mean(allThresh[allThresh != 0]) #Don't consider intial values
         detThresh_Std = np.std(allThresh[allThresh != 0]) #Don't consider intial values
-        detThresh_All = r.TH1F("scurveMean_All","All VFATs;S-Curve Mean #left(fC#right);N",
+        hDetThresh_All = r.TH1F("hScurveMeanDist_All","All VFATs;S-Curve Mean #left(fC#right);N",
                             40, detThresh_Mean - 5. * detThresh_Std, detThresh_Mean + 5. * detThresh_Std )
         for thresh in allThresh[allThresh != 0]:
-            detThresh_All.Fill(thresh)
-        gDetThresh_All = r.TGraphErrors(detThresh_All)
+            hDetThresh_All.Fill(thresh)
+        hDetThresh_All.GetXaxis().SetTitle("scurve mean pos #left(fC#right)")
+        hDetThresh_All.GetYaxis().SetTitle("Entries / %f fC"%(detThresh_Std/4.))
+        gDetThresh_All = r.TGraphErrors(hDetThresh_All)
         gDetThresh_All.SetName("gScurveMeanDist_All")
-        gDetThresh_All.GetXaxis().SetTitle("scurve mean pos #left(fC#right)")
-        gDetThresh_All.GetYaxis().SetTitle("Entries / %f fC"%(detThresh_Std/4.))
 
         # Make a ENC Summary Dist For the entire Detector
         detENC_Mean = np.mean(allENC[allENC != 0]) #Don't consider intial values
         detENC_Std = np.std(allENC[allENC != 0]) #Don't consider intial values
-        detENC_All = r.TH1F("scurveMean_All","All VFATs;S-Curve Mean #left(fC#right);N",
+        hDetENC_All = r.TH1F("hScurveWidthDist_All","All VFATs;S-Curve Mean #left(fC#right);N",
                             40, detENC_Mean - 5. * detENC_Std, detENC_Mean + 5. * detENC_Std )
         for thresh in allENC[allENC != 0]:
-            detENC_All.Fill(thresh)
-        gDetENC_All = r.TGraphErrors(detENC_All)
-        gDetENC_All.SetName("gScurveMeanDist_All")
-        gDetENC_All.GetXaxis().SetTitle("scurve mean pos #left(fC#right)")
-        gDetENC_All.GetYaxis().SetTitle("Entries / %f fC"%(detENC_Std/4.))
+            hDetENC_All.Fill(thresh)
+        hDetENC_All.GetXaxis().SetTitle("scurve width #left(fC#right)")
+        hDetENC_All.GetYaxis().SetTitle("Entries / %f fC"%(detENC_Std/4.))
+        gDetENC_All = r.TGraphErrors(hDetENC_All)
+        gDetENC_All.SetName("gScurveWidthDist_All")
         pass
     
     # Check if inputfile is trimmed
@@ -685,8 +685,11 @@ if __name__ == '__main__':
             canvOfScurveFits[vfat].Write()
             pass
     if options.performFit:
-        outF.cd()
+        dirSummary = outF.mkdir("Summary")
+        dirSummary.cd()
+        hDetThresh_All.Write()
         gDetThresh_All.Write()
+        hDetENC_All.Write()
         gDetENC_All.Write()
     
     # Close output root file

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -579,14 +579,14 @@ if __name__ == '__main__':
         # Make a ENC Summary Dist For the entire Detector
         detENC_Mean = np.mean(allENC[allENC != 0]) #Don't consider intial values
         detENC_Std = np.std(allENC[allENC != 0]) #Don't consider intial values
-        hDetENC_All = r.TH1F("hScurveWidthDist_All","All VFATs;S-Curve Mean #left(fC#right);N",
+        hDetENC_All = r.TH1F("hScurveSigmaDist_All","All VFATs;S-Curve Mean #left(fC#right);N",
                             40, detENC_Mean - 5. * detENC_Std, detENC_Mean + 5. * detENC_Std )
         for thresh in allENC[allENC != 0]:
             hDetENC_All.Fill(thresh)
         hDetENC_All.GetXaxis().SetTitle("scurve width #left(fC#right)")
         hDetENC_All.GetYaxis().SetTitle("Entries / %f fC"%(detENC_Std/4.))
         gDetENC_All = r.TGraphErrors(hDetENC_All)
-        gDetENC_All.SetName("gScurveWidthDist_All")
+        gDetENC_All.SetName("gScurveSigmaDist_All")
         pass
     
     # Check if inputfile is trimmed
@@ -618,7 +618,7 @@ if __name__ == '__main__':
             saveSummary(vSummaryPlotsNoMaskedChan, None, '%s/PrunedSummary.png'%filename, trimVcal)
         saveSummary(fitSummaryPlots, None, '%s/fitSummary.png'%filename, None, drawOpt="APE1")
         saveSummary(threshSummaryPlots, None, '%s/ScurveMeanSummary.png'%filename, None, drawOpt="AP")
-        saveSummary(encSummaryPlots, None, '%s/ScurveWidthSummary.png'%filename, None, drawOpt="AP")
+        saveSummary(encSummaryPlots, None, '%s/ScurveSigmaSummary.png'%filename, None, drawOpt="AP")
 
         confF = open(filename+'/chConfig.txt','w')
         confF.write('vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:mask/I\n')

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -527,6 +527,8 @@ if __name__ == '__main__':
                     histThresh.Fill(thresh)
             gThresh = r.TGraphErrors(histThresh)
             gThresh.SetName("gScurveMeanDist_vfat%i"%vfat)
+            gThresh.GetXaxis().SetTitle("scurve mean pos #left(fC#right)")
+            gThresh.GetYaxis().SetTitle("Entries / %f fC"%(np.std(fitThr)/4.))
             threshSummaryPlots[vfat] = gThresh
 
             # Make enc summary plot - bin size is variable
@@ -538,6 +540,8 @@ if __name__ == '__main__':
                     histENC.Fill(enc)
             gENC = r.TGraphErrors(histENC)
             gENC.SetName("gScurveSigmaDist_vfat%i"%vfat)
+            gENC.GetXaxis().SetTitle("scurve mean pos #left(fC#right)")
+            gENC.GetYaxis().SetTitle("Entries / %f fC"%(np.std(fitENC)/4.))
             encSummaryPlots[vfat] = gENC
             pass
         pass

--- a/anautilities.py
+++ b/anautilities.py
@@ -21,6 +21,20 @@ def filePathExists(searchPath, subPath=None, debug=False):
             print "Found %s"%s(testPath)
         return True
 
+def first_index_gt(data_list, value):
+    """
+    http://code.activestate.com/recipes/578071-fast-indexing-functions-greater-than-less-than-equ/
+    
+    return the first index greater than value from a given list like object.
+    If value is greater than all elements in the list like object, the length 
+    of the list like object is returned instead
+    """
+    try:
+        index = next(data[0] for data in enumerate(data_list) if data[1] > value)
+        return index
+    except StopIteration: 
+        return len(data_list)
+
 def getDirByAnaType(anaType, cName, ztrim=4):
     from anaInfo import ana_config
     

--- a/anautilities.py
+++ b/anautilities.py
@@ -247,3 +247,57 @@ def rejectOutliersMAD(arrayData, thresh=3.5):
 def rejectOutliersMADOneSided(arrayData, thresh=3.5, rejectHighTail=True):
     arrayOutliers = isOutlierMADOneSided(arrayData, thresh, rejectHighTail)
     return arrayData[arrayOutliers != True]
+
+def saveSummary(dictSummary, dictSummaryPanPin2=None, name='Summary', trimPt=None):
+    """
+    Makes an image with summary canvases drawn on it
+
+    dictSummary        - dict of TObjects to be drawn, one per VFAT.  Each will be 
+                         drawn on a separate canvas
+    dictSummaryPanPin2 - Optional, as dictSummary but if the independent variable is the
+                         readout connector pin this is the other side of the connector
+    name               - Name of output image
+    trimPt             - Optional, list of trim points the dependent variable was aligned
+                         to if it is the result of trimming.  One entry per VFAT
+    """
+
+    import ROOT as r
+
+    legend = r.TLegend(0.75,0.7,0.88,0.88)
+    r.gStyle.SetOptStat(0)
+    if dictSummaryPanPin2 is None:
+        canv = make3x8Canvas('canv', dictSummary, 'colz')
+        for vfat in range(0,24):
+            canv.cd(vfat+1)
+            if trimPt is not None and trimLine is not None:
+                trimLine = r.TLine(-0.5, trimVcal[vfat], 127.5, trimVcal[vfat])
+                legend.Clear()
+                legend.AddEntry(trimLine, 'trimVCal is %f'%(trimVcal[vfat]))
+                legend.Draw('SAME')
+                trimLine.SetLineColor(1)
+                trimLine.SetLineWidth(3)
+                trimLine.Draw('SAME')
+                pass
+            canv.Update()
+            pass
+        pass
+    else:
+        canv = r.TCanvas('canv','canv',500*8,500*3)
+        canv.Divide(8,6)
+        r.gStyle.SetOptStat(0)
+        for ieta in range(0,8):
+            for iphi in range (0,3):
+                r.gStyle.SetOptStat(0)
+                canv.cd((ieta+1 + iphi*16)%48 + 16)
+                dictSummary[ieta+(8*iphi)].Draw('colz')
+                canv.Update()
+                canv.cd((ieta+9 + iphi*16)%48 + 16)
+                dictSummaryPanPin2[ieta+(8*iphi)].Draw('colz')
+                canv.Update()
+                pass
+            pass
+        pass
+
+    canv.SaveAs(name)
+
+    return

--- a/anautilities.py
+++ b/anautilities.py
@@ -248,7 +248,7 @@ def rejectOutliersMADOneSided(arrayData, thresh=3.5, rejectHighTail=True):
     arrayOutliers = isOutlierMADOneSided(arrayData, thresh, rejectHighTail)
     return arrayData[arrayOutliers != True]
 
-def saveSummary(dictSummary, dictSummaryPanPin2=None, name='Summary', trimPt=None):
+def saveSummary(dictSummary, dictSummaryPanPin2=None, name='Summary', trimPt=None, drawOpt="colz"):
     """
     Makes an image with summary canvases drawn on it
 
@@ -259,6 +259,7 @@ def saveSummary(dictSummary, dictSummaryPanPin2=None, name='Summary', trimPt=Non
     name               - Name of output image
     trimPt             - Optional, list of trim points the dependent variable was aligned
                          to if it is the result of trimming.  One entry per VFAT
+    drawOpt            - Draw option
     """
 
     import ROOT as r
@@ -266,7 +267,7 @@ def saveSummary(dictSummary, dictSummaryPanPin2=None, name='Summary', trimPt=Non
     legend = r.TLegend(0.75,0.7,0.88,0.88)
     r.gStyle.SetOptStat(0)
     if dictSummaryPanPin2 is None:
-        canv = make3x8Canvas('canv', dictSummary, 'colz')
+        canv = make3x8Canvas('canv', dictSummary, drawOpt)
         for vfat in range(0,24):
             canv.cd(vfat+1)
             if trimPt is not None and trimLine is not None:
@@ -289,10 +290,10 @@ def saveSummary(dictSummary, dictSummaryPanPin2=None, name='Summary', trimPt=Non
             for iphi in range (0,3):
                 r.gStyle.SetOptStat(0)
                 canv.cd((ieta+1 + iphi*16)%48 + 16)
-                dictSummary[ieta+(8*iphi)].Draw('colz')
+                dictSummary[ieta+(8*iphi)].Draw(drawOpt)
                 canv.Update()
                 canv.cd((ieta+9 + iphi*16)%48 + 16)
-                dictSummaryPanPin2[ieta+(8*iphi)].Draw('colz')
+                dictSummaryPanPin2[ieta+(8*iphi)].Draw(drawOpt)
                 canv.Update()
                 pass
             pass

--- a/anautilities.py
+++ b/anautilities.py
@@ -54,6 +54,16 @@ def getDirByAnaType(anaType, cName, ztrim=4):
 
     return dirPath
 
+def getEmptyPerVFATList(n_vfat=24):
+    """
+    Returns a list of lists
+    Each of the inner lists are empty
+
+    There are n_vfat inner lists
+    """
+
+    return [ [] for vfat in range(0,n_vfat) ]
+
 def getMapping(mappingFileName):
     """
     Returns a nested dictionary, the outer dictionary uses VFAT position as the has a key,

--- a/anautilities.py
+++ b/anautilities.py
@@ -70,11 +70,12 @@ def getMapping(mappingFileName):
     the inner most dict has keys from the list anaInfo.py mappingNames.
     
     The inner dict stores a list whose index is ordered by ASIC channel number, accessing
-    the i^th element of this list gives either the readout strip number of readout connector
-    pin number as shown in this example:
+    the i^th element of this list gives either the readout strip number, the readout connector
+    pin number, or the vfat channel number as shown in this example:
 
         ret_dict[vfatN]['Strip'][asic_chan] is the strip number
         ret_dict[vfatN]['PanPin'][asic_chan] is the pin number on the readout connector
+        ret_dict[vfatN]['vfatCH'][asic_chan] is the vfat channel number
 
     mappingFile - physical filename of file which contains the mapping information, 
                   expected format:
@@ -124,6 +125,7 @@ def getMapping(mappingFileName):
         mapping = line.rsplit('\t')
         ret_mapDict[int(mapping[0])]['Strip'][int(mapping[2]) - 1] = int(mapping[1])
         ret_mapDict[int(mapping[0])]['PanPin'][int(mapping[2]) -1] = int(mapping[3])
+        ret_mapDict[int(mapping[0])]['vfatCH'][int(mapping[2]) - 1] = int(mapping[2]) - 1
 
     return ret_mapDict
 

--- a/anautilities.py
+++ b/anautilities.py
@@ -35,6 +35,24 @@ def first_index_gt(data_list, value):
     except StopIteration: 
         return len(data_list)
 
+def getCyclicColor(idx):
+    import ROOT as r
+
+    colors = {
+        0:r.kBlack,
+        1:r.kRed-1,
+        2:r.kGreen-1,
+        3:r.kBlue-1,
+        4:r.kRed-2,
+        5:r.kGreen-2,
+        6:r.kBlue-2,
+        7:r.kRed-3,
+        8:r.kGreen-3,
+        9:r.kBlue-3,
+            }
+
+    return colors[idx % 10]
+
 def getDirByAnaType(anaType, cName, ztrim=4):
     from anaInfo import ana_config
     
@@ -241,7 +259,7 @@ def isOutlierMADOneSided(arrayData, thresh=3.5, rejectHighTail=True):
         else:
             return modified_z_score < -1.0 * thresh
 
-def make3x8Canvas(name, initialContent = None, initialDrawOpt = '', secondaryContent = None, secondaryDrawOpt = ''):
+def make3x8Canvas(name, initialContent = None, initialDrawOpt = '', secondaryContent = None, secondaryDrawOpt = '', canv=None):
     """
     Creates a 3x8 canvas for summary plots.
 
@@ -250,12 +268,15 @@ def make3x8Canvas(name, initialContent = None, initialDrawOpt = '', secondaryCon
     initialDrawOpt - draw option to be used when drawing elements of initialContent
     secondaryContent - either None or an array of 24 (one per VFAT) TObjects that will be drawn on top of the canvas.
     secondaryDrawOpt - draw option to be used when drawing elements of secondaryContent
+    canv - TCanvas previously produced by make3x8Canvas() or one that has been subdivided into a 3x8 grid
     """
 
     import ROOT as r
     
-    canv = r.TCanvas(name,name,500*8,500*3)
-    canv.Divide(8,3)
+    if canv is None:
+        canv = r.TCanvas(name,name,500*8,500*3)
+        canv.Divide(8,3)
+
     if initialContent is not None:
         for vfat in range(24):
             canv.cd(vfat+1)

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -41,11 +41,12 @@ class ScanDataFitter(DeadChannelFinder):
         self.scanHistos[event.vfatN][event.vfatCH].Fill(event.vcal,event.Nhits)
         if(event.vcal > 250):
             self.scanCount[event.vfatN][event.vfatCH] += event.Nhits
-        #if self.Nev < 0:
-        #    self.Nev = event.Nev
-        #else:
-        #    assert self.Nev == event.Nev, 'Inconsistent S-curve tree'
         self.Nev = event.Nev
+
+    def feedHisto(self, vfatN, vfatCH, Nev, histo):
+        self.scanHistos[event.vfatN][event.vfatCH] = histo
+        self.isDead[vfatN][vfatCH] = False
+        self.Nev = Nev
 
     def fit(self):
         r.gROOT.SetBatch(True)

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -1,5 +1,6 @@
 import numpy as np
 import ROOT as r
+from anaInfo import dict_calSF
 
 class DeadChannelFinder(object):
     def __init__(self):
@@ -30,7 +31,6 @@ class ScanDataFitter(DeadChannelFinder):
 
         self.isVFAT3    = isVFAT3
         self.isIPulse   = isIPulse
-        self.dict_calSF = dict((calSF, 0.25*calSF+0.25) for calSF in range(0,4))
 
         self.calDAC2Q_m = np.ones(24)
         if calDAC2Q_m is not None:
@@ -66,7 +66,7 @@ class ScanDataFitter(DeadChannelFinder):
         if self.isVFAT3: #v3 electronics
             if event.isIPulse:
                 #Q = CAL_DUR * CAL_DAC * 10nA * CAL_FS
-                charge = (1./ 40079000) * event.vcal * (10 * 1e-9) * self.dict_calSF[event.calSF] * 1e15
+                charge = (1./ 40079000) * event.vcal * (10 * 1e-9) * dict_calSF[event.calSF] * 1e15
                 if(event.vcal > 254):
                     self.scanCount[event.vfatN][event.vfatCH] += event.Nhits
             else:

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -112,11 +112,11 @@ class ScanDataFitter(DeadChannelFinder):
 
         random = r.TRandom3()
         random.SetSeed(0)
-        fitTF1 = r.TF1('myERF','[3]*TMath::Erf((TMath::Max([2],x)-[0])/(TMath::Sqrt(2)*[1]))+[3]',
-                        self.calDAC2Q_m[vfat]*1+self.calDAC2Q_b[vfat],self.calDAC2Q_m[vfat]*253+self.calDAC2Q_b[vfat])
         for vfat in range(0,24):
-            print 'fitting vfat %i'%vfat
+            fitTF1 = r.TF1('myERF','[3]*TMath::Erf((TMath::Max([2],x)-[0])/(TMath::Sqrt(2)*[1]))+[3]',
+                        self.calDAC2Q_m[vfat]*1+self.calDAC2Q_b[vfat],self.calDAC2Q_m[vfat]*253+self.calDAC2Q_b[vfat])
             for ch in range(0,128):
+                print 'fitting vfat %i chan %i'%(vfat,ch)
                 if self.isDead[vfat][ch]:
                     continue # Don't try to fit dead channels
                 elif not (self.scanHistos[vfat][ch].Integral() > 0):
@@ -126,7 +126,12 @@ class ScanDataFitter(DeadChannelFinder):
                 stepN = 0
                 while(stepN < 15):
                     rand = random.Gaus(10, 5)
+                    
+                    # Make sure the input parameters are positive
                     if (rand < 0.0 or rand > 100): continue
+                    #if self.calDAC2Q_m[vfat]*(8+stepN*8)+self.calDAC2Q_b[vfat] < 0: continue
+                    #if self.calDAC2Q_m[vfat]*(rand)+self.calDAC2Q_b[vfat] < 0: continue
+
                     # Provide an initial guess
                     fitTF1.SetParameter(0, self.calDAC2Q_m[vfat]*(8+stepN*8)+self.calDAC2Q_b[vfat] )
                     fitTF1.SetParameter(1, self.calDAC2Q_m[vfat]*(rand)+self.calDAC2Q_b[vfat])
@@ -134,11 +139,11 @@ class ScanDataFitter(DeadChannelFinder):
                     fitTF1.SetParameter(3, self.Nev[vfat][ch]/2.)
 
                     # Set Parameter Limits
-                    fitTF1.SetParLimits(0, 0.01, self.calDAC2Q_m[vfat]*(300.0)+self.calDAC2Q_b[vfat])
-                    fitTF1.SetParLimits(1, 0.0,  self.calDAC2Q_m[vfat]*(100.0)+self.calDAC2Q_b[vfat])
-                    fitTF1.SetParLimits(2, 0.0,  self.calDAC2Q_m[vfat]*(300.0)+self.calDAC2Q_b[vfat])
+                    fitTF1.SetParLimits(0, 0.01, self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat])
+                    fitTF1.SetParLimits(1, 0.0,  self.calDAC2Q_m[vfat]*(128)+self.calDAC2Q_b[vfat])
+                    fitTF1.SetParLimits(2, 0.0,  self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat])
                     fitTF1.SetParLimits(3, 0.0,  self.Nev[vfat][ch] * 2.)
-
+                    
                     # Fit
                     fitResult = self.scanHistos[vfat][ch].Fit('myERF','SQ')
                     fitEmpty = fitResult.IsEmpty()

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -32,11 +32,11 @@ class ScanDataFitter(DeadChannelFinder):
         self.isIPulse   = isIPulse
         self.dict_calSF = dict((calSF, 0.25*calSF+0.25) for calSF in range(0,4))
 
-        self.calDAC2Q_m = [1.]*24
+        self.calDAC2Q_m = np.ones(24)
         if calDAC2Q_m is not None:
             self.calDAC2Q_m = calDAC2Q_m
 
-        self.calDAC2Q_b = [0.]*24
+        self.calDAC2Q_b = np.zeros(24)
         if calDAC2Q_b is not None:
             self.calDAC2Q_b = calDAC2Q_b
 

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -26,7 +26,7 @@ class ScanDataFitter(DeadChannelFinder):
         self.scanFuncs  = ndict()
         self.scanHistos = ndict()
         self.scanCount  = ndict()
-        self.scanFits   = ndict()
+        self.scanFitResults   = ndict()
 
         self.isVFAT3    = isVFAT3
         self.isIPulse   = isIPulse
@@ -41,13 +41,13 @@ class ScanDataFitter(DeadChannelFinder):
             self.calDAC2Q_b = calDAC2Q_b
 
         for vfat in range(0,24):
-            self.scanFits[0][vfat] = np.zeros(128)
-            self.scanFits[1][vfat] = np.zeros(128)
-            self.scanFits[2][vfat] = np.zeros(128)
-            self.scanFits[3][vfat] = np.zeros(128)
-            self.scanFits[4][vfat] = np.zeros(128)
-            self.scanFits[5][vfat] = np.zeros(128)
-            self.scanFits[6][vfat] = np.zeros(128, dtype=bool)
+            self.scanFitResults[0][vfat] = np.zeros(128)
+            self.scanFitResults[1][vfat] = np.zeros(128)
+            self.scanFitResults[2][vfat] = np.zeros(128)
+            self.scanFitResults[3][vfat] = np.zeros(128)
+            self.scanFitResults[4][vfat] = np.zeros(128)
+            self.scanFitResults[5][vfat] = np.zeros(128)
+            self.scanFitResults[6][vfat] = np.zeros(128, dtype=bool)
             for ch in range(0,128):
                 self.scanCount[vfat][ch] = 0
                 self.scanFuncs[vfat][ch] = r.TF1('scurveFit_vfat%i_chan%i'%(vfat,ch),'[3]*TMath::Erf((TMath::Max([2],x)-[0])/(TMath::Sqrt(2)*[1]))+[3]',
@@ -99,7 +99,7 @@ class ScanDataFitter(DeadChannelFinder):
                 construction then output container will have relevant
                 parameters in charge units instead of DAC units
 
-        Returns self.scanFits
+        Returns self.scanFitResults
             
                  [0][vfat][ch] = scurve mean in either DAC units or charge (threshold of comparator)
                  [1][vfat][ch] = scurve width in either DAC units or charge (noise seen by comparator)
@@ -155,12 +155,12 @@ class ScanDataFitter(DeadChannelFinder):
                     stepN +=1
                     if (fitChi2 < MinChi2Temp and fitChi2 > 0.0):
                         self.scanFuncs[vfat][ch] = fitTF1.Clone('scurveFit_vfat%i_chan%i_h'%(vfat,ch))
-                        self.scanFits[0][vfat][ch] = fitTF1.GetParameter(0)
-                        self.scanFits[1][vfat][ch] = fitTF1.GetParameter(1)
-                        self.scanFits[2][vfat][ch] = fitTF1.GetParameter(2)
-                        self.scanFits[3][vfat][ch] = fitChi2
-                        self.scanFits[4][vfat][ch] = self.scanCount[vfat][ch]
-                        self.scanFits[5][vfat][ch] = fitNDF
+                        self.scanFitResults[0][vfat][ch] = fitTF1.GetParameter(0)
+                        self.scanFitResults[1][vfat][ch] = fitTF1.GetParameter(1)
+                        self.scanFitResults[2][vfat][ch] = fitTF1.GetParameter(2)
+                        self.scanFitResults[3][vfat][ch] = fitChi2
+                        self.scanFitResults[4][vfat][ch] = self.scanCount[vfat][ch]
+                        self.scanFitResults[5][vfat][ch] = fitNDF
                         self.fitValid[vfat][ch] = True
                         MinChi2Temp = fitChi2
                         pass
@@ -168,7 +168,7 @@ class ScanDataFitter(DeadChannelFinder):
                     pass
                 pass
             pass
-        return self.scanFits
+        return self.scanFitResults
     
     def getFunc(self, vfat, ch):
         return self.scanFuncs[vfat][ch]

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -9,7 +9,14 @@ class DeadChannelFinder(object):
         self.isDead[event.vfatN][event.vfatCH] = False
 
 class ScanDataFitter(DeadChannelFinder):
-    def __init__(self):
+    def __init__(self, calDAC2Q_m=None, calDAC2Q_b=None, isVFAT3=False, isIPulse=False):
+        """
+        calDAC2Q_m - list of slope values for "fC = m * cal_dac + b" equation, ordered by vfat position
+        calDAC2Q_b - as calDAC2Q_m but for intercept b
+        isVFAT3 - if using VFAT3
+        isIPulse - if using current pulse mode of vfat3
+        """
+
         super(ScanDataFitter, self).__init__()
 
         from gempython.utils.nesteddict import nesteddict as ndict
@@ -21,6 +28,18 @@ class ScanDataFitter(DeadChannelFinder):
         self.scanCount  = ndict()
         self.scanFits   = ndict()
 
+        self.isVFAT3    = isVFAT3
+        self.isIPulse   = isIPulse
+        self.dict_calSF = dict((calSF, 0.25*calSF+0.25) for calSF in range(0,4))
+
+        self.calDAC2Q_m = [1.]*24
+        if calDAC2Q_m is not None:
+            self.calDAC2Q_m = calDAC2Q_m
+
+        self.calDAC2Q_b = [0.]*24
+        if calDAC2Q_b is not None:
+            self.calDAC2Q_b = calDAC2Q_b
+
         for vfat in range(0,24):
             self.scanFits[0][vfat] = np.zeros(128)
             self.scanFits[1][vfat] = np.zeros(128)
@@ -30,18 +49,37 @@ class ScanDataFitter(DeadChannelFinder):
             self.scanFits[5][vfat] = np.zeros(128)
             self.scanFits[6][vfat] = np.zeros(128, dtype=bool)
             for ch in range(0,128):
-                self.scanFuncs[vfat][ch] = r.TF1('scurveFit_vfat%i_chan%i'%(vfat,ch),'[3]*TMath::Erf((TMath::Max([2],x)-[0])/(TMath::Sqrt(2)*[1]))+[3]',1,253)
-                self.scanHistos[vfat][ch] = r.TH1D('scurve_vfat%i_chan%i_h'%(vfat,ch),'scurve_vfat%i_chan%i_h'%(vfat,ch),254,0.5,254.5)
                 self.scanCount[vfat][ch] = 0
+                self.scanFuncs[vfat][ch] = r.TF1('scurveFit_vfat%i_chan%i'%(vfat,ch),'[3]*TMath::Erf((TMath::Max([2],x)-[0])/(TMath::Sqrt(2)*[1]))+[3]',
+                        self.calDAC2Q_m[vfat]*1+self.calDAC2Q_b[vfat],self.calDAC2Q_m[vfat]*253+self.calDAC2Q_b[vfat])
+                self.scanHistos[vfat][ch] = r.TH1D('scurve_vfat%i_chan%i_h'%(vfat,ch),'scurve_vfat%i_chan%i_h'%(vfat,ch),
+                        254,self.calDAC2Q_m[vfat]*0.5+self.calDAC2Q_b[vfat],self.calDAC2Q_m[vfat]*254.5+self.calDAC2Q_b[vfat])
 
         self.fitValid = [ np.zeros(128, dtype=bool) for vfat in range(24) ]
 
+        return
+
     def feed(self, event):
         super(ScanDataFitter, self).feed(event)
-        self.scanHistos[event.vfatN][event.vfatCH].Fill(event.vcal,event.Nhits)
-        if(event.vcal > 250):
-            self.scanCount[event.vfatN][event.vfatCH] += event.Nhits
+
+        charge = self.calDAC2Q_m[event.vfatN]*event.vcal+self.calDAC2Q_b[event.vfatN]
+        if self.isVFAT3: #v3 electronics
+            if event.isIPulse:
+                #Q = CAL_DUR * CAL_DAC * 10nA * CAL_FS
+                charge = (1./ 40079000) * event.vcal * (10 * 1e-9) * self.dict_calSF[event.calSF] * 1e15
+                if(event.vcal > 254):
+                    self.scanCount[event.vfatN][event.vfatCH] += event.Nhits
+            else:
+                charge = self.calDAC2Q_m[event.vfatN]*(256-event.vcal)+self.calDAC2Q_b[event.vfatN]
+                if((256-event.vcal) > 254):
+                    self.scanCount[event.vfatN][event.vfatCH] += event.Nhits
+        else:
+            if(event.vcal > 250):
+                self.scanCount[event.vfatN][event.vfatCH] += event.Nhits
+        self.scanHistos[event.vfatN][event.vfatCH].Fill(charge,event.Nhits)
         self.Nev[event.vfatN][event.vfatCH] = event.Nev
+
+        return
 
     def feedHisto(self, vfatN, vfatCH, histo, nEvts=None):
         self.scanHistos[vfatN][vfatCH] = histo
@@ -52,13 +90,32 @@ class ScanDataFitter(DeadChannelFinder):
         else:
             self.Nev[vfatN][vfatCH] = nEvts
 
+        return
+
     def fit(self):
+        """
+        Iteratively fits all scurves
+        Note:   if the user supplied calDAC2Q_m and calDAC2Q_b at
+                construction then output container will have relevant
+                parameters in charge units instead of DAC units
+
+        Returns self.scanFits
+            
+                 [0][vfat][ch] = scurve mean in either DAC units or charge (threshold of comparator)
+                 [1][vfat][ch] = scurve width in either DAC units or charge (noise seen by comparator)
+                 [2][vfat][ch] = scurve pedestal in hits (e.g. at 0 VCAL this is the noise)
+                 [3][vfat][ch] = fitChi2
+                 [4][vfat][ch] = self.scanCount[vfat][ch]
+                 [5][vfat][ch] = fitNDF
+        """
+
         r.gROOT.SetBatch(True)
         r.gStyle.SetOptStat(0)
 
         random = r.TRandom3()
         random.SetSeed(0)
-        fitTF1 = r.TF1('myERF','[3]*TMath::Erf((TMath::Max([2],x)-[0])/(TMath::Sqrt(2)*[1]))+[3]',1,253)
+        fitTF1 = r.TF1('myERF','[3]*TMath::Erf((TMath::Max([2],x)-[0])/(TMath::Sqrt(2)*[1]))+[3]',
+                        self.calDAC2Q_m[vfat]*1+self.calDAC2Q_b[vfat],self.calDAC2Q_m[vfat]*253+self.calDAC2Q_b[vfat])
         for vfat in range(0,24):
             print 'fitting vfat %i'%vfat
             for ch in range(0,128):
@@ -73,16 +130,16 @@ class ScanDataFitter(DeadChannelFinder):
                     rand = random.Gaus(10, 5)
                     if (rand < 0.0 or rand > 100): continue
                     # Provide an initial guess
-                    fitTF1.SetParameter(0, 8+stepN*8)
-                    fitTF1.SetParameter(1,rand)
-                    fitTF1.SetParameter(2,8+stepN*8)
+                    fitTF1.SetParameter(0, self.calDAC2Q_m[vfat]*(8+stepN*8)+self.calDAC2Q_b[vfat] )
+                    fitTF1.SetParameter(1, self.calDAC2Q_m[vfat]*(rand)+self.calDAC2Q_b[vfat])
+                    fitTF1.SetParameter(2, self.calDAC2Q_m[vfat]*(8+stepN*8)+self.calDAC2Q_b[vfat])
                     fitTF1.SetParameter(3, self.Nev[vfat][ch]/2.)
 
                     # Set Parameter Limits
-                    fitTF1.SetParLimits(0, 0.01, 300.0)
-                    fitTF1.SetParLimits(1, 0.0, 100.0)
-                    fitTF1.SetParLimits(2, 0.0, 300.0)
-                    fitTF1.SetParLimits(3, 0.0, self.Nev[vfat][ch] * 2.)
+                    fitTF1.SetParLimits(0, 0.01, self.calDAC2Q_m[vfat]*(300.0)+self.calDAC2Q_b[vfat])
+                    fitTF1.SetParLimits(1, 0.0,  self.calDAC2Q_m[vfat]*(100.0)+self.calDAC2Q_b[vfat])
+                    fitTF1.SetParLimits(2, 0.0,  self.calDAC2Q_m[vfat]*(300.0)+self.calDAC2Q_b[vfat])
+                    fitTF1.SetParLimits(3, 0.0,  self.Nev[vfat][ch] * 2.)
 
                     # Fit
                     fitResult = self.scanHistos[vfat][ch].Fit('myERF','SQ')
@@ -120,6 +177,7 @@ class ScanDataFitter(DeadChannelFinder):
         inF = r.TFile(treeFileName)
         for event in inF.scurveTree :
             self.feed(event)
+        return
 
 def fitScanData(treeFileName):
     fitter = ScanDataFitter()

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -10,12 +10,11 @@ class DeadChannelFinder(object):
         self.isDead[event.vfatN][event.vfatCH] = False
 
 class ScanDataFitter(DeadChannelFinder):
-    def __init__(self, calDAC2Q_m=None, calDAC2Q_b=None, isVFAT3=False, isIPulse=False):
+    def __init__(self, calDAC2Q_m=None, calDAC2Q_b=None, isVFAT3=False):
         """
         calDAC2Q_m - list of slope values for "fC = m * cal_dac + b" equation, ordered by vfat position
         calDAC2Q_b - as calDAC2Q_m but for intercept b
         isVFAT3 - if using VFAT3
-        isIPulse - if using current pulse mode of vfat3
         """
 
         super(ScanDataFitter, self).__init__()
@@ -30,7 +29,6 @@ class ScanDataFitter(DeadChannelFinder):
         self.scanFitResults   = ndict()
 
         self.isVFAT3    = isVFAT3
-        self.isIPulse   = isIPulse
 
         self.calDAC2Q_m = np.ones(24)
         if calDAC2Q_m is not None:
@@ -64,7 +62,7 @@ class ScanDataFitter(DeadChannelFinder):
 
         charge = self.calDAC2Q_m[event.vfatN]*event.vcal+self.calDAC2Q_b[event.vfatN]
         if self.isVFAT3: #v3 electronics
-            if event.isIPulse:
+            if event.isCurrentPulse:
                 #Q = CAL_DUR * CAL_DAC * 10nA * CAL_FS
                 charge = (1./ 40079000) * event.vcal * (10 * 1e-9) * dict_calSF[event.calSF] * 1e15
                 if(event.vcal > 254):

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -122,17 +122,25 @@ class ScanDataFitter(DeadChannelFinder):
             fitTF1 = r.TF1('myERF','[3]*TMath::Erf((TMath::Max([2],x)-[0])/(TMath::Sqrt(2)*[1]))+[3]',
                         self.calDAC2Q_m[vfat]*1+self.calDAC2Q_b[vfat],self.calDAC2Q_m[vfat]*253+self.calDAC2Q_b[vfat])
             fitTF1.SetLineColor(r.kBlack)
+            
+            if not debug:
+                print 'fitting vfat %i'%(vfat)
+
             for ch in range(0,128):
-                print 'fitting vfat %i chan %i'%(vfat,ch)
+                if debug:
+                    print 'fitting vfat %i chan %i'%(vfat,ch)
+                
                 if self.isDead[vfat][ch]:
                     fitTF1.SetLineColor(r.kGray)
                     continue # Don't try to fit dead channels
                 elif not (self.scanHistos[vfat][ch].Integral() > 0):
                     fitTF1.SetLineColor(r.kGray)
                     continue # Don't try to fit with 0 entries
+                
                 fitChi2 = 0
                 MinChi2Temp = 99999999
                 stepN = 0
+                
                 if debug:
                     print "| p0_low | p0 | p0_high | p1_low | p1 | p1_high | p2_low | p2 | p2_high |"
                     print "| ------ | -- | ------- | ------ | -- | ------- | ------ | -- | ------- |"
@@ -211,7 +219,7 @@ class ScanDataFitter(DeadChannelFinder):
             self.feed(event)
         return
 
-def fitScanData(treeFileName):
-    fitter = ScanDataFitter()
+def fitScanData(treeFileName, isVFAT3=False):
+    fitter = ScanDataFitter(isVFAT3=isVFAT3)
     fitter.readFile(treeFileName)
     return fitter.fit()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Refactoring of `anaUltraScurve.py` with updates/additions to supporting tools.

All distributions created will now be in fC.  The output `TFile` will have relevant s-curve parameters stored in fC.  The default behavior is to use the `vfat2` `VCAL` to `fC` conversion that has been hard coded for some time.  The user can supply an external text file which specifies the conversion between the `CAL DAC` (either `vfat2` or `vfat3`) to `fC` using the `--calFile` argument.  The expected format of this file is shown as:

```
vfatN/I:slope/F:intercept/F
0   0.2692  -2.629748
1   0.238106    -2.65316
2   0.2532  -2.193826
3   0.276783    -2.477547
...
5   1.000000    0.000000    
...
...
```

If one prefers to stick in terms of `DAC` units simply supply a slope of `1.0` with an intercept of `0.0` as in the above example (e.g. a chip where the calibration is not known or was not possible). 

The fitting class ScanDataFitter is now also capable of working with quantities in terms of fC but the default behavior of this class will be in DAC units to preserve compatibility with `trimChamber.py`.  Supplying additional arguments at construction (as is done now in `anaUltraScurve.py`) will enable the fitter to parse input information, and return output results, in terms of fC. 

Additionally a series of new distributions have been added:
1. `ScurveMeanSummary.png`, shows the distribution of s-curve mean positions (after fitting) for all VFATs in the standard grid layout,
2. `ScurveWidthSummary.png`, shows the distribution of s-curve width positions (after fitting) for all VFATs in the standard grid layout.
3. `scurves_vfatX`, a `TCanvas` for `VFATX` showing all 1D scurves on the same `TPad` for a given `vfat` (as shown by the VFAT3 production team in a recent DAQ meeting)
4. `scurvesNoMaskedChan_vfatX`, as item 3 but omitting curves from masked channels.
5. `canvScurveFits_vfatX`, as item 4 but instead here the fitted `TF1` objects are plotted.

Additionally the `TObject`s used in items 1 & 2 are also stored in the output `TFile` in a TDirectory `VFATX` where `X` is the VFAT position.  Items 3-5 are available in the output `TFile` but are not stored as images in the output directory.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Originally wanted to add a few distributions to the analysis routine but the code was pretty hacked together and it was unclear where certain things defined or what units they were in (e.g. DAC units or fC).

Address comments about unnecessary sub-process calls that were brought up [here](https://github.com/cms-gem-daq-project/vfatqc-python-scripts/issues/120)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Extensive analysis and testing.

### Screenshots (if appropriate):
Example `TFile` output structure now (note the `TTree` structure has *not* changed):
<img width="255" alt="screen shot 2018-03-23 at 20 37 19" src="https://user-images.githubusercontent.com/6432141/37850513-ae942c92-2edb-11e8-9acf-87009393d25f.png">

Summary.png:
<img width="1678" alt="screen shot 2018-03-23 at 20 38 30" src="https://user-images.githubusercontent.com/6432141/37850403-46163610-2edb-11e8-8e97-c44e203b884a.png">

PrunedSummary.png:
<img width="1676" alt="screen shot 2018-03-23 at 20 39 11" src="https://user-images.githubusercontent.com/6432141/37850422-577fa936-2edb-11e8-9a32-9cef88352b34.png">

fitSumnmary.png:
<img width="1679" alt="screen shot 2018-03-23 at 20 39 42" src="https://user-images.githubusercontent.com/6432141/37850430-5ec65cd0-2edb-11e8-9118-f512681fc14c.png">

ScurveMeanSummary.png:
<img width="1676" alt="screen shot 2018-03-23 at 20 44 06" src="https://user-images.githubusercontent.com/6432141/37850444-687069b0-2edb-11e8-8ec0-fe0be7ce11b5.png">

ScurveWidthSummary.png:
<img width="1679" alt="screen shot 2018-03-23 at 20 44 44" src="https://user-images.githubusercontent.com/6432141/37850456-745874ac-2edb-11e8-8a24-2e60d41671a6.png">

`TCanvas` scurves_vfat0:
<img width="595" alt="screen shot 2018-03-23 at 20 45 39" src="https://user-images.githubusercontent.com/6432141/37850468-803b73c8-2edb-11e8-812f-bc6b4c57bef5.png">

`TCanvas` scurvesNoMaskedChan_vfat0
<img width="595" alt="screen shot 2018-03-23 at 20 45 55" src="https://user-images.githubusercontent.com/6432141/37850493-90441eaa-2edb-11e8-9fea-2602984db979.png">

`TCanvas` canvScurveFits_vfat0
<img width="595" alt="screen shot 2018-03-23 at 20 46 10" src="https://user-images.githubusercontent.com/6432141/37850498-99f9155e-2edb-11e8-9a34-8289d5ebff08.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
