### PR TITLE
Addresses #64: 3x8 Grid TCanvas Objects Now Follow Physical VFAT Layout

### DIFF
--- a/anaSBitThresh.py
+++ b/anaSBitThresh.py
@@ -47,12 +47,13 @@ for event in inF.rateTree :
 #Save Output
 outF.cd()
 from anautilities import make3x8Canvas
+from mapping.chamberInfo import chamber_vfatPos2PadIdx
 canv_RateSummary = make3x8Canvas('canv_RateSummary', vRate, 'hist')
 dirVFATPlots = outF.mkdir("VFAT_Plots")
 dirRatePlots1D = dirVFATPlots.mkdir("Rate_Plots_1D")
 for vfat in range(0,24):
-    canv_RateSummary.cd(vfat).SetLogy()
-    canv_RateSummary.cd(vfat).Update()
+    canv_RateSummary.cd(chamber_vfatPos2PadIdx[vfat]).SetLogy()
+    canv_RateSummary.cd(chamber_vfatPos2PadIdx[vfat]).Update()
     dirRatePlots1D.cd()
     vRate[vfat].Write()
 canv_RateSummary.SaveAs(filename+'/RateSummary1D.png')
@@ -60,8 +61,8 @@ canv_RateSummary.SaveAs(filename+'/RateSummary1D.png')
 canv_Rate2DSummary = make3x8Canvas('canv_Rate2DSummary', vRate2D, 'colz')
 dirRatePlots2D = dirVFATPlots.mkdir("Rate_Plots_2D")
 for vfat in range(0,24):
-    canv_Rate2DSummary.cd(vfat).SetLogz()
-    canv_Rate2DSummary.cd(vfat).Update()
+    canv_Rate2DSummary.cd(chamber_vfatPos2PadIdx[vfat]).SetLogz()
+    canv_Rate2DSummary.cd(chamber_vfatPos2PadIdx[vfat]).Update()
     dirRatePlots2D.cd()
     vRate2D[vfat].Write()
 canv_Rate2DSummary.SaveAs(filename+'/RateSummary2D.png')

--- a/anaUltraThreshold.py
+++ b/anaUltraThreshold.py
@@ -132,6 +132,7 @@ dict_hMaxVT1_NoOutlier = {}
 for vfat in range(0,24):
     dict_hMaxVT1[vfat]          = r.TH1F('vfat%iChanMaxVT1'%vfat,"vfat%i"%vfat,256,-0.5,255.5)
     dict_hMaxVT1_NoOutlier[vfat]= r.TH1F('vfat%iChanMaxVT1_NoOutlier'%vfat,"vfat%i - No Outliers"%vfat,256,-0.5,255.5)
+    dict_hMaxVT1_NoOutlier[vfat].SetLineColor(r.kRed)
 
     #For each channel determine the maximum thresholds
     chanMaxVT1 = np.zeros((2,vSum[vfat].GetNbinsX()))
@@ -199,43 +200,21 @@ if options.chConfigKnown:
 
 #Save Output
 outF.cd()
-canv = r.TCanvas('canv','canv',500*8,500*3)
-canv.Divide(8,3)
-r.gStyle.SetOptStat(0)
-print 'Saving Thresh Summary File'
-for vfat in range(0,24):
-    r.gStyle.SetOptStat(0)
-    canv.cd(vfat+1)
-    vSum[vfat].Draw('colz')
-    vSum[vfat].Write()
-    pass
-canv.SaveAs(filename+'/ThreshSummary.png')
+saveSummary(dictSummary=vSum, name='%s/ThreshSummary.png'%filename, drawOpt="colz")
 
-canv_proj = r.TCanvas('canv_proj', 'canv_proj', 500*8, 500*3)
-canv_proj.Divide(8,3)
-r.gStyle.SetOptStat(0)
-print 'Saving VFAT Summary File'
+vSumProj = {}
 for vfat in range(0,24):
-    r.gStyle.SetOptStat(0)
-    canv_proj.cd(vfat+1)
-    r.gPad.SetLogy()
-    proj = vSum[vfat].ProjectionY()
-    proj.Draw()
+    vSumProj[vfat] = vSum[vfat].ProjectionY()
     pass
-canv_proj.SaveAs(filename+'/VFATSummary.png')
+saveSummary(dictSummary=vSumProj, name='%s/VFATSummary.png'%filename, drawOpt="")
 
 #Save VT1Max Distributions Before/After Outlier Rejection
-canv_vt1Max = r.TCanvas('canv_vt1Max','canv_vt1Max', 500*8, 500*3)
-canv_vt1Max.Divide(8,3)
-r.gStyle.SetOptStat(0)
-print 'Saving vt1Max distributions'
-for vfat in range(0,24):
-    r.gStyle.SetOptStat(0)
-    canv_vt1Max.cd(vfat+1)
-    dict_hMaxVT1[vfat].Draw("hist")
-    dict_hMaxVT1_NoOutlier[vfat].SetLineColor(r.kRed)
-    dict_hMaxVT1_NoOutlier[vfat].Draw("samehist")
-    pass
+canv_vt1Max = make3x8Canvas(
+        name="canv_vt1Max", 
+        initialContent=dict_hMaxVT1, 
+        initialDrawOpt="hist",
+        secondaryContent=dict_hMaxVT1_NoOutlier,
+        secondaryDrawOpt="hist")
 canv_vt1Max.SaveAs(filename+'/VT1MaxSummary.png')
 
 #Subtracting off the hot channels, so the projection shows only usable ones.
