### PR TITLE
New Features: Effective Pedestal Distributions 

### DIFF
--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -607,7 +607,7 @@ if __name__ == '__main__':
         for effPed in allEffPed[allEffPed > -1]:
             hDetEffPed_All.Fill(effPed)
             pass
-        hDetEffPed_All.GetXaxis().SetTitle("scurve effective pedestal #left(fC#right)")
+        hDetEffPed_All.GetXaxis().SetTitle("scurve effective pedestal #left(N#right)")
         hDetEffPed_All.GetYaxis().SetTitle("Entries")
         hDetEffPed_All.SetMarkerStyle(21)
         hDetEffPed_All.SetMarkerColor(r.kRed)

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -195,7 +195,7 @@ if __name__ == '__main__':
     # Initialize distributions
     for vfat in range(0,24):
         vSummaryPlots[vfat] = r.TH2D('vSummaryPlots%i'%vfat,
-                'VFAT %i;Channels;VCal #lef(fC#right)'%vfat,
+                'VFAT %i;Channels;VCal #left(fC#right)'%vfat,
                 128,-0.5,127.5,256,
                 calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
                 calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -176,8 +176,8 @@ if __name__ == '__main__':
         myT = r.TTree('scurveFitTree','Tree Holding FitData')
 
     tuple_calInfo = parseCalFile(options.calFile)
-    calDAC2Q_Intercept = tuple_calInfo[0]
-    calDAC2Q_Slope = tuple_calInfo[1]
+    calDAC2Q_Slope = tuple_calInfo[0]
+    calDAC2Q_Intercept = tuple_calInfo[1]
     
     # Create output plot containers
     vSummaryPlots = ndict()

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -547,7 +547,7 @@ if __name__ == '__main__':
             threshSummaryPlots[vfat] = gThresh
 
             # Make effective pedestal summary plot - bin size is fixed
-            histEffPed = r.TH1F("scurveEffPed_vfat%i"%vfat,"VFAT %i;S-Curve Effective Pedestal #left(fC#right);N"%vfat,
+            histEffPed = r.TH1F("scurveEffPed_vfat%i"%vfat,"VFAT %i;S-Curve Effective Pedestal #left(N#right);N"%vfat,
                                 nPulses+1, -0.5, nPulses+0.5)
             histEffPed.Sumw2()
             for effPed in allEffPed[(vfat*128):((vfat+1)*128)]:
@@ -561,7 +561,7 @@ if __name__ == '__main__':
             histEffPed.SetLineColor(r.kRed)
             #gEffPed = r.TGraphErrors(histEffPed)
             #gEffPed.SetName("gScurveEffPedDist_vfat%i"%vfat)
-            #gEffPed.GetXaxis().SetTitle("scurve effective pedestal #left(fC#right)")
+            #gEffPed.GetXaxis().SetTitle("scurve effective pedestal #left(N#right)")
             #gEffPed.GetYaxis().SetTitle("Entries / %f fC"%(thisVFAT_EffPedStd/4.))
             #effPedSummaryPlots[vfat] = gEffPed
             effPedSummaryPlots[vfat] = histEffPed
@@ -602,7 +602,7 @@ if __name__ == '__main__':
         gDetThresh_All.GetYaxis().SetTitle("Entries / %f fC"%(detThresh_Std/10.))
 
         # Make a EffPed Summary Dist For the entire Detector
-        hDetEffPed_All = r.TH1F("hScurveEffPedDist_All","All VFATs;S-Curve Effective Pedestal #left(fC#right);N",
+        hDetEffPed_All = r.TH1F("hScurveEffPedDist_All","All VFATs;S-Curve Effective Pedestal #left(N#right);N",
                                 nPulses+1, -0.5, nPulses+0.5)
         for effPed in allEffPed[allEffPed > -1]:
             hDetEffPed_All.Fill(effPed)
@@ -614,7 +614,7 @@ if __name__ == '__main__':
         hDetEffPed_All.SetLineColor(r.kRed)
         gDetEffPed_All = r.TGraphErrors(hDetEffPed_All)
         gDetEffPed_All.SetName("gScurveEffPedDist_All")
-        gDetEffPed_All.GetXaxis().SetTitle("scurve effective pedestal #left(fC#right)")
+        gDetEffPed_All.GetXaxis().SetTitle("scurve effective pedestal #left(N#right)")
         gDetEffPed_All.GetYaxis().SetTitle("Entries")
 
         # Make a ENC Summary Dist For the entire Detector
@@ -657,7 +657,7 @@ if __name__ == '__main__':
             # S-curve effective pedestal
             hEffPed_iEta = r.TH1F(
                     "hScurveEffPedDist_ieta%i"%(ieta),
-                    "i#eta=%i;S-Curve Effective Pedestal #left(fC#right);N"%(ieta),
+                    "i#eta=%i;S-Curve Effective Pedestal #left(N#right);N"%(ieta),
                      nPulses+1, -0.5, nPulses+0.5)
             
             for effPed in allEffPedByiEta[ieta][allEffPedByiEta[ieta] > -1]:

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -128,11 +128,10 @@ def plotAllSCurvesOnCanvas(vfatHistos, vfatHistosPanPin2=None, obsName="scurves"
 if __name__ == '__main__':
     import os
     import numpy as np
-    import root_numpy as rp #note need root_numpy-4.7.2 (may need to run 'pip install root_numpy --upgrade')
     import ROOT as r
     
     from array import array
-    from anautilities import getEmptyPerVFATList, getMapping, isOutlierMADOneSided, saveSummary
+    from anautilities import getEmptyPerVFATList, getMapping, isOutlierMADOneSided, parseCalFile, saveSummary
     from anaInfo import mappingNames, MaskReason
     from fitting.fitScanData import ScanDataFitter
     from gempython.utils.nesteddict import nesteddict as ndict
@@ -174,22 +173,10 @@ if __name__ == '__main__':
     outF = r.TFile(filename+'/'+outfilename, 'recreate')
     if options.performFit:
         myT = r.TTree('scurveFitTree','Tree Holding FitData')
-    
-    # Set the CAL DAC to fC conversion
-    calDAC2Q_Intercept = np.zeros(24)
-    calDAC2Q_Slope = np.zeros(24)
-    if options.calFile is not None:
-        list_bNames = ["vfatN","slope","intercept"]
-        calTree = r.TTree('calTree','Tree holding VFAT Calibration Info')
-        calTree.ReadFile(options.calFile)
-        array_CalData = rp.tree2array(tree=calTree, branches=list_bNames)
-    
-        for dataPt in array_CalData:
-            calDAC2Q_Intercept[dataPt['vfatN']] = dataPt['intercept']
-            calDAC2Q_Slope[dataPt['vfatN']] = dataPt['slope']
-    else:
-        calDAC2Q_Intercept = -0.8 * np.ones(24)
-        calDAC2Q_Slope = 0.05 * np.ones(24)
+
+    tuple_calInfo = parseCalFile(options.calFile)
+    calDAC2Q_Intercept = tuple_calInfo[0]
+    calDAC2Q_Slope = tuple_calInfo[1]
     
     # Create output plot containers
     vSummaryPlots = ndict()

--- a/anautilities.py
+++ b/anautilities.py
@@ -320,6 +320,7 @@ def parseCalFile(filename=None):
 
     import numpy as np
     import root_numpy as rp #note need root_numpy-4.7.2 (may need to run 'pip install root_numpy --upgrade')
+    import ROOT as r
 
     # Set the CAL DAC to fC conversion
     calDAC2Q_b = np.zeros(24)

--- a/anautilities.py
+++ b/anautilities.py
@@ -288,6 +288,59 @@ def make3x8Canvas(name, initialContent = None, initialDrawOpt = '', secondaryCon
     canv.Update()
     return canv
 
+def parseCalFile(filename=None):
+    """
+    Gives the conversion between VCal/CFG_CAL_DAC to fC from either
+    an optional external file (filename) or the hard coded vfat2 
+    values.
+
+    Returns a tuple of numpy arrays where index 0 (1) of the tuple
+    corresponds to the slope (intercept) arrays.  The returned 
+    arrays are indexed by VFAT position.
+    
+    The conversion follows via:
+
+    fC = ret_tuple[0][vfat] * CAL_DAC + ret_tuple[1][vfat]
+
+    The structure of filename, if supplied, is expected to be:
+
+        vfatN/I:slope/F:intercept/F
+        0   0.2692  -2.629748
+        1   0.238106    -2.65316
+        2   0.2532  -2.193826
+        3   0.276783    -2.477547
+        ...
+        5   1.000000    0.000000    
+        ...
+        ...
+
+    Inputing a slope (intercept) of 1.0 (0.0) will keep the numbers
+    in DAC units
+    """
+
+    import numpy as np
+    import root_numpy as rp #note need root_numpy-4.7.2 (may need to run 'pip install root_numpy --upgrade')
+
+    # Set the CAL DAC to fC conversion
+    calDAC2Q_b = np.zeros(24)
+    calDAC2Q_m = np.zeros(24)
+    if filename is not None:
+        list_bNames = ["vfatN","slope","intercept"]
+        calTree = r.TTree('calTree','Tree holding VFAT Calibration Info')
+        calTree.ReadFile(filename)
+        array_CalData = rp.tree2array(tree=calTree, branches=list_bNames)
+    
+        for dataPt in array_CalData:
+            calDAC2Q_b[dataPt['vfatN']] = dataPt['intercept']
+            calDAC2Q_m[dataPt['vfatN']] = dataPt['slope']
+            pass
+    else:
+        calDAC2Q_b = -0.8 * np.ones(24)
+        calDAC2Q_m = 0.05 * np.ones(24)
+        pass
+
+    return (calDAC2Q_m, calDAC2Q_b)
+
 def parseListOfScanDatesFile(filename, alphaLabels=False, delim='\t'):
     """
     Parses a filename which describes a list of scandates.  Two formats of the filename

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -219,7 +219,23 @@ class ScanDataFitter(DeadChannelFinder):
             self.feed(event)
         return
 
-def fitScanData(treeFileName, isVFAT3=False):
-    fitter = ScanDataFitter(isVFAT3=isVFAT3)
+def fitScanData(treeFileName, isVFAT3=False, calFileName=None):
+    from anautilities import parseCalFile
+    
+    # Get the fitter
+    if calFileName is not None:
+        tuple_calInfo = parseCalFile(calFileName)
+        fitter = ScanDataFitter(
+                calDAC2Q_m = tuple_calInfo[0],
+                calDAC2Q_b = tuple_calInfo[1],
+                isVFAT3=isVFAT3
+                )
+    else:
+        fitter = ScanDataFitter(isVFAT3=isVFAT3)
+        pass
+
+    # Read the output data
     fitter.readFile(treeFileName)
+
+    # Fit
     return fitter.fit()

--- a/macros/plotSCurveFitResults.py
+++ b/macros/plotSCurveFitResults.py
@@ -53,7 +53,8 @@ if __name__ == '__main__':
     dict_fitSum = ndict()
     dict_ScurveMean = ndict() # Inner key: (0,23) follows vfat #, -1 is summary over all det
     dict_ScurveSigma = ndict() 
-   
+    dict_ScurveEffPed = ndict()
+
     dict_ScurveMeanByiEta = ndict()
     dict_ScurveSigmaByiEta = ndict() 
 
@@ -160,6 +161,17 @@ if __name__ == '__main__':
         dict_ScurveSigma[chamberAndScanDatePair][-1].SetLineColor(getCyclicColor(idx))
         dict_ScurveSigma[chamberAndScanDatePair][-1].SetMarkerColor(getCyclicColor(idx))
         dict_ScurveSigma[chamberAndScanDatePair][-1].SetMarkerStyle(20+idx)
+        
+        dict_ScurveEffPed[chamberAndScanDatePair][-1] = scanFile.Get("Summary/hScurveEffPedDist_All")
+        dict_ScurveEffPed[chamberAndScanDatePair][-1].SetName(
+                    "%s_%s_%s"%(
+                        dict_ScurveEffPed[chamberAndScanDatePair][-1].GetName(),
+                        chamberAndScanDatePair[0],
+                        chamberAndScanDatePair[1])
+                )
+        dict_ScurveEffPed[chamberAndScanDatePair][-1].SetLineColor(getCyclicColor(idx))
+        dict_ScurveEffPed[chamberAndScanDatePair][-1].SetMarkerColor(getCyclicColor(idx))
+        dict_ScurveEffPed[chamberAndScanDatePair][-1].SetMarkerStyle(20+idx)
         pass
 
     # Define the TMultiGraph dictionaries
@@ -186,6 +198,7 @@ if __name__ == '__main__':
     # Make the summary canvases
     canvScurveMean_DetSum = r.TCanvas("canvSCurveMeanDetSumAllScandates","Scurve Mean - Detector Summary",600,600)
     canvScurveSigma_DetSum = r.TCanvas("canvSCurveSigmaDetSumAllScandates","Scurve Sigma - Detector Summary",600,600)
+    canvScurveEffPed_DetSum = r.TCanvas("canvSCurveEffPedDetSumAllScandates","Scurve EffPed - Detector Summary",600,600)
     plotLeg = r.TLegend(0.1,0.65,0.45,0.9)
     for idx,chamberAndScanDatePair in enumerate(listChamberAndScanDate):
         drawOpt="APE1"
@@ -256,6 +269,12 @@ if __name__ == '__main__':
         dict_mGraph_ScurveMean[-1].Add(dict_ScurveMean[chamberAndScanDatePair][-1])
         dict_mGraph_ScurveSigma[-1].Add(dict_ScurveSigma[chamberAndScanDatePair][-1])
 
+        canvScurveEffPed_DetSum.cd()
+        if idx == 0:
+            dict_ScurveEffPed[chamberAndScanDatePair][-1].Draw("E1")
+        else:
+            dict_ScurveEffPed[chamberAndScanDatePair][-1].Draw("sameE1")
+
         # Fill Legend - use VFAT0 of each
         plotLeg.AddEntry(dict_fitSum[chamberAndScanDatePair][0],chamberAndScanDatePair[2],"LPE")
         pass
@@ -281,6 +300,8 @@ if __name__ == '__main__':
     #dict_mGraph_ScurveSigma[-1].GetXaxis().SetRangeUser(0,5)
     #dict_mGraph_ScurveSigma[-1].GetYaxis().SetRangeUser(1e-1,1e3)
     #dict_mGraph_ScurveSigma[-1].Draw("APE1")
+
+    canvScurveEffPed_DetSum.cd().SetLogy()
 
     if options.drawLeg:
         # VFAT level
@@ -320,11 +341,15 @@ if __name__ == '__main__':
 
         canvScurveSigma_Grid_iEta.cd(1)
         plotLeg.Draw("same")
-        
+       
+        # Draw legend at the detector level
         canvScurveMean_DetSum.cd()
         plotLeg.Draw("same")
         
         canvScurveSigma_DetSum.cd()
+        plotLeg.Draw("same")
+        
+        canvScurveEffPed_DetSum.cd()
         plotLeg.Draw("same")
         pass
 
@@ -338,6 +363,7 @@ if __name__ == '__main__':
     
     canvScurveMean_DetSum.SaveAs("%s/%s.png"%(elogPath,canvScurveMean_DetSum.GetName()))
     canvScurveSigma_DetSum.SaveAs("%s/%s.png"%(elogPath,canvScurveSigma_DetSum.GetName()))
+    canvScurveEffPed_DetSum.SaveAs("%s/%s.png"%(elogPath,canvScurveEffPed_DetSum.GetName()))
 
     # Save summary canvas objects in output root file
     outF = r.TFile("%s/%s"%(elogPath,options.rootName),options.rootOpt)
@@ -378,6 +404,7 @@ if __name__ == '__main__':
     dict_mGraph_ScurveMean[-1].Write()
     canvScurveSigma_DetSum.Write()
     dict_mGraph_ScurveSigma[-1].Write()
+    canvScurveEffPed_DetSum.Write()
 
     print "Your plots can be found in:"
     print ""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
To assist in understanding https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/77 have added summary plots for the effective pedestal distribution.

Recall the effective pedestal of a channel is determined via:

```
s_curve_equation.Eval(0 fC)
``` 

So this is the number of times the channel's comparator fires when zero charge is injected by the calibration module.  Obviously a healthy channel has 0 hits.

Additionally there is a new utility function `parseCalFile(...)` that will parse an input text file which provides the slope and intercept values for the `VCAL` or `CFG_CAL_DAC` conversion to `fC`.

Finally `plotSCurveFitResults.py` will now also make comparison plots for scurve pedestals as well.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Multiple places needed DAC units to fC conversion so made a utility function for it.  In principle this function could be used for converting any DAC into either charge or voltage units depending on the slope and intercept parameters provided (assuming a `y = m * x + b` behavior). 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Made plots as shown below.

### Screenshots (if appropriate):
![scurveeffpedsummary](https://user-images.githubusercontent.com/6432141/38318631-161aa49c-3830-11e8-94ff-014d07a389f9.png)
![scurveeffpedsummarybyieta](https://user-images.githubusercontent.com/6432141/38318632-163dc51c-3830-11e8-99cb-c1ad50b9dc10.png)
<img width="801" alt="screen shot 2018-04-04 at 17 52 35" src="https://user-images.githubusercontent.com/6432141/38318975-ff64955e-3830-11e8-8725-0517469d6c0c.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
