### PR TITLE
New Tool For Visualizing Results from Multiple Scurve Runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Table of Contents
             * [gemSCurveAnaToolkit.py Arguments](#gemscurveanatoolkitpy-arguments)
             * [gemSCurveAnaToolkit.py Input File](#gemscurveanatoolkitpy-input-file)
             * [gemSCurveAnaToolkit.py Example: Making a Plot](#gemscurveanatoolkitpy-example-making-a-plot)
+         * [Comparing Scurves Results Across Scandates: plotSCurveFitResults.py](#comparing-scurves-results-across-scandates-plotscurvefitresultspy)
+            * [plotSCurveFitResults.py Arguments](#plotscurvefitresultspy-arguments)
+            * [plotSCurveFitResults.py Input File](#plotscurvefitresultspy-input-file)
+            * [plotSCurveFitResults.py Example](#plotscurvefitresultspy-example)
 
 Created by [gh-md-toc](https://github.com/ekalinin/github-markdown-toc)
 

--- a/README.md
+++ b/README.md
@@ -427,3 +427,38 @@ gemSCurveAnaToolkit.py -ilistOfScanDates_Scurve.txt -v0 -s29 --anaType=scurveAna
 ```
 
 This will produce a `*.png` file for each of the scandates defined in `listOfScanDates_Scurve.txt` and one `*.png` file showing all the scurves with their fits drawn on it as a summary.  Additionally an output `TFile` will be produced containing each of the scurves and their fits.
+
+### Comparing Scurves Results Across Scandates: plotSCurveFitResults.py
+While `gemTreeDrawWrapper.py` and `gemPlotter.py` allow you to plot observables from multiple runs sometimes you are interested in seeing the results made from `anaUltraScurve.py`, from multiple scandates, on the same set of `TCanvas`es.  The tool `plotSCurveFitResults.py` allows you to do this.  The tool will create five output `*.png` files and one `TFile` which stores relevant plots for each VFAT from each of the input scandates.  These five `*.png` files are:
+
+- `scurveFitSummaryGridAllScandates.png`, shows the `fitSummary` curves from all input scandates on one `TCanvas` in a 3-by-8 grid,
+- `scurveMeanGridAllScandates.png`, shows the distribution of s-curve mean positions from each VFAT from all input scandates on one `TCanvas` in a 3-by-8 grid,
+- `scurveSigmaGridAllScandates.png`, as `scurveMeanGridAllScandates.png` but for s-curve sigma,
+- `canvSCurveSigmaDetSumAllScandates.png`, shows a summary distribution of s-curve sigma positions from all VFATs of the detector from all scandates on one `TCanvas`, and
+- `canvSCurveMeanDetSumAllScandates.png`, as `canvSCurveSigmaDetSumAllScandates.png` but for s-curve mean.
+
+The files will be found in `$ELOG_PATH` along with the output `TFile`, named `scurveFitResultPlots.root`.
+
+#### plotSCurveFitResults.py Arguments
+
+| Name | Type | Description |
+| :--: | :--: | :---------- |
+| `-i`, `--infilename` | string | Physical filename of the input file to be passed to `plotSCurveFitResults.py`.  The format of this input file is the same as for the `gemPlotter.py` tool, see [gemPlotter.py Input File](#gemPlotterpy-input-file) for more details. |
+| `--alphaLabels` | none | When providing this flag `plotSCurveFitResults.py` will interpret the **Indep. Variable** as a string. |
+| `--anaType` | string | Analysis type to be executed, taken from the list {'scurveAna','trimAna'}. |
+| `--drawLeg` | none | Draws a TLegend on the output plots. For those 3x8 grid plots the legend will only be drawn on the plot for VFAT0. |
+| `--rootName` | string | Name of output `TFile`.  This file will be found in `$ELOG_PATH`. |
+| `--rootOpt` | string | Option for creating the output `TFile`, e.g. {'RECREATE','UPDATE'} |
+| `--ztrim` | int | The ztrim value that was used when running the scans listed in `--infilename` |
+
+#### plotSCurveFitResults.py Input File
+The format of this input file is the same as for the `gemPlotter.py` tool, see [gemPlotter.py Input File](#gemplotterpy-input-file) for more details.  Note that here the **Indep. Variable** for each row will be used as the `TLegend` entry if the `--drawLeg` argument is supplied.
+
+#### plotSCurveFitResults.py Example
+To plot results from a set of scandates defined in `listOfScanDates_Scurve.txt` taken by either `ultraScurve.py` or `trimChamber.py` and analyzed with `anaUltraScurve.py` you would call:
+
+```
+plotSCurveFitResults.py --anaType=scurveAna --drawLeg -i listOfScanDates_Scurve.txt --alphaLabels
+```
+
+This will produce the five `*.png` files mentioned above along with the output `TFile`.

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -526,7 +526,11 @@ if __name__ == '__main__':
             histThresh.Sumw2()
             if thisVFAT_ThreshStd != 0: # Don't fill if we still at initial values
                 for thresh in allThresh[(vfat*128):((vfat+1)*128)]:
+                    if thresh == 0: # Skip the case where it still equals the inital value
+                        continue
                     histThresh.Fill(thresh)
+                    pass
+                pass
             gThresh = r.TGraphErrors(histThresh)
             gThresh.SetName("gScurveMeanDist_vfat%i"%vfat)
             gThresh.GetXaxis().SetTitle("scurve mean pos #left(fC#right)")
@@ -541,7 +545,11 @@ if __name__ == '__main__':
             histENC.Sumw2()
             if thisVFAT_ENCStd != 0: # Don't fill if we are still at initial values
                 for enc in allENC[(vfat*128):((vfat+1)*128)]:
+                    if enc == 0: # Skip the case where it still equals the inital value
+                        continue
                     histENC.Fill(enc)
+                    pass
+                pass
             gENC = r.TGraphErrors(histENC)
             gENC.SetName("gScurveSigmaDist_vfat%i"%vfat)
             gENC.GetXaxis().SetTitle("scurve width #left(fC#right)")

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -208,13 +208,13 @@ if __name__ == '__main__':
     # Initialize distributions
     for vfat in range(0,24):
         vSummaryPlots[vfat] = r.TH2D('vSummaryPlots%i'%vfat,
-                'VFAT %i;Channels;VCal [fC]'%vfat,
+                'VFAT %i;Channels;VCal #lef(fC#right)'%vfat,
                 128,-0.5,127.5,256,
                 calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
                 calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
         vSummaryPlots[vfat].GetYaxis().SetTitleOffset(1.5)
         vSummaryPlotsNoMaskedChan[vfat] = r.TH2D('vSummaryPlotsNoMaskedChan%i'%vfat,
-                'VFAT %i;Channels;VCal [fC]'%vfat,
+                'VFAT %i;Channels;VCal #left(fC#right)'%vfat,
                 128,-0.5,127.5,256,
                 calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
                 calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
@@ -225,25 +225,25 @@ if __name__ == '__main__':
             pass
         if options.PanPin:
             vSummaryPlots[vfat] = r.TH2D('vSummaryPlots%i'%vfat,
-                    'VFAT %i_0-63;63 - Panasonic Pin;VCal [fC]'%vfat,
+                    'VFAT %i_0-63;63 - Panasonic Pin;VCal #left(fC#right)'%vfat,
                     64,-0.5,63.5,256,
                     calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
                     calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
             vSummaryPlots[vfat].GetYaxis().SetTitleOffset(1.5)
             vSummaryPlotsNoMaskedChan[vfat] = r.TH2D('vSummaryPlotsNoMaskedChan%i'%vfat,
-                    'VFAT %i_0-63;63 - Panasonic Pin;VCal [fC]'%vfat,
+                    'VFAT %i_0-63;63 - Panasonic Pin;VCal #left(fC#right)'%vfat,
                     64,-0.5,63.5,256,
                     calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
                     calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
             vSummaryPlotsNoMaskedChan[vfat].GetYaxis().SetTitleOffset(1.5)
             vSummaryPlotsPanPin2[vfat] = r.TH2D('vSummaryPlotsPanPin2_%i'%vfat,
-                    'vSummaryPlots%i_64-127;127 - Panasonic Pin;VCal [fC]'%vfat,
+                    'vSummaryPlots%i_64-127;127 - Panasonic Pin;VCal #left(fC#right)'%vfat,
                     64,-0.5,63.5,256,
                     calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
                     calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
             vSummaryPlotsPanPin2[vfat].GetYaxis().SetTitleOffset(1.5)
             vSummaryPlotsNoMaskedChanPanPin2[vfat] = r.TH2D('vSummaryPlotsNoMaskedChanPanPin2_%i'%vfat,
-                    'vSummaryPlots%i_64-127;127 - Panasonic Pin;VCal [fC]'%vfat,
+                    'vSummaryPlots%i_64-127;127 - Panasonic Pin;VCal #left(fC#right)'%vfat,
                     64,-0.5,63.5,256,
                     calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
                     calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
@@ -506,7 +506,7 @@ if __name__ == '__main__':
                     np.zeros(128),
                     allENC[(vfat*128):((vfat+1)*128)]
                     )
-            fitSummaryPlots[vfat].SetTitle("VFAT %i Fit Summary;Channel;Threshold [fC]"%vfat)
+            fitSummaryPlots[vfat].SetTitle("VFAT %i Fit Summary;Channel;Threshold #left(fC#right)"%vfat)
             
             if not (options.channels or options.PanPin):
                 fitSummaryPlots[vfat].GetXaxis().SetTitle("Strip")

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -208,7 +208,7 @@ if __name__ == '__main__':
     # Initialize distributions
     for vfat in range(0,24):
         vSummaryPlots[vfat] = r.TH2D('vSummaryPlots%i'%vfat,
-                'VFAT %i;Channels;VCal #lef(fC#right)'%vfat,
+                'VFAT %i;Channels;VCal #left(fC#right)'%vfat,
                 128,-0.5,127.5,256,
                 calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
                 calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])

--- a/anautilities.py
+++ b/anautilities.py
@@ -40,14 +40,14 @@ def getCyclicColor(idx):
 
     colors = {
         0:r.kBlack,
-        1:r.kRed-1,
-        2:r.kGreen-1,
+        1:r.kGreen-1,
+        2:r.kRed-1,
         3:r.kBlue-1,
-        4:r.kRed-2,
-        5:r.kGreen-2,
+        4:r.kGreen-2,
+        5:r.kRed-2,
         6:r.kBlue-2,
-        7:r.kRed-3,
-        8:r.kGreen-3,
+        7:r.kGreen-3,
+        8:r.kRed-3,
         9:r.kBlue-3,
             }
 

--- a/anautilities.py
+++ b/anautilities.py
@@ -259,6 +259,35 @@ def isOutlierMADOneSided(arrayData, thresh=3.5, rejectHighTail=True):
         else:
             return modified_z_score < -1.0 * thresh
 
+def make2x4Canvas(name, initialContent = None, initialDrawOpt = '', secondaryContent = None, secondaryDrawOpt = '', canv=None):
+    """
+    Creates a 2x4 canvas for summary plots.
+
+    name - TName of output TCanvas
+    initialContent - either None or an array of 24 (one per VFAT) TObjects that will be drawn on the canvas.
+    initialDrawOpt - draw option to be used when drawing elements of initialContent
+    secondaryContent - either None or an array of 24 (one per VFAT) TObjects that will be drawn on top of the canvas.
+    secondaryDrawOpt - draw option to be used when drawing elements of secondaryContent
+    canv - TCanvas previously produced by make3x8Canvas() or one that has been subdivided into a 3x8 grid
+    """
+
+    import ROOT as r
+    
+    if canv is None:
+        canv = r.TCanvas(name,name,500*8,500*3)
+        canv.Divide(4,2)
+
+    if initialContent is not None:
+        for ieta in range(1,9):
+            canv.cd(ieta)
+            initialContent[ieta].Draw(initialDrawOpt)
+    if secondaryContent is not None:
+        for ieta in range(1,9):
+            canv.cd(ieta)
+            secondaryContent[ieta].Draw("same%s"%secondaryDrawOpt)
+    canv.Update()
+    return canv
+
 def make3x8Canvas(name, initialContent = None, initialDrawOpt = '', secondaryContent = None, secondaryDrawOpt = '', canv=None):
     """
     Creates a 3x8 canvas for summary plots.
@@ -396,7 +425,7 @@ def saveSummary(dictSummary, dictSummaryPanPin2=None, name='Summary', trimPt=Non
     Makes an image with summary canvases drawn on it
 
     dictSummary        - dict of TObjects to be drawn, one per VFAT.  Each will be 
-                         drawn on a separate canvas
+                         drawn on a separate pad
     dictSummaryPanPin2 - Optional, as dictSummary but if the independent variable is the
                          readout connector pin this is the other side of the connector
     name               - Name of output image
@@ -440,6 +469,41 @@ def saveSummary(dictSummary, dictSummaryPanPin2=None, name='Summary', trimPt=Non
                 canv.Update()
                 pass
             pass
+        pass
+
+    canv.SaveAs(name)
+
+    return
+
+def saveSummaryByiEta(dictSummary, name='Summary', trimPt=None, drawOpt="colz"):
+    """
+    Makes an image with summary canvases drawn on it
+
+    dictSummary        - dict of TObjects to be drawn, one per ieta.  Each will be 
+                         drawn on a separate pad
+    name               - Name of output image
+    trimPt             - Optional, list of trim points the dependent variable was aligned
+                         to if it is the result of trimming.  One entry per VFAT
+    drawOpt            - Draw option
+    """
+
+    import ROOT as r
+
+    legend = r.TLegend(0.75,0.7,0.88,0.88)
+    r.gStyle.SetOptStat(0)
+    canv = make2x4Canvas(name='canv', initialContent=dictSummary, initialDrawOpt=drawOpt)
+    for ieta in range(0,8):
+        canv.cd(ieta+1)
+        if trimPt is not None and trimLine is not None:
+            trimLine = r.TLine(-0.5, trimVcal[ieta], 127.5, trimVcal[ieta])
+            legend.Clear()
+            legend.AddEntry(trimLine, 'trimVCal is %f'%(trimVcal[vfat]))
+            legend.Draw('SAME')
+            trimLine.SetLineColor(1)
+            trimLine.SetLineWidth(3)
+            trimLine.Draw('SAME')
+            pass
+        canv.Update()
         pass
 
     canv.SaveAs(name)

--- a/macros/plotSCurveFitResults.py
+++ b/macros/plotSCurveFitResults.py
@@ -190,12 +190,6 @@ if __name__ == '__main__':
                 dict_mGraph_ScurveMean[vfat]= r.TMultiGraph("mGraph_ScurveMeanDist_vfat%i"%(vfat),"")
                 dict_mGraph_ScurveSigma[vfat]=r.TMultiGraph("mGraph_ScurveSigmaDist_vfat%i"%(vfat),"")
 
-                dict_mGraph_fitSum[vfat].GetXaxis().SetTitle(dict_fitSum[chamberAndScanDatePair[1]][vfat].GetXaxis().GetTitle())
-                dict_mGraph_fitSum[vfat].GetYaxis().SetTitle("Threshold #left(fC#right)")
-
-                dict_mGraph_ScurveMean[vfat].GetXaxis().SetTitle("scurve mean #left(fC#right)")
-                dict_mGraph_ScurveSigma[vfat].GetXaxis().SetTitle("scurve sigma #left(fC#right)")
-
                 dict_canvSCurveFitSum[vfat] = r.TCanvas("canvScurveFitSum_VFAT%i"%(vfat),"SCurve Fit Summary - VFAT%i"%(vfat),600,600)
                 dict_canvSCurveMean[vfat]   = r.TCanvas("canvScurveMean_VFAT%i"%(vfat),"SCurve Mean - VFAT%i"%(vfat),600,600)
                 dict_canvSCurveSigma[vfat]  = r.TCanvas("canvScurveSigma_VFAT%i"%(vfat),"SCurve Sigma - VFAT%i"%(vfat),600,600)
@@ -206,13 +200,22 @@ if __name__ == '__main__':
             dict_mGraph_ScurveSigma[vfat].Add(dict_ScurveSigma[chamberAndScanDatePair[1]][vfat])
             
             if (idx == (len(listChamberAndScanDate) - 1) ):
+                chanStripOrPanPin = dict_fitSum[chamberAndScanDatePair[1]][vfat].GetXaxis().GetTitle()
+                
                 dict_canvSCurveFitSum[vfat].cd()
+                dict_mGraph_fitSum[vfat].Draw(drawOpt) # The axis doesn't exist unless we draw it first, ROOT magic =/
+                dict_mGraph_fitSum[vfat].GetXaxis().SetTitle(chanStripOrPanPin)
+                dict_mGraph_fitSum[vfat].GetYaxis().SetTitle("Threshold #left(fC#right)")
                 dict_mGraph_fitSum[vfat].Draw(drawOpt)
 
                 dict_canvSCurveMean[vfat].cd()
                 dict_mGraph_ScurveMean[vfat].Draw(drawOpt)
+                dict_mGraph_ScurveMean[vfat].GetXaxis().SetTitle("scurve mean #left(fC#right)")
+                dict_mGraph_ScurveMean[vfat].Draw(drawOpt)
                 
                 dict_canvSCurveSigma[vfat].cd()
+                dict_mGraph_ScurveSigma[vfat].Draw(drawOpt)
+                dict_mGraph_ScurveSigma[vfat].GetXaxis().SetTitle("scurve sigma #left(fC#right)")
                 dict_mGraph_ScurveSigma[vfat].Draw(drawOpt)
                 pass
             pass
@@ -223,9 +226,6 @@ if __name__ == '__main__':
                 dict_mGraph_ScurveMeanByiEta[ieta] = r.TMultiGraph("mGraph_ScurveMeanDist_ieta%i"%(ieta),"")
                 dict_mGraph_ScurveSigmaByiEta[ieta] = r.TMultiGraph("mGraph_ScurveSigmaDist_ieta%i"%(ieta),"")
 
-                dict_mGraph_ScurveMeanByiEta[vfat].GetXaxis().SetTitle("scurve mean #left(fC#right)")
-                dict_mGraph_ScurveSigmaByiEta[vfat].GetXaxis().SetTitle("scurve sigma #left(fC#right)")
-                
                 dict_canvSCurveMeanByiEta[ieta]   = r.TCanvas("canvScurveMean_ieta%i"%(ieta),"SCurve Mean - ieta%i"%(ieta),600,600)
                 dict_canvSCurveSigmaByiEta[ieta]  = r.TCanvas("canvScurveSigma_ieta%i"%(ieta),"SCurve Sigma - ieta%i"%(ieta),600,600)
                 pass
@@ -236,8 +236,12 @@ if __name__ == '__main__':
             if (idx == (len(listChamberAndScanDate) - 1) ):
                 dict_canvSCurveMeanByiEta[ieta].cd()
                 dict_mGraph_ScurveMeanByiEta[ieta].Draw(drawOpt)
+                dict_mGraph_ScurveMeanByiEta[ieta].GetXaxis().SetTitle("scurve mean #left(fC#right)")
+                dict_mGraph_ScurveMeanByiEta[ieta].Draw(drawOpt)
 
                 dict_canvSCurveSigmaByiEta[ieta].cd()
+                dict_mGraph_ScurveSigmaByiEta[ieta].Draw(drawOpt)
+                dict_mGraph_ScurveSigmaByiEta[ieta].GetXaxis().SetTitle("scurve sigma #left(fC#right)")
                 dict_mGraph_ScurveSigmaByiEta[ieta].Draw(drawOpt)
                 pass
             pass

--- a/macros/plotSCurveFitResults.py
+++ b/macros/plotSCurveFitResults.py
@@ -125,6 +125,10 @@ if __name__ == '__main__':
         pass
 
     # Make the plots
+    dict_canvSCurveFitSum = ndict()
+    dict_canvSCurveMean = ndict()
+    dict_canvSCurveSigma = ndict()
+    
     canvFitSum_Grid = None
     canvScurveMean_DetSum = r.TCanvas("canvSCurveMeanDetSumAllScandates","Scurve Mean - Detector Summary",600,600)
     #canvScurveMean_DetSum.cd().SetLogy()
@@ -139,6 +143,24 @@ if __name__ == '__main__':
             drawOpt="APE1"
         else:
             drawOpt="samePE1"
+
+        # Draw per VFAT distributions
+        for vfat in range(0,24):
+            if idx == 0:
+                dict_canvSCurveFitSum[vfat] = r.TCanvas("canvScurveFitSum_VFAT%i"%(vfat),"SCurve Fit Summary - VFAT%i"%(vfat),600,600)
+                dict_canvSCurveMean[vfat]   = r.TCanvas("canvScurveMean_VFAT%i"%(vfat),"SCurve Mean - VFAT%i"%(vfat),600,600)
+                dict_canvSCurveSigma[vfat]  = r.TCanvas("canvScurveSigma_VFAT%i"%(vfat),"SCurve Sigma - VFAT%i"%(vfat),600,600)
+                pass
+
+            dict_canvSCurveFitSum[vfat].cd()
+            dict_fitSum[chamberAndScanDatePair[1]][vfat].Draw(drawOpt)
+            
+            dict_canvSCurveMean[vfat].cd()
+            dict_ScurveMean[chamberAndScanDatePair[1]][vfat].Draw(drawOpt)
+
+            dict_canvSCurveSigma[vfat].cd()
+            dict_ScurveSigma[chamberAndScanDatePair[1]][vfat].Draw(drawOpt)
+            pass
 
         # Draw grid distributions
         canvFitSum_Grid = make3x8Canvas("scurveFitSummaryGridAllScandates",dict_fitSum[chamberAndScanDatePair[1]],drawOpt,canv=canvFitSum_Grid)
@@ -156,6 +178,17 @@ if __name__ == '__main__':
         pass
 
     if options.drawLeg:
+        for vfat in range(0,24):
+            dict_canvSCurveFitSum[vfat].cd()
+            plotLeg.Draw("same")
+            
+            dict_canvSCurveMean[vfat].cd()
+            plotLeg.Draw("same")
+
+            dict_canvSCurveSigma[vfat].cd()
+            plotLeg.Draw("same")
+            pass
+
         canvFitSum_Grid.cd(1)
         plotLeg.Draw("same")
         
@@ -180,9 +213,20 @@ if __name__ == '__main__':
     canvScurveMean_DetSum.SaveAs("%s/%s.png"%(elogPath,canvScurveMean_DetSum.GetName()))
     canvScurveSigma_DetSum.SaveAs("%s/%s.png"%(elogPath,canvScurveSigma_DetSum.GetName()))
 
-    # Save canvas objects in output root file
+    # Save summary canvas objects in output root file
     outF = r.TFile("%s/%s"%(elogPath,options.rootName),options.rootOpt)
-    outF.cd()
+    
+    for vfat in range(0,24):
+        dirVFAT = outF.mkdir("VFAT%i"%(vfat))
+        dirVFAT.cd()
+
+        dict_canvSCurveFitSum[vfat].Write()
+        dict_canvSCurveMean[vfat].Write()
+        dict_canvSCurveSigma[vfat].Write()
+        pass
+
+    dirSummary = outF.mkdir("Summary")
+    dirSummary.cd()
     canvFitSum_Grid.Write()
     canvScurveMean_Grid.Write()
     canvScurveSigma_Grid.Write()
@@ -193,3 +237,9 @@ if __name__ == '__main__':
     print ""
     print "     %s"%elogPath
     print ""
+    
+    print "You can open the output TFile via:"
+    print ""
+    print "     root -l %s/%s"%(elogPath,options.rootName)
+    print ""
+    print "Good-bye"

--- a/macros/plotSCurveFitResults.py
+++ b/macros/plotSCurveFitResults.py
@@ -291,7 +291,6 @@ if __name__ == '__main__':
         pass
 
     dirSummary = outF.mkdir("Summary")
-    dirSummary.cd()
     for ieta in range(1,9):
         dir_iEta = dirSummary.mkdir("ieta%i"%ieta)
         dir_iEta.cd()
@@ -299,6 +298,7 @@ if __name__ == '__main__':
         dict_canvSCurveMeanByiEta[ieta].Write()
         dict_canvSCurveSigmaByiEta[ieta].Write()
 
+    dirSummary.cd()
     canvFitSum_Grid.Write()
     canvScurveMean_Grid.Write()
     canvScurveMean_Grid_iEta.Write()

--- a/macros/plotSCurveFitResults.py
+++ b/macros/plotSCurveFitResults.py
@@ -191,7 +191,7 @@ if __name__ == '__main__':
 
         # Draw per ieta distributions
         for ieta in range(1,9):
-            if idx == 1:
+            if idx == 0:
                 dict_canvSCurveMeanByiEta[ieta]   = r.TCanvas("canvScurveMean_ieta%i"%(ieta),"SCurve Mean - ieta%i"%(ieta),600,600)
                 dict_canvSCurveSigmaByiEta[ieta]  = r.TCanvas("canvScurveSigma_ieta%i"%(ieta),"SCurve Sigma - ieta%i"%(ieta),600,600)
                 pass
@@ -236,10 +236,10 @@ if __name__ == '__main__':
 
         # ieta level
         for ieta in range(1,9):
-            dict_canvSCurveMeanByiEta.cd()
+            dict_canvSCurveMeanByiEta[ieta].cd()
             plotLeg.Draw("same")
 
-            dict_canvSCurveSigmaByiEta.cd()
+            dict_canvSCurveSigmaByiEta[ieta].cd()
             plotLeg.Draw("same")
             pass
 

--- a/macros/plotSCurveFitResults.py
+++ b/macros/plotSCurveFitResults.py
@@ -269,10 +269,18 @@ if __name__ == '__main__':
     canvScurveSigma_Grid_iEta = make2x4Canvas("scurveSigmaGridByiEtaAllScandates",dict_mGraph_ScurveSigmaByiEta,"APE1")
     
     canvScurveMean_DetSum.cd()
+    canvScurveMean_DetSum.cd().SetLogy()
     dict_mGraph_ScurveMean[-1].Draw("APE1")
+    #dict_mGraph_ScurveMean[-1].GetXaxis().SetRangeUser(0,40)
+    #dict_mGraph_ScurveMean[-1].GetYaxis().SetRangeUser(1e-1,1e3)
+    #dict_mGraph_ScurveMean[-1].Draw("APE1")
 
     canvScurveSigma_DetSum.cd()
+    canvScurveSigma_DetSum.cd().SetLogy()
     dict_mGraph_ScurveSigma[-1].Draw("APE1")
+    #dict_mGraph_ScurveSigma[-1].GetXaxis().SetRangeUser(0,5)
+    #dict_mGraph_ScurveSigma[-1].GetYaxis().SetRangeUser(1e-1,1e3)
+    #dict_mGraph_ScurveSigma[-1].Draw("APE1")
 
     if options.drawLeg:
         # VFAT level

--- a/macros/plotSCurveFitResults.py
+++ b/macros/plotSCurveFitResults.py
@@ -138,7 +138,7 @@ if __name__ == '__main__':
         dict_ScurveMean[chamberAndScanDatePair[1]][-1].SetLineColor(getCyclicColor(idx))
         dict_ScurveMean[chamberAndScanDatePair[1]][-1].SetMarkerColor(getCyclicColor(idx))
 
-        dict_ScurveSigma[chamberAndScanDatePair[1]][-1] = scanFile.Get("Summary/gScurveMeanDist_All")
+        dict_ScurveSigma[chamberAndScanDatePair[1]][-1] = scanFile.Get("Summary/gScurveSigmaDist_All")
         dict_ScurveSigma[chamberAndScanDatePair[1]][-1].SetName(
                     "%s_%s"%(
                         dict_ScurveSigma[chamberAndScanDatePair[1]][-1].GetName(),
@@ -149,77 +149,101 @@ if __name__ == '__main__':
         
         pass
 
-    # Make the plots
+    # Define the TMultiGraph dictionaries
+    dict_mGraph_fitSum = ndict()        # key: (0,23) follows vfat #
+    dict_mGraph_ScurveMean = ndict()    # key: (0,23) follows vfat #, -1 is summary over all det
+    dict_mGraph_ScurveSigma = ndict()   # key: (0,23) follows vfat #, -1 is summary over all det
+   
+    dict_mGraph_ScurveMean[-1] = r.TMultiGraph("mGraph_ScurveMeanDist_All","")
+    dict_mGraph_ScurveSigma[-1] = r.TMultiGraph("mGraph_ScurveSigmaDist_All","")
+
+    dict_mGraph_ScurveMeanByiEta = ndict()
+    dict_mGraph_ScurveSigmaByiEta = ndict() 
+    
+    # Make the canvas dictionaries
     dict_canvSCurveFitSum = ndict()
     dict_canvSCurveMean = ndict()
     dict_canvSCurveMeanByiEta = ndict()
     dict_canvSCurveSigma = ndict()
     dict_canvSCurveSigmaByiEta = ndict()
     
-    canvFitSum_Grid = None
+    # Make the summary canvases
     canvScurveMean_DetSum = r.TCanvas("canvSCurveMeanDetSumAllScandates","Scurve Mean - Detector Summary",600,600)
-    canvScurveMean_Grid = None
-    canvScurveMean_Grid_iEta = None
     canvScurveSigma_DetSum = r.TCanvas("canvSCurveSigmaDetSumAllScandates","Scurve Sigma - Detector Summary",600,600)
-    canvScurveSigma_Grid = None
-    canvScurveSigma_Grid_iEta = None
     plotLeg = r.TLegend(0.1,0.65,0.45,0.9)
     for idx,chamberAndScanDatePair in enumerate(listChamberAndScanDate):
-        # Determine draw option
-        if idx==0:
-            drawOpt="APE1"
-        else:
-            drawOpt="samePE1"
+        drawOpt="APE1"
 
         # Draw per VFAT distributions
         for vfat in range(0,24):
             if idx == 0:
+                dict_mGraph_fitSum[vfat]    = r.TMultiGraph("mGraph_FitSummary_VFAT%i"%(vfat),"")
+                dict_mGraph_ScurveMean[vfat]= r.TMultiGraph("mGraph_ScurveMeanDist_vfat%i"%(vfat),"")
+                dict_mGraph_ScurveSigma[vfat]=r.TMultiGraph("mGraph_ScurveSigmaDist_vfat%i"%(vfat),"")
+
                 dict_canvSCurveFitSum[vfat] = r.TCanvas("canvScurveFitSum_VFAT%i"%(vfat),"SCurve Fit Summary - VFAT%i"%(vfat),600,600)
                 dict_canvSCurveMean[vfat]   = r.TCanvas("canvScurveMean_VFAT%i"%(vfat),"SCurve Mean - VFAT%i"%(vfat),600,600)
                 dict_canvSCurveSigma[vfat]  = r.TCanvas("canvScurveSigma_VFAT%i"%(vfat),"SCurve Sigma - VFAT%i"%(vfat),600,600)
                 pass
 
-            dict_canvSCurveFitSum[vfat].cd()
-            dict_fitSum[chamberAndScanDatePair[1]][vfat].Draw(drawOpt)
+            dict_mGraph_fitSum[vfat].Add(dict_fitSum[chamberAndScanDatePair[1]][vfat])
+            dict_mGraph_ScurveMean[vfat].Add(dict_ScurveMean[chamberAndScanDatePair[1]][vfat])
+            dict_mGraph_ScurveSigma[vfat].Add(dict_ScurveSigma[chamberAndScanDatePair[1]][vfat])
             
-            dict_canvSCurveMean[vfat].cd()
-            dict_ScurveMean[chamberAndScanDatePair[1]][vfat].Draw(drawOpt)
+            if (idx == (len(listChamberAndScanDate) - 1) ):
+                dict_canvSCurveFitSum[vfat].cd()
+                dict_mGraph_fitSum[vfat].Draw(drawOpt)
 
-            dict_canvSCurveSigma[vfat].cd()
-            dict_ScurveSigma[chamberAndScanDatePair[1]][vfat].Draw(drawOpt)
+                dict_canvSCurveMean[vfat].cd()
+                dict_mGraph_ScurveMean[vfat].Draw(drawOpt)
+                
+                dict_canvSCurveSigma[vfat].cd()
+                dict_mGraph_ScurveSigma[vfat].Draw(drawOpt)
+                pass
             pass
 
         # Draw per ieta distributions
         for ieta in range(1,9):
             if idx == 0:
+                dict_mGraph_ScurveMeanByiEta[ieta] = r.TMultiGraph("mGraph_ScurveMeanDist_ieta%i"%(ieta),"")
+                dict_mGraph_ScurveSigmaByiEta[ieta] = r.TMultiGraph("mGraph_ScurveSigmaDist_ieta%i"%(ieta),"")
+
                 dict_canvSCurveMeanByiEta[ieta]   = r.TCanvas("canvScurveMean_ieta%i"%(ieta),"SCurve Mean - ieta%i"%(ieta),600,600)
                 dict_canvSCurveSigmaByiEta[ieta]  = r.TCanvas("canvScurveSigma_ieta%i"%(ieta),"SCurve Sigma - ieta%i"%(ieta),600,600)
                 pass
 
-            dict_canvSCurveMeanByiEta[ieta].cd()
-            dict_ScurveMeanByiEta[chamberAndScanDatePair[1]][ieta].Draw(drawOpt)
+            dict_mGraph_ScurveMeanByiEta[ieta].Add(dict_ScurveMeanByiEta[chamberAndScanDatePair[1]][ieta])
+            dict_mGraph_ScurveSigmaByiEta[ieta].Add(dict_ScurveSigmaByiEta[chamberAndScanDatePair[1]][ieta])
 
-            dict_canvSCurveSigmaByiEta[ieta].cd()
-            dict_ScurveSigmaByiEta[chamberAndScanDatePair[1]][ieta].Draw(drawOpt)
+            if (idx == (len(listChamberAndScanDate) - 1) ):
+                dict_canvSCurveMeanByiEta[ieta].cd()
+                dict_mGraph_ScurveMeanByiEta[ieta].Draw(drawOpt)
+
+                dict_canvSCurveSigmaByiEta[ieta].cd()
+                dict_mGraph_ScurveSigmaByiEta[ieta].Draw(drawOpt)
+                pass
             pass
 
-        # Draw grid distributions
-        canvFitSum_Grid = make3x8Canvas("scurveFitSummaryGridAllScandates",dict_fitSum[chamberAndScanDatePair[1]],drawOpt,canv=canvFitSum_Grid)
-        canvScurveMean_Grid = make3x8Canvas("scurveMeanGridAllScandates",dict_ScurveMean[chamberAndScanDatePair[1]],drawOpt,canv=canvScurveMean_Grid)
-        canvScurveSigma_Grid = make3x8Canvas("scurveSigmaGridAllScandates",dict_ScurveSigma[chamberAndScanDatePair[1]],drawOpt,canv=canvScurveSigma_Grid)
-
-        canvScurveMean_Grid_iEta = make2x4Canvas("scurveMeanGridByiEtaAllScandates",dict_ScurveMeanByiEta[chamberAndScanDatePair[1]],drawOpt,canv=canvScurveMean_Grid_iEta)
-        canvScurveSigma_Grid_iEta = make2x4Canvas("scurveSigmaGridByiEtaAllScandates",dict_ScurveSigmaByiEta[chamberAndScanDatePair[1]],drawOpt,canv=canvScurveSigma_Grid_iEta)
-
-        # Draw detector summary distributions
-        canvScurveMean_DetSum.cd()
-        dict_ScurveMean[chamberAndScanDatePair[1]][-1].Draw(drawOpt)
-        canvScurveSigma_DetSum.cd()
-        dict_ScurveSigma[chamberAndScanDatePair[1]][-1].Draw(drawOpt)
+        dict_mGraph_ScurveMean[-1].Add(dict_ScurveMean[chamberAndScanDatePair[1]][-1])
+        dict_mGraph_ScurveSigma[-1].Add(dict_ScurveSigma[chamberAndScanDatePair[1]][-1])
 
         # Fill Legend - use VFAT0 of each
         plotLeg.AddEntry(dict_fitSum[chamberAndScanDatePair[1]][0],chamberAndScanDatePair[2],"LPE")
         pass
+
+    # Draw multigraphs for summary cases
+    canvFitSum_Grid = make3x8Canvas("scurveFitSummaryGridAllScandates",dict_mGraph_fitSum,"APE1")
+    canvScurveMean_Grid = make3x8Canvas("scurveMeanGridAllScandates",dict_mGraph_ScurveMean,"APE1")
+    canvScurveSigma_Grid = make3x8Canvas("scurveSigmaGridAllScandates",dict_mGraph_ScurveSigma,"APE1")
+
+    canvScurveMean_Grid_iEta = make2x4Canvas("scurveMeanGridByiEtaAllScandates",dict_mGraph_ScurveMeanByiEta,"APE1")
+    canvScurveSigma_Grid_iEta = make2x4Canvas("scurveSigmaGridByiEtaAllScandates",dict_mGraph_ScurveSigmaByiEta,"APE1")
+    
+    canvScurveMean_DetSum.cd()
+    dict_mGraph_ScurveMean[-1].Draw("APE1")
+
+    canvScurveSigma_DetSum.cd()
+    dict_mGraph_ScurveSigma[-1].Draw("APE1")
 
     if options.drawLeg:
         # VFAT level
@@ -286,8 +310,13 @@ if __name__ == '__main__':
         dirVFAT.cd()
 
         dict_canvSCurveFitSum[vfat].Write()
+        dict_mGraph_fitSum[vfat].Write()
+
         dict_canvSCurveMean[vfat].Write()
+        dict_mGraph_ScurveMean[vfat].Write()
+
         dict_canvSCurveSigma[vfat].Write()
+        dict_mGraph_ScurveSigma[vfat].Write()
         pass
 
     dirSummary = outF.mkdir("Summary")
@@ -296,7 +325,11 @@ if __name__ == '__main__':
         dir_iEta.cd()
 
         dict_canvSCurveMeanByiEta[ieta].Write()
+        dict_mGraph_ScurveMeanByiEta[ieta].Write()
+
         dict_canvSCurveSigmaByiEta[ieta].Write()
+        dict_mGraph_ScurveSigmaByiEta[ieta].Write()
+        pass
 
     dirSummary.cd()
     canvFitSum_Grid.Write()
@@ -305,7 +338,9 @@ if __name__ == '__main__':
     canvScurveSigma_Grid.Write()
     canvScurveSigma_Grid_iEta.Write()
     canvScurveMean_DetSum.Write()
+    dict_mGraph_ScurveMean[-1].Write()
     canvScurveSigma_DetSum.Write()
+    dict_mGraph_ScurveSigma[-1].Write()
 
     print "Your plots can be found in:"
     print ""

--- a/macros/plotSCurveFitResults.py
+++ b/macros/plotSCurveFitResults.py
@@ -83,6 +83,7 @@ if __name__ == '__main__':
                     )
             dict_fitSum[chamberAndScanDatePair[1]][vfat].SetLineColor(getCyclicColor(idx))
             dict_fitSum[chamberAndScanDatePair[1]][vfat].SetMarkerColor(getCyclicColor(idx))
+            dict_fitSum[chamberAndScanDatePair[1]][vfat].SetMarkerStyle(20+idx)
 
             # Scurve Mean
             dict_ScurveMean[chamberAndScanDatePair[1]][vfat] = scanFile.Get("VFAT%i/gScurveMeanDist_vfat%i"%(vfat,vfat))
@@ -93,6 +94,7 @@ if __name__ == '__main__':
                     )
             dict_ScurveMean[chamberAndScanDatePair[1]][vfat].SetLineColor(getCyclicColor(idx))
             dict_ScurveMean[chamberAndScanDatePair[1]][vfat].SetMarkerColor(getCyclicColor(idx))
+            dict_ScurveMean[chamberAndScanDatePair[1]][vfat].SetMarkerStyle(20+idx)
             
             # Scurve Width
             dict_ScurveSigma[chamberAndScanDatePair[1]][vfat] = scanFile.Get("VFAT%i/gScurveSigmaDist_vfat%i"%(vfat,vfat))
@@ -103,6 +105,7 @@ if __name__ == '__main__':
                     )
             dict_ScurveSigma[chamberAndScanDatePair[1]][vfat].SetLineColor(getCyclicColor(idx))
             dict_ScurveSigma[chamberAndScanDatePair[1]][vfat].SetMarkerColor(getCyclicColor(idx))
+            dict_ScurveSigma[chamberAndScanDatePair[1]][vfat].SetMarkerStyle(20+idx)
 
             pass
 
@@ -116,6 +119,7 @@ if __name__ == '__main__':
                     )
             dict_ScurveMeanByiEta[chamberAndScanDatePair[1]][ieta].SetLineColor(getCyclicColor(idx))
             dict_ScurveMeanByiEta[chamberAndScanDatePair[1]][ieta].SetMarkerColor(getCyclicColor(idx))
+            dict_ScurveMeanByiEta[chamberAndScanDatePair[1]][ieta].SetMarkerStyle(20+idx)
 
             # Scurve Sigma
             dict_ScurveSigmaByiEta[chamberAndScanDatePair[1]][ieta] = scanFile.Get("Summary/ieta%i/gScurveSigmaDist_ieta%i"%(ieta,ieta))
@@ -126,6 +130,7 @@ if __name__ == '__main__':
                     )
             dict_ScurveSigmaByiEta[chamberAndScanDatePair[1]][ieta].SetLineColor(getCyclicColor(idx))
             dict_ScurveSigmaByiEta[chamberAndScanDatePair[1]][ieta].SetMarkerColor(getCyclicColor(idx))
+            dict_ScurveSigmaByiEta[chamberAndScanDatePair[1]][ieta].SetMarkerStyle(20+idx)
             pass
 
         # Get the detector level plots
@@ -137,6 +142,7 @@ if __name__ == '__main__':
                 )
         dict_ScurveMean[chamberAndScanDatePair[1]][-1].SetLineColor(getCyclicColor(idx))
         dict_ScurveMean[chamberAndScanDatePair[1]][-1].SetMarkerColor(getCyclicColor(idx))
+        dict_ScurveMean[chamberAndScanDatePair[1]][-1].SetMarkerStyle(20+idx)
 
         dict_ScurveSigma[chamberAndScanDatePair[1]][-1] = scanFile.Get("Summary/gScurveSigmaDist_All")
         dict_ScurveSigma[chamberAndScanDatePair[1]][-1].SetName(
@@ -146,7 +152,7 @@ if __name__ == '__main__':
                 )
         dict_ScurveSigma[chamberAndScanDatePair[1]][-1].SetLineColor(getCyclicColor(idx))
         dict_ScurveSigma[chamberAndScanDatePair[1]][-1].SetMarkerColor(getCyclicColor(idx))
-        
+        dict_ScurveSigma[chamberAndScanDatePair[1]][-1].SetMarkerStyle(20+idx)
         pass
 
     # Define the TMultiGraph dictionaries
@@ -155,7 +161,10 @@ if __name__ == '__main__':
     dict_mGraph_ScurveSigma = ndict()   # key: (0,23) follows vfat #, -1 is summary over all det
    
     dict_mGraph_ScurveMean[-1] = r.TMultiGraph("mGraph_ScurveMeanDist_All","")
+    dict_mGraph_ScurveMean[-1].GetXaxis().SetTitle("scurve mean #left(fC#right)")
+
     dict_mGraph_ScurveSigma[-1] = r.TMultiGraph("mGraph_ScurveSigmaDist_All","")
+    dict_mGraph_ScurveSigma[-1].GetXaxis().SetTitle("scurve sigma #left(fC#right)")
 
     dict_mGraph_ScurveMeanByiEta = ndict()
     dict_mGraph_ScurveSigmaByiEta = ndict() 
@@ -180,6 +189,12 @@ if __name__ == '__main__':
                 dict_mGraph_fitSum[vfat]    = r.TMultiGraph("mGraph_FitSummary_VFAT%i"%(vfat),"")
                 dict_mGraph_ScurveMean[vfat]= r.TMultiGraph("mGraph_ScurveMeanDist_vfat%i"%(vfat),"")
                 dict_mGraph_ScurveSigma[vfat]=r.TMultiGraph("mGraph_ScurveSigmaDist_vfat%i"%(vfat),"")
+
+                dict_mGraph_fitSum[vfat].GetXaxis().SetTitle(dict_fitSum[chamberAndScanDatePair[1]][vfat].GetXaxis().GetTitle())
+                dict_mGraph_fitSum[vfat].GetYaxis().SetTitle("Threshold #left(fC#right)")
+
+                dict_mGraph_ScurveMean[vfat].GetXaxis().SetTitle("scurve mean #left(fC#right)")
+                dict_mGraph_ScurveSigma[vfat].GetXaxis().SetTitle("scurve sigma #left(fC#right)")
 
                 dict_canvSCurveFitSum[vfat] = r.TCanvas("canvScurveFitSum_VFAT%i"%(vfat),"SCurve Fit Summary - VFAT%i"%(vfat),600,600)
                 dict_canvSCurveMean[vfat]   = r.TCanvas("canvScurveMean_VFAT%i"%(vfat),"SCurve Mean - VFAT%i"%(vfat),600,600)
@@ -208,6 +223,9 @@ if __name__ == '__main__':
                 dict_mGraph_ScurveMeanByiEta[ieta] = r.TMultiGraph("mGraph_ScurveMeanDist_ieta%i"%(ieta),"")
                 dict_mGraph_ScurveSigmaByiEta[ieta] = r.TMultiGraph("mGraph_ScurveSigmaDist_ieta%i"%(ieta),"")
 
+                dict_mGraph_ScurveMeanByiEta[vfat].GetXaxis().SetTitle("scurve mean #left(fC#right)")
+                dict_mGraph_ScurveSigmaByiEta[vfat].GetXaxis().SetTitle("scurve sigma #left(fC#right)")
+                
                 dict_canvSCurveMeanByiEta[ieta]   = r.TCanvas("canvScurveMean_ieta%i"%(ieta),"SCurve Mean - ieta%i"%(ieta),600,600)
                 dict_canvSCurveSigmaByiEta[ieta]  = r.TCanvas("canvScurveSigma_ieta%i"%(ieta),"SCurve Sigma - ieta%i"%(ieta),600,600)
                 pass

--- a/macros/plotSCurveFitResults.py
+++ b/macros/plotSCurveFitResults.py
@@ -193,9 +193,9 @@ if __name__ == '__main__':
         # Draw per VFAT distributions
         for vfat in range(0,24):
             if idx == 0:
-                dict_mGraph_fitSum[vfat]    = r.TMultiGraph("mGraph_FitSummary_VFAT%i"%(vfat),"")
-                dict_mGraph_ScurveMean[vfat]= r.TMultiGraph("mGraph_ScurveMeanDist_vfat%i"%(vfat),"")
-                dict_mGraph_ScurveSigma[vfat]=r.TMultiGraph("mGraph_ScurveSigmaDist_vfat%i"%(vfat),"")
+                dict_mGraph_fitSum[vfat]    = r.TMultiGraph("mGraph_FitSummary_VFAT%i"%(vfat),"VFAT%i"%(vfat))
+                dict_mGraph_ScurveMean[vfat]= r.TMultiGraph("mGraph_ScurveMeanDist_vfat%i"%(vfat),"VFAT%i"%(vfat))
+                dict_mGraph_ScurveSigma[vfat]=r.TMultiGraph("mGraph_ScurveSigmaDist_vfat%i"%(vfat),"VFAT%i"%(vfat))
 
                 dict_canvSCurveFitSum[vfat] = r.TCanvas("canvScurveFitSum_VFAT%i"%(vfat),"SCurve Fit Summary - VFAT%i"%(vfat),600,600)
                 dict_canvSCurveMean[vfat]   = r.TCanvas("canvScurveMean_VFAT%i"%(vfat),"SCurve Mean - VFAT%i"%(vfat),600,600)
@@ -230,8 +230,8 @@ if __name__ == '__main__':
         # Draw per ieta distributions
         for ieta in range(1,9):
             if idx == 0:
-                dict_mGraph_ScurveMeanByiEta[ieta] = r.TMultiGraph("mGraph_ScurveMeanDist_ieta%i"%(ieta),"")
-                dict_mGraph_ScurveSigmaByiEta[ieta] = r.TMultiGraph("mGraph_ScurveSigmaDist_ieta%i"%(ieta),"")
+                dict_mGraph_ScurveMeanByiEta[ieta] = r.TMultiGraph("mGraph_ScurveMeanDist_ieta%i"%(ieta),"i#eta = %i"%(ieta))
+                dict_mGraph_ScurveSigmaByiEta[ieta] = r.TMultiGraph("mGraph_ScurveSigmaDist_ieta%i"%(ieta),"i#eta = %i"%(ieta))
 
                 dict_canvSCurveMeanByiEta[ieta]   = r.TCanvas("canvScurveMean_ieta%i"%(ieta),"SCurve Mean - ieta%i"%(ieta),600,600)
                 dict_canvSCurveSigmaByiEta[ieta]  = r.TCanvas("canvScurveSigma_ieta%i"%(ieta),"SCurve Sigma - ieta%i"%(ieta),600,600)

--- a/macros/plotSCurveFitResults.py
+++ b/macros/plotSCurveFitResults.py
@@ -48,7 +48,7 @@ if __name__ == '__main__':
     listChamberAndScanDate = parsedTuple[0]
 
     # Define nested dictioniaries
-    #   Outer key -> scandate
+    #   Outer key -> (chamberName,scandate) tuple
     #   Inner key -> vfat position
     dict_fitSum = ndict()
     dict_ScurveMean = ndict() # Inner key: (0,23) follows vfat #, -1 is summary over all det
@@ -75,91 +75,91 @@ if __name__ == '__main__':
         # Get all plots from scanFile - vfat level
         for vfat in range(0,24):
             # Fit summary 
-            dict_fitSum[chamberAndScanDatePair[1]][vfat] = scanFile.Get("VFAT%i/gFitSummary_VFAT%i"%(vfat,vfat))
-            dict_fitSum[chamberAndScanDatePair[1]][vfat].SetName(
+            dict_fitSum[chamberAndScanDatePair][vfat] = scanFile.Get("VFAT%i/gFitSummary_VFAT%i"%(vfat,vfat))
+            dict_fitSum[chamberAndScanDatePair][vfat].SetName(
                     "%s_%s_%s"%(
-                        dict_fitSum[chamberAndScanDatePair[1]][vfat].GetName(),
-                        chamberAndScanDatePair[0]),
+                        dict_fitSum[chamberAndScanDatePair][vfat].GetName(),
+                        chamberAndScanDatePair[0],
                         chamberAndScanDatePair[1])
                     )
-            dict_fitSum[chamberAndScanDatePair[1]][vfat].SetLineColor(getCyclicColor(idx))
-            dict_fitSum[chamberAndScanDatePair[1]][vfat].SetMarkerColor(getCyclicColor(idx))
-            dict_fitSum[chamberAndScanDatePair[1]][vfat].SetMarkerStyle(20+idx)
+            dict_fitSum[chamberAndScanDatePair][vfat].SetLineColor(getCyclicColor(idx))
+            dict_fitSum[chamberAndScanDatePair][vfat].SetMarkerColor(getCyclicColor(idx))
+            dict_fitSum[chamberAndScanDatePair][vfat].SetMarkerStyle(20+idx)
 
             # Scurve Mean
-            dict_ScurveMean[chamberAndScanDatePair[1]][vfat] = scanFile.Get("VFAT%i/gScurveMeanDist_vfat%i"%(vfat,vfat))
-            dict_ScurveMean[chamberAndScanDatePair[1]][vfat].SetName(
+            dict_ScurveMean[chamberAndScanDatePair][vfat] = scanFile.Get("VFAT%i/gScurveMeanDist_vfat%i"%(vfat,vfat))
+            dict_ScurveMean[chamberAndScanDatePair][vfat].SetName(
                     "%s_%s_%s"%(
-                        dict_ScurveMean[chamberAndScanDatePair[1]][vfat].GetName(),
-                        chamberAndScanDatePair[0]),
+                        dict_ScurveMean[chamberAndScanDatePair][vfat].GetName(),
+                        chamberAndScanDatePair[0],
                         chamberAndScanDatePair[1])
                     )
-            dict_ScurveMean[chamberAndScanDatePair[1]][vfat].SetLineColor(getCyclicColor(idx))
-            dict_ScurveMean[chamberAndScanDatePair[1]][vfat].SetMarkerColor(getCyclicColor(idx))
-            dict_ScurveMean[chamberAndScanDatePair[1]][vfat].SetMarkerStyle(20+idx)
+            dict_ScurveMean[chamberAndScanDatePair][vfat].SetLineColor(getCyclicColor(idx))
+            dict_ScurveMean[chamberAndScanDatePair][vfat].SetMarkerColor(getCyclicColor(idx))
+            dict_ScurveMean[chamberAndScanDatePair][vfat].SetMarkerStyle(20+idx)
             
             # Scurve Width
-            dict_ScurveSigma[chamberAndScanDatePair[1]][vfat] = scanFile.Get("VFAT%i/gScurveSigmaDist_vfat%i"%(vfat,vfat))
-            dict_ScurveSigma[chamberAndScanDatePair[1]][vfat].SetName(
+            dict_ScurveSigma[chamberAndScanDatePair][vfat] = scanFile.Get("VFAT%i/gScurveSigmaDist_vfat%i"%(vfat,vfat))
+            dict_ScurveSigma[chamberAndScanDatePair][vfat].SetName(
                     "%s_%s_%s"%(
-                        dict_ScurveSigma[chamberAndScanDatePair[1]][vfat].GetName(),
-                        chamberAndScanDatePair[0]),
+                        dict_ScurveSigma[chamberAndScanDatePair][vfat].GetName(),
+                        chamberAndScanDatePair[0],
                         chamberAndScanDatePair[1])
                     )
-            dict_ScurveSigma[chamberAndScanDatePair[1]][vfat].SetLineColor(getCyclicColor(idx))
-            dict_ScurveSigma[chamberAndScanDatePair[1]][vfat].SetMarkerColor(getCyclicColor(idx))
-            dict_ScurveSigma[chamberAndScanDatePair[1]][vfat].SetMarkerStyle(20+idx)
+            dict_ScurveSigma[chamberAndScanDatePair][vfat].SetLineColor(getCyclicColor(idx))
+            dict_ScurveSigma[chamberAndScanDatePair][vfat].SetMarkerColor(getCyclicColor(idx))
+            dict_ScurveSigma[chamberAndScanDatePair][vfat].SetMarkerStyle(20+idx)
 
             pass
 
         for ieta in range(1,9):
             # Scurve Mean
-            dict_ScurveMeanByiEta[chamberAndScanDatePair[1]][ieta] = scanFile.Get("Summary/ieta%i/gScurveMeanDist_ieta%i"%(ieta,ieta))
-            dict_ScurveMeanByiEta[chamberAndScanDatePair[1]][ieta].SetName(
+            dict_ScurveMeanByiEta[chamberAndScanDatePair][ieta] = scanFile.Get("Summary/ieta%i/gScurveMeanDist_ieta%i"%(ieta,ieta))
+            dict_ScurveMeanByiEta[chamberAndScanDatePair][ieta].SetName(
                     "%s_%s_%s"%(
-                        dict_ScurveMeanByiEta[chamberAndScanDatePair[1]][ieta].GetName(),
-                        chamberAndScanDatePair[0]),
+                        dict_ScurveMeanByiEta[chamberAndScanDatePair][ieta].GetName(),
+                        chamberAndScanDatePair[0],
                         chamberAndScanDatePair[1])
                     )
-            dict_ScurveMeanByiEta[chamberAndScanDatePair[1]][ieta].SetLineColor(getCyclicColor(idx))
-            dict_ScurveMeanByiEta[chamberAndScanDatePair[1]][ieta].SetMarkerColor(getCyclicColor(idx))
-            dict_ScurveMeanByiEta[chamberAndScanDatePair[1]][ieta].SetMarkerStyle(20+idx)
+            dict_ScurveMeanByiEta[chamberAndScanDatePair][ieta].SetLineColor(getCyclicColor(idx))
+            dict_ScurveMeanByiEta[chamberAndScanDatePair][ieta].SetMarkerColor(getCyclicColor(idx))
+            dict_ScurveMeanByiEta[chamberAndScanDatePair][ieta].SetMarkerStyle(20+idx)
 
             # Scurve Sigma
-            dict_ScurveSigmaByiEta[chamberAndScanDatePair[1]][ieta] = scanFile.Get("Summary/ieta%i/gScurveSigmaDist_ieta%i"%(ieta,ieta))
-            dict_ScurveSigmaByiEta[chamberAndScanDatePair[1]][ieta].SetName(
+            dict_ScurveSigmaByiEta[chamberAndScanDatePair][ieta] = scanFile.Get("Summary/ieta%i/gScurveSigmaDist_ieta%i"%(ieta,ieta))
+            dict_ScurveSigmaByiEta[chamberAndScanDatePair][ieta].SetName(
                     "%s_%s_%s"%(
-                        dict_ScurveSigmaByiEta[chamberAndScanDatePair[1]][ieta].GetName(),
-                        chamberAndScanDatePair[0]),
+                        dict_ScurveSigmaByiEta[chamberAndScanDatePair][ieta].GetName(),
+                        chamberAndScanDatePair[0],
                         chamberAndScanDatePair[1])
                     )
-            dict_ScurveSigmaByiEta[chamberAndScanDatePair[1]][ieta].SetLineColor(getCyclicColor(idx))
-            dict_ScurveSigmaByiEta[chamberAndScanDatePair[1]][ieta].SetMarkerColor(getCyclicColor(idx))
-            dict_ScurveSigmaByiEta[chamberAndScanDatePair[1]][ieta].SetMarkerStyle(20+idx)
+            dict_ScurveSigmaByiEta[chamberAndScanDatePair][ieta].SetLineColor(getCyclicColor(idx))
+            dict_ScurveSigmaByiEta[chamberAndScanDatePair][ieta].SetMarkerColor(getCyclicColor(idx))
+            dict_ScurveSigmaByiEta[chamberAndScanDatePair][ieta].SetMarkerStyle(20+idx)
             pass
 
         # Get the detector level plots
-        dict_ScurveMean[chamberAndScanDatePair[1]][-1] = scanFile.Get("Summary/gScurveMeanDist_All")
-        dict_ScurveMean[chamberAndScanDatePair[1]][-1].SetName(
+        dict_ScurveMean[chamberAndScanDatePair][-1] = scanFile.Get("Summary/gScurveMeanDist_All")
+        dict_ScurveMean[chamberAndScanDatePair][-1].SetName(
                     "%s_%s_%s"%(
-                        dict_ScurveMean[chamberAndScanDatePair[1]][-1].GetName(),
-                        chamberAndScanDatePair[0]),
+                        dict_ScurveMean[chamberAndScanDatePair][-1].GetName(),
+                        chamberAndScanDatePair[0],
                         chamberAndScanDatePair[1])
                 )
-        dict_ScurveMean[chamberAndScanDatePair[1]][-1].SetLineColor(getCyclicColor(idx))
-        dict_ScurveMean[chamberAndScanDatePair[1]][-1].SetMarkerColor(getCyclicColor(idx))
-        dict_ScurveMean[chamberAndScanDatePair[1]][-1].SetMarkerStyle(20+idx)
+        dict_ScurveMean[chamberAndScanDatePair][-1].SetLineColor(getCyclicColor(idx))
+        dict_ScurveMean[chamberAndScanDatePair][-1].SetMarkerColor(getCyclicColor(idx))
+        dict_ScurveMean[chamberAndScanDatePair][-1].SetMarkerStyle(20+idx)
 
-        dict_ScurveSigma[chamberAndScanDatePair[1]][-1] = scanFile.Get("Summary/gScurveSigmaDist_All")
-        dict_ScurveSigma[chamberAndScanDatePair[1]][-1].SetName(
+        dict_ScurveSigma[chamberAndScanDatePair][-1] = scanFile.Get("Summary/gScurveSigmaDist_All")
+        dict_ScurveSigma[chamberAndScanDatePair][-1].SetName(
                     "%s_%s_%s"%(
-                        dict_ScurveSigma[chamberAndScanDatePair[1]][-1].GetName(),
-                        chamberAndScanDatePair[0]),
+                        dict_ScurveSigma[chamberAndScanDatePair][-1].GetName(),
+                        chamberAndScanDatePair[0],
                         chamberAndScanDatePair[1])
                 )
-        dict_ScurveSigma[chamberAndScanDatePair[1]][-1].SetLineColor(getCyclicColor(idx))
-        dict_ScurveSigma[chamberAndScanDatePair[1]][-1].SetMarkerColor(getCyclicColor(idx))
-        dict_ScurveSigma[chamberAndScanDatePair[1]][-1].SetMarkerStyle(20+idx)
+        dict_ScurveSigma[chamberAndScanDatePair][-1].SetLineColor(getCyclicColor(idx))
+        dict_ScurveSigma[chamberAndScanDatePair][-1].SetMarkerColor(getCyclicColor(idx))
+        dict_ScurveSigma[chamberAndScanDatePair][-1].SetMarkerStyle(20+idx)
         pass
 
     # Define the TMultiGraph dictionaries
@@ -202,12 +202,12 @@ if __name__ == '__main__':
                 dict_canvSCurveSigma[vfat]  = r.TCanvas("canvScurveSigma_VFAT%i"%(vfat),"SCurve Sigma - VFAT%i"%(vfat),600,600)
                 pass
 
-            dict_mGraph_fitSum[vfat].Add(dict_fitSum[chamberAndScanDatePair[1]][vfat])
-            dict_mGraph_ScurveMean[vfat].Add(dict_ScurveMean[chamberAndScanDatePair[1]][vfat])
-            dict_mGraph_ScurveSigma[vfat].Add(dict_ScurveSigma[chamberAndScanDatePair[1]][vfat])
+            dict_mGraph_fitSum[vfat].Add(dict_fitSum[chamberAndScanDatePair][vfat])
+            dict_mGraph_ScurveMean[vfat].Add(dict_ScurveMean[chamberAndScanDatePair][vfat])
+            dict_mGraph_ScurveSigma[vfat].Add(dict_ScurveSigma[chamberAndScanDatePair][vfat])
             
             if (idx == (len(listChamberAndScanDate) - 1) ):
-                chanStripOrPanPin = dict_fitSum[chamberAndScanDatePair[1]][vfat].GetXaxis().GetTitle()
+                chanStripOrPanPin = dict_fitSum[chamberAndScanDatePair][vfat].GetXaxis().GetTitle()
                 
                 dict_canvSCurveFitSum[vfat].cd()
                 dict_mGraph_fitSum[vfat].Draw(drawOpt) # The axis doesn't exist unless we draw it first, ROOT magic =/
@@ -237,8 +237,8 @@ if __name__ == '__main__':
                 dict_canvSCurveSigmaByiEta[ieta]  = r.TCanvas("canvScurveSigma_ieta%i"%(ieta),"SCurve Sigma - ieta%i"%(ieta),600,600)
                 pass
 
-            dict_mGraph_ScurveMeanByiEta[ieta].Add(dict_ScurveMeanByiEta[chamberAndScanDatePair[1]][ieta])
-            dict_mGraph_ScurveSigmaByiEta[ieta].Add(dict_ScurveSigmaByiEta[chamberAndScanDatePair[1]][ieta])
+            dict_mGraph_ScurveMeanByiEta[ieta].Add(dict_ScurveMeanByiEta[chamberAndScanDatePair][ieta])
+            dict_mGraph_ScurveSigmaByiEta[ieta].Add(dict_ScurveSigmaByiEta[chamberAndScanDatePair][ieta])
 
             if (idx == (len(listChamberAndScanDate) - 1) ):
                 dict_canvSCurveMeanByiEta[ieta].cd()
@@ -253,11 +253,11 @@ if __name__ == '__main__':
                 pass
             pass
 
-        dict_mGraph_ScurveMean[-1].Add(dict_ScurveMean[chamberAndScanDatePair[1]][-1])
-        dict_mGraph_ScurveSigma[-1].Add(dict_ScurveSigma[chamberAndScanDatePair[1]][-1])
+        dict_mGraph_ScurveMean[-1].Add(dict_ScurveMean[chamberAndScanDatePair][-1])
+        dict_mGraph_ScurveSigma[-1].Add(dict_ScurveSigma[chamberAndScanDatePair][-1])
 
         # Fill Legend - use VFAT0 of each
-        plotLeg.AddEntry(dict_fitSum[chamberAndScanDatePair[1]][0],chamberAndScanDatePair[2],"LPE")
+        plotLeg.AddEntry(dict_fitSum[chamberAndScanDatePair][0],chamberAndScanDatePair[2],"LPE")
         pass
 
     # Draw multigraphs for summary cases

--- a/macros/plotSCurveFitResults.py
+++ b/macros/plotSCurveFitResults.py
@@ -77,8 +77,9 @@ if __name__ == '__main__':
             # Fit summary 
             dict_fitSum[chamberAndScanDatePair[1]][vfat] = scanFile.Get("VFAT%i/gFitSummary_VFAT%i"%(vfat,vfat))
             dict_fitSum[chamberAndScanDatePair[1]][vfat].SetName(
-                    "%s_%s"%(
+                    "%s_%s_%s"%(
                         dict_fitSum[chamberAndScanDatePair[1]][vfat].GetName(),
+                        chamberAndScanDatePair[0]),
                         chamberAndScanDatePair[1])
                     )
             dict_fitSum[chamberAndScanDatePair[1]][vfat].SetLineColor(getCyclicColor(idx))
@@ -88,8 +89,9 @@ if __name__ == '__main__':
             # Scurve Mean
             dict_ScurveMean[chamberAndScanDatePair[1]][vfat] = scanFile.Get("VFAT%i/gScurveMeanDist_vfat%i"%(vfat,vfat))
             dict_ScurveMean[chamberAndScanDatePair[1]][vfat].SetName(
-                    "%s_%s"%(
+                    "%s_%s_%s"%(
                         dict_ScurveMean[chamberAndScanDatePair[1]][vfat].GetName(),
+                        chamberAndScanDatePair[0]),
                         chamberAndScanDatePair[1])
                     )
             dict_ScurveMean[chamberAndScanDatePair[1]][vfat].SetLineColor(getCyclicColor(idx))
@@ -99,8 +101,9 @@ if __name__ == '__main__':
             # Scurve Width
             dict_ScurveSigma[chamberAndScanDatePair[1]][vfat] = scanFile.Get("VFAT%i/gScurveSigmaDist_vfat%i"%(vfat,vfat))
             dict_ScurveSigma[chamberAndScanDatePair[1]][vfat].SetName(
-                    "%s_%s"%(
+                    "%s_%s_%s"%(
                         dict_ScurveSigma[chamberAndScanDatePair[1]][vfat].GetName(),
+                        chamberAndScanDatePair[0]),
                         chamberAndScanDatePair[1])
                     )
             dict_ScurveSigma[chamberAndScanDatePair[1]][vfat].SetLineColor(getCyclicColor(idx))
@@ -113,8 +116,9 @@ if __name__ == '__main__':
             # Scurve Mean
             dict_ScurveMeanByiEta[chamberAndScanDatePair[1]][ieta] = scanFile.Get("Summary/ieta%i/gScurveMeanDist_ieta%i"%(ieta,ieta))
             dict_ScurveMeanByiEta[chamberAndScanDatePair[1]][ieta].SetName(
-                    "%s_%s"%(
+                    "%s_%s_%s"%(
                         dict_ScurveMeanByiEta[chamberAndScanDatePair[1]][ieta].GetName(),
+                        chamberAndScanDatePair[0]),
                         chamberAndScanDatePair[1])
                     )
             dict_ScurveMeanByiEta[chamberAndScanDatePair[1]][ieta].SetLineColor(getCyclicColor(idx))
@@ -124,8 +128,9 @@ if __name__ == '__main__':
             # Scurve Sigma
             dict_ScurveSigmaByiEta[chamberAndScanDatePair[1]][ieta] = scanFile.Get("Summary/ieta%i/gScurveSigmaDist_ieta%i"%(ieta,ieta))
             dict_ScurveSigmaByiEta[chamberAndScanDatePair[1]][ieta].SetName(
-                    "%s_%s"%(
+                    "%s_%s_%s"%(
                         dict_ScurveSigmaByiEta[chamberAndScanDatePair[1]][ieta].GetName(),
+                        chamberAndScanDatePair[0]),
                         chamberAndScanDatePair[1])
                     )
             dict_ScurveSigmaByiEta[chamberAndScanDatePair[1]][ieta].SetLineColor(getCyclicColor(idx))
@@ -136,8 +141,9 @@ if __name__ == '__main__':
         # Get the detector level plots
         dict_ScurveMean[chamberAndScanDatePair[1]][-1] = scanFile.Get("Summary/gScurveMeanDist_All")
         dict_ScurveMean[chamberAndScanDatePair[1]][-1].SetName(
-                    "%s_%s"%(
+                    "%s_%s_%s"%(
                         dict_ScurveMean[chamberAndScanDatePair[1]][-1].GetName(),
+                        chamberAndScanDatePair[0]),
                         chamberAndScanDatePair[1])
                 )
         dict_ScurveMean[chamberAndScanDatePair[1]][-1].SetLineColor(getCyclicColor(idx))
@@ -146,8 +152,9 @@ if __name__ == '__main__':
 
         dict_ScurveSigma[chamberAndScanDatePair[1]][-1] = scanFile.Get("Summary/gScurveSigmaDist_All")
         dict_ScurveSigma[chamberAndScanDatePair[1]][-1].SetName(
-                    "%s_%s"%(
+                    "%s_%s_%s"%(
                         dict_ScurveSigma[chamberAndScanDatePair[1]][-1].GetName(),
+                        chamberAndScanDatePair[0]),
                         chamberAndScanDatePair[1])
                 )
         dict_ScurveSigma[chamberAndScanDatePair[1]][-1].SetLineColor(getCyclicColor(idx))

--- a/macros/plotSCurveFitResults.py
+++ b/macros/plotSCurveFitResults.py
@@ -1,0 +1,195 @@
+#!/bin/env python
+
+if __name__ == '__main__':
+    from anaInfo import tree_names
+    from anautilities import getCyclicColor, getDirByAnaType, filePathExists, make3x8Canvas, parseListOfScanDatesFile
+    from gempython.utils.nesteddict import nesteddict as ndict
+    from gempython.utils.wrappers import envCheck, runCommand
+    from macros.plotoptions import parser
+    from macros.scurvePlottingUtitilities import overlay_scurve
+   
+    import os
+    import ROOT as r
+
+    parser.add_option("--alphaLabels", action="store_true", dest="alphaLabels",
+                    help="Draw output plot using alphanumeric lables instead of pure floating point", metavar="alphaLabels")
+    parser.add_option("--anaType", type="string", dest="anaType",
+                    help="Analysis type to be executed, from list {'scurveAna','trimAna'}", metavar="anaType")
+    parser.add_option("--drawLeg", action="store_true", dest="drawLeg",
+                    help="When used with --summary option draws a TLegend on the output plot", metavar="drawLeg")
+    parser.add_option("--rootName", type="string", dest="rootName", default="scurveFitResultPlots.root",
+                    help="Name for the output TFile, will be found in ELOG_PATH", metavar="rootName")
+    parser.add_option("--rootOpt", type="string", dest="rootOpt", default="RECREATE",
+                    help="Option for the output TFile, e.g. {'RECREATE','UPDATE'}", metavar="rootOpt")
+    parser.add_option("--ztrim", type="float", dest="ztrim", default=4.0,
+                    help="Specify the p value of the trim", metavar="ztrim")
+    
+    parser.set_defaults(filename="listOfScanDates.txt")
+    (options, args) = parser.parse_args()
+ 
+    # Suppress all pop-ups from ROOT
+    r.gROOT.SetBatch(True)
+
+    # Check Paths
+    envCheck('DATA_PATH')
+    envCheck('ELOG_PATH')
+    elogPath  = os.getenv('ELOG_PATH')
+    
+    # Check anaType is understood
+    supportedAnaTypes = ['scurveAna','trimAna']
+    if options.anaType not in supportedAnaTypes:
+        print("Invalid analysis specificed, please select only from the list:")
+        print(supportedAnaTypes)
+        exit(os.EX_USAGE)
+        pass
+
+    # Get info from input file
+    parsedTuple = parseListOfScanDatesFile(options.filename, options.alphaLabels)
+    listChamberAndScanDate = parsedTuple[0]
+
+    # Define nested dictioniaries
+    #   Outer key -> scandate
+    #   Inner key -> vfat position
+    dict_fitSum = ndict()
+    dict_ScurveMean = ndict() # Inner key: (0,23) follows vfat #, -1 is summary over all det
+    dict_ScurveSigma = ndict() 
+    
+    # Get the plots from all files
+    for idx,chamberAndScanDatePair in enumerate(listChamberAndScanDate):
+        # Setup the path
+        dirPath = getDirByAnaType(options.anaType.strip("Ana"), chamberAndScanDatePair[0], options.ztrim)
+        if not filePathExists(dirPath, chamberAndScanDatePair[1]):
+            print 'Filepath %s/%s does not exist!'%(dirPath, scandate)
+            print 'Please cross-check, exiting!'
+            outF.Close()
+            exit(os.EX_DATAERR)
+        filename = "%s/%s/%s"%(dirPath, chamberAndScanDatePair[1], tree_names[options.anaType][0])
+
+        # Load the file
+        r.TH1.AddDirectory(False)
+        scanFile   = r.TFile(filename,"READ")
+
+        # Get all plots from scanFile - vfat level
+        for vfat in range(0,24):
+            # Fit summary 
+            dict_fitSum[chamberAndScanDatePair[1]][vfat] = scanFile.Get("VFAT%i/gFitSummary_VFAT%i"%(vfat,vfat))
+            dict_fitSum[chamberAndScanDatePair[1]][vfat].SetName(
+                    "%s_%s"%(
+                        dict_fitSum[chamberAndScanDatePair[1]][vfat].GetName(),
+                        chamberAndScanDatePair[1])
+                    )
+            dict_fitSum[chamberAndScanDatePair[1]][vfat].SetLineColor(getCyclicColor(idx))
+            dict_fitSum[chamberAndScanDatePair[1]][vfat].SetMarkerColor(getCyclicColor(idx))
+
+            # Scurve Mean
+            dict_ScurveMean[chamberAndScanDatePair[1]][vfat] = scanFile.Get("VFAT%i/gScurveMeanDist_vfat%i"%(vfat,vfat))
+            dict_ScurveMean[chamberAndScanDatePair[1]][vfat].SetName(
+                    "%s_%s"%(
+                        dict_ScurveMean[chamberAndScanDatePair[1]][vfat].GetName(),
+                        chamberAndScanDatePair[1])
+                    )
+            dict_ScurveMean[chamberAndScanDatePair[1]][vfat].SetLineColor(getCyclicColor(idx))
+            dict_ScurveMean[chamberAndScanDatePair[1]][vfat].SetMarkerColor(getCyclicColor(idx))
+            
+            # Scurve Width
+            dict_ScurveSigma[chamberAndScanDatePair[1]][vfat] = scanFile.Get("VFAT%i/gScurveSigmaDist_vfat%i"%(vfat,vfat))
+            dict_ScurveSigma[chamberAndScanDatePair[1]][vfat].SetName(
+                    "%s_%s"%(
+                        dict_ScurveSigma[chamberAndScanDatePair[1]][vfat].GetName(),
+                        chamberAndScanDatePair[1])
+                    )
+            dict_ScurveSigma[chamberAndScanDatePair[1]][vfat].SetLineColor(getCyclicColor(idx))
+            dict_ScurveSigma[chamberAndScanDatePair[1]][vfat].SetMarkerColor(getCyclicColor(idx))
+
+            pass
+
+        # Get the detector level plots
+        dict_ScurveMean[chamberAndScanDatePair[1]][-1] = scanFile.Get("Summary/gScurveMeanDist_All")
+        dict_ScurveMean[chamberAndScanDatePair[1]][-1].SetName(
+                    "%s_%s"%(
+                        dict_ScurveMean[chamberAndScanDatePair[1]][-1].GetName(),
+                        chamberAndScanDatePair[1])
+                )
+        dict_ScurveMean[chamberAndScanDatePair[1]][-1].SetLineColor(getCyclicColor(idx))
+        dict_ScurveMean[chamberAndScanDatePair[1]][-1].SetMarkerColor(getCyclicColor(idx))
+
+        dict_ScurveSigma[chamberAndScanDatePair[1]][-1] = scanFile.Get("Summary/gScurveMeanDist_All")
+        dict_ScurveSigma[chamberAndScanDatePair[1]][-1].SetName(
+                    "%s_%s"%(
+                        dict_ScurveSigma[chamberAndScanDatePair[1]][-1].GetName(),
+                        chamberAndScanDatePair[1])
+                )
+        dict_ScurveSigma[chamberAndScanDatePair[1]][-1].SetLineColor(getCyclicColor(idx))
+        dict_ScurveSigma[chamberAndScanDatePair[1]][-1].SetMarkerColor(getCyclicColor(idx))
+        
+        pass
+
+    # Make the plots
+    canvFitSum_Grid = None
+    canvScurveMean_DetSum = r.TCanvas("canvSCurveMeanDetSumAllScandates","Scurve Mean - Detector Summary",600,600)
+    #canvScurveMean_DetSum.cd().SetLogy()
+    canvScurveMean_Grid = None
+    canvScurveSigma_DetSum = r.TCanvas("canvSCurveSigmaDetSumAllScandates","Scurve Sigma - Detector Summary",600,600)
+    #canvScurveSigma_DetSum.cd().SetLogy()
+    canvScurveSigma_Grid = None
+    plotLeg = r.TLegend(0.1,0.65,0.45,0.9)
+    for idx,chamberAndScanDatePair in enumerate(listChamberAndScanDate):
+        # Determine draw option
+        if idx==0:
+            drawOpt="APE1"
+        else:
+            drawOpt="samePE1"
+
+        # Draw grid distributions
+        canvFitSum_Grid = make3x8Canvas("scurveFitSummaryGridAllScandates",dict_fitSum[chamberAndScanDatePair[1]],drawOpt,canv=canvFitSum_Grid)
+        canvScurveMean_Grid = make3x8Canvas("scurveMeanGridAllScandates",dict_ScurveMean[chamberAndScanDatePair[1]],drawOpt,canv=canvScurveMean_Grid)
+        canvScurveSigma_Grid = make3x8Canvas("scurveSigmaGridAllScandates",dict_ScurveSigma[chamberAndScanDatePair[1]],drawOpt,canv=canvScurveSigma_Grid)
+
+        # Draw detector summary distributions
+        canvScurveMean_DetSum.cd()
+        dict_ScurveMean[chamberAndScanDatePair[1]][-1].Draw(drawOpt)
+        canvScurveSigma_DetSum.cd()
+        dict_ScurveSigma[chamberAndScanDatePair[1]][-1].Draw(drawOpt)
+
+        # Fill Legend - use VFAT0 of each
+        plotLeg.AddEntry(dict_fitSum[chamberAndScanDatePair[1]][0],chamberAndScanDatePair[2],"LPE")
+        pass
+
+    if options.drawLeg:
+        canvFitSum_Grid.cd(1)
+        plotLeg.Draw("same")
+        
+        canvScurveMean_Grid.cd(1)
+        plotLeg.Draw("same")
+
+        canvScurveSigma_Grid.cd(1)
+        plotLeg.Draw("same")
+
+        canvScurveMean_DetSum.cd()
+        plotLeg.Draw("same")
+        
+        canvScurveSigma_DetSum.cd()
+        plotLeg.Draw("same")
+        pass
+
+    # Make output images
+    canvFitSum_Grid.SaveAs("%s/%s.png"%(elogPath,canvFitSum_Grid.GetName()))
+    canvScurveMean_Grid.SaveAs("%s/%s.png"%(elogPath,canvScurveMean_Grid.GetName()))
+    canvScurveSigma_Grid.SaveAs("%s/%s.png"%(elogPath,canvScurveSigma_Grid.GetName()))
+
+    canvScurveMean_DetSum.SaveAs("%s/%s.png"%(elogPath,canvScurveMean_DetSum.GetName()))
+    canvScurveSigma_DetSum.SaveAs("%s/%s.png"%(elogPath,canvScurveSigma_DetSum.GetName()))
+
+    # Save canvas objects in output root file
+    outF = r.TFile("%s/%s"%(elogPath,options.rootName),options.rootOpt)
+    outF.cd()
+    canvFitSum_Grid.Write()
+    canvScurveMean_Grid.Write()
+    canvScurveSigma_Grid.Write()
+    canvScurveMean_DetSum.Write()
+    canvScurveSigma_DetSum.Write()
+
+    print "Your plots can be found in:"
+    print ""
+    print "     %s"%elogPath
+    print ""

--- a/mapping/chamberInfo.py
+++ b/mapping/chamberInfo.py
@@ -51,7 +51,26 @@ chamber_vfatMask = {
     8:0x0,
     9:0x0
     }
-    
+   
+# Matches CMS coordinates
+chamber_iEta2VFATPos = {
+        1: { 7:1, 15:2, 23:3 }, #ieta: [ (vfat, iphi), (vfat, iphi), (vfat, iphi) ]
+        2: { 6:1, 14:2, 22:3 },
+        3: { 5:1, 13:2, 21:3 },
+        4: { 4:1, 12:2, 20:3 },
+        5: { 3:1, 11:2, 19:3 },
+        6: { 2:1, 10:2, 18:3 },
+        7: { 1:1,  9:2, 17:3 },
+        8: { 0:1,  8:2, 16:3 }
+        }
+
+chamber_vfatPos2iEta = {}
+for ieta, vfatRow in chamber_iEta2VFATPos.iteritems():
+    for vfat,phi in vfatRow.iteritems():
+        chamber_vfatPos2iEta[vfat] = ieta
+        pass
+    pass
+
 chamber_vfatDACSettings = {    
     # V2b Electronics Instructions:
     # For changing VFAT DAC settings from defaults shown in vfat_user_functions.py


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
New tool for visualizing results from multiple s-curve scandates.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
I wanted to plot per VFAT distributions from multiple scurves on the same TCanvas, there was no "go to" tool for that yet.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I made a tool to do this, see example calling syntax in updated `README.md`.

Example outputs:
![canvscurvemeandetsumallscandates](https://user-images.githubusercontent.com/6432141/38049255-0696ad12-32c8-11e8-9b35-5ab4c4ef5342.png)
![canvscurvesigmadetsumallscandates](https://user-images.githubusercontent.com/6432141/38049257-06b56c8e-32c8-11e8-9ffd-3049b68cc38b.png)
![scurvesigmagridallscandates](https://user-images.githubusercontent.com/6432141/38049259-06d0b7be-32c8-11e8-9f86-d4162e7f3517.png)
![scurvefitsummarygridallscandates](https://user-images.githubusercontent.com/6432141/38049260-06e95a80-32c8-11e8-9f2a-2afeeb3737d5.png)
![scurvemeangridallscandates](https://user-images.githubusercontent.com/6432141/38049261-0702f4d6-32c8-11e8-9d51-b1626d069e3f.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