@@ -261,31 +240,14 @@ if not options.pervfat:
     pass
 
 #Save output with new hot channels subtracted off
-canv_pruned = r.TCanvas('canv_pruned','canv_pruned',500*8,500*3)
-canv_pruned.Divide(8,3)
-r.gStyle.SetOptStat(0)
-print 'Saving Pruned File'
-for vfat in range(0,24):
-    r.gStyle.SetOptStat(0)
-    canv_pruned.cd(vfat+1)
-    vSum[vfat].Draw('colz')
-    vSum[vfat].Clone("%s_Pruned"%(vSum[vfat].GetName())).Write()
-    pass
-canv_pruned.SaveAs(filename+'/ThreshPrunedSummary.png')
+saveSummary(dictSummary=vSum, name='%s/ThreshPrunedSummary.png'%filename, drawOpt="colz")
 
-canv_proj = r.TCanvas('canv_proj_pruned', 'canv_proj_pruned', 500*8, 500*3)
-canv_proj.Divide(8,3)
-r.gStyle.SetOptStat(0)
-print 'Saving Pruned Projection File'
+vSumProjPruned = {}
 for vfat in range(0,24):
-    r.gStyle.SetOptStat(0)
-    canv_proj.cd(vfat+1)
-    r.gPad.SetLogy()
-    proj = vSum[vfat].ProjectionY("h_VT1_VFAT%i"%vfat)
-    proj.Draw()
-    proj.Write()
+    vSumProjPruned[vfat] = vSum[vfat].ProjectionY("h_VT1_VFAT%i"%vfat)
+    vSumProjPruned[vfat].Write()
     pass
-canv_proj.SaveAs(filename+'/VFATPrunedSummary.png')
+saveSummary(dictSummary=vSumProjPruned, name='%s/VFATPrunedSummary.png'%filename, drawOpt="")
 
 #Now determine what VT1 to use for configuration.  The first threshold bin with no entries for now.
 #Make a text file readable by TTree::ReadFile

--- a/anautilities.py
+++ b/anautilities.py
@@ -301,6 +301,7 @@ def make3x8Canvas(name, initialContent = None, initialDrawOpt = '', secondaryCon
     """
 
     import ROOT as r
+    from mapping.chamberInfo import chamber_vfatPos2PadIdx
     
     if canv is None:
         canv = r.TCanvas(name,name,500*8,500*3)
@@ -308,11 +309,11 @@ def make3x8Canvas(name, initialContent = None, initialDrawOpt = '', secondaryCon
 
     if initialContent is not None:
         for vfat in range(24):
-            canv.cd(vfat+1)
+            canv.cd(chamber_vfatPos2PadIdx[vfat])
             initialContent[vfat].Draw(initialDrawOpt)
     if secondaryContent is not None:
         for vfat in range(24):
-            canv.cd(vfat+1)
+            canv.cd(chamber_vfatPos2PadIdx[vfat])
             secondaryContent[vfat].Draw("same%s"%secondaryDrawOpt)
     canv.Update()
     return canv
@@ -489,13 +490,14 @@ def saveSummary(dictSummary, dictSummaryPanPin2=None, name='Summary', trimPt=Non
     """
 
     import ROOT as r
+    from mapping.chamberInfo import chamber_vfatPos2PadIdx
 
     legend = r.TLegend(0.75,0.7,0.88,0.88)
     r.gStyle.SetOptStat(0)
     if dictSummaryPanPin2 is None:
         canv = make3x8Canvas('canv', dictSummary, drawOpt)
         for vfat in range(0,24):
-            canv.cd(vfat+1)
+            canv.cd(chamber_vfatPos2PadIdx[vfat])
             if trimPt is not None and trimLine is not None:
                 trimLine = r.TLine(-0.5, trimVcal[vfat], 127.5, trimVcal[vfat])
                 legend.Clear()

--- a/macros/summary_plots.py
+++ b/macros/summary_plots.py
@@ -1,6 +1,7 @@
 #!/bin/env python
 
 import os
+from anautilities import saveSummary
 from gempython.utils.nesteddict import nesteddict as ndict
 from macros.plotoptions import parser
 
@@ -53,70 +54,13 @@ for event in inF.scurveFitTree:
 
 if options.fit_plots or options.all_plots:
     r.gStyle.SetOptStat(111100)
-    canv_comp = r.TCanvas('canv_comp','canv_comp',500*8,500*3)
-    canv_comp.Divide(8,3)
-    for vfat in range(0,24):
-        canv_comp.cd(vfat+1)
-        r.gStyle.SetOptStat(111100)
-        vComparison[vfat].Draw('colz')
-        canv_comp.Update()
-        pass
-    canv_comp.SaveAs(filename+'_FitSummary.png')
-
-    r.gStyle.SetOptStat(111100)
-    canv_trim = r.TCanvas('canv_trim','canv_trim',500*8,500*3)
-    canv_trim.Divide(8,3)
-    for vfat in range(0,24):
-        canv_trim.cd(vfat+1)
-        r.gStyle.SetOptStat(111100)
-        vNoiseTrim[vfat].Draw('colz')
-        canv_trim.Update()
-        pass
-    canv_trim.SaveAs(filename+'_TrimNoiseSummary.png')
-
-    canv_thresh = r.TCanvas('canv_thresh','canv_thresh',500*8,500*3)
-    canv_thresh.Divide(8,3)
-    for vfat in range(0,24):
-        canv_thresh.cd(vfat+1)
-        r.gStyle.SetOptStat(111100)
-        vThreshold[vfat].Draw()
-        r.gPad.SetLogy()
-        canv_thresh.Update()
-        pass
-    canv_thresh.SaveAs(filename+'_FitThreshSummary.png')
-
-    canv_Pedestal = r.TCanvas('canv_Pedestal','canv_Pedestal',500*8,500*3)
-    canv_Pedestal.Divide(8,3)
-    for vfat in range(0,24):
-        canv_Pedestal.cd(vfat+1)
-        r.gStyle.SetOptStat(111100)
-        vPedestal[vfat].Draw()
-        r.gPad.SetLogy()
-        canv_Pedestal.Update()
-        pass
-    canv_Pedestal.SaveAs(filename+'_FitPedestalSummary.png')
-
-    canv_noise = r.TCanvas('canv_noise','canv_noise',500*8,500*3)
-    canv_noise.Divide(8,3)
-    for vfat in range(0,24):
-        canv_noise.cd(vfat+1)
-        vNoise[vfat].Draw()
-        r.gPad.SetLogy()
-        canv_noise.Update()
-        pass
-    canv_noise.SetLogy()
-    canv_noise.SaveAs(filename+'_FitNoiseSummary.png')
+    saveSummary(dictSummary=vComparison, name=("%s_FitSummary.png"%filename),drawOpt="colz")
+    saveSummary(dictSummary=vNoiseTrim, name=("%s_TrimNoiseSummary.png"%filename),drawOpt="colz")
+    saveSummary(dictSummary=vThreshold, name=("%s_FitThreshSummary.png"%filename),drawOpt="")
+    saveSummary(dictSummary=vPedestal, name=("%s_FitPedestalSummary.png"%filename),drawOpt="")
+    saveSummary(dictSummary=vNoise, name=("%s_FitNoiseSummary.png"%filename),drawOpt="")
     pass
+
 if options.chi2_plots or options.all_plots:
-    canv_Chi2 = r.TCanvas('canv_Chi2','canv_Chi2',500*8,500*3)
-    canv_Chi2.Divide(8,3)
-    canv_Chi2.SetLogy()
-    for vfat in range(0,24):
-        canv_Chi2.cd(vfat+1)
-        vChi2[vfat].Draw()
-        r.gPad.SetLogy()
-        canv_Chi2.Update()
-        pass
-    canv_Chi2.SetLogy()
-    canv_Chi2.SaveAs(filename+'_FitChi2Summary.png')
+    saveSummary(dictSummary=vChi2, name=("%s_FitChi2Summary.png"%filename),drawOpt="")
     pass

--- a/mapping/chamberInfo.py
+++ b/mapping/chamberInfo.py
@@ -149,3 +149,15 @@ chamber_vfatDACSettings = {
     #        #"CFG_FORCE_EN_ZCC":1
     #        }
     }
+
+# Canvas to VFAT Position Mapping
+chamber_vfatPos2PadIdx = { }
+for vfat in range(0,24):
+    if (0 <= vfat and vfat < 8):
+        chamber_vfatPos2PadIdx[vfat] = vfat+17
+    elif (8 <= vfat and vfat < 16):
+        chamber_vfatPos2PadIdx[vfat] = vfat+1
+    elif (16 <= vfat and vfat < 24):
+        chamber_vfatPos2PadIdx[vfat] = vfat-15
+        pass # end if-elif statement
+    pass # end loop over all VFATs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
With superchamber construction coming soon we will be doing a lot of benchtop testing before/after assembly of detectors.  To reduce confusion I have made the TCanvas objects that produced 3x8 grid plots follow the physical VFAT ordering when looking from above the detector with the narrow (wide) base of the trapezoid on your left (right). 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

The "Breaking Change" may not be the correct designation, but it *will* change the order on how plots are shown and may catch certain users off guard.  Overall though I believe this will **save** trouble in the long run.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
When looking at 3x8 grid plots produced by our tools the VFAT numbering in the plot does not match the physical layout of the detector, e.g. VFATs 0->7 appear where VFATs 16-23 are located.  During the mass production of superchambers and subsequent in lab testing by non-experts this has a strong possibility to generate confusion and/or mistakes. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Reanalyzed old data.

### Screenshots (if appropriate):
![summary](https://user-images.githubusercontent.com/6432141/38611689-a5e4e746-3d84-11e8-8230-599a99ddbdf2.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
