### PR TITLE
Bug Fix: Fit Summary Plot was using incorrectly mapped x-axis

### DIFF
--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -64,7 +64,7 @@ def fill2DScurveSummaryPlots(scurveTree, vfatHistos, vfatChanLUT, vfatHistosPanP
         
         # Determine the binY that corresponds to this charge value
         chargeBin = first_index_gt(listOfBinEdgesY[event.vfatN], charge)-1
-        
+
         # Fill Summary Histogram 
         if lutType is mappingNames[1] and vfatHistosPanPin2 is not None:
             if (stripPinOrChan < 64):
@@ -78,6 +78,7 @@ def fill2DScurveSummaryPlots(scurveTree, vfatHistos, vfatChanLUT, vfatHistosPanP
             pass
         else:
             vfatHistos[event.vfatN].SetBinContent(stripPinOrChan+1,chargeBin,event.Nhits)
+            pass
 
     return
 
@@ -449,6 +450,7 @@ if __name__ == '__main__':
         allEffPedByiEta = { ieta:(-1.*np.ones(3*128)) for ieta in range(1,9) }
         allThresh = np.zeros(3072)
         allThreshByiEta = { ieta:np.zeros(3*128) for ieta in range(1,9) }
+        
         for vfat in range(0,24):
             stripPinOrChanArray = np.zeros(128)
             for chan in range (0, 128):
@@ -463,7 +465,7 @@ if __name__ == '__main__':
                 allENC[vfat*128 + chan] =  scanFitResults[1][vfat][chan]
                 allEffPed[vfat*128 + chan] = effectivePedestals[vfat][chan]
                 allThresh[vfat*128 + chan] = scanFitResults[0][vfat][chan]
-                stripPinOrChanArray[stripPinOrChan] = float(stripPinOrChan)
+                stripPinOrChanArray[chan] = float(stripPinOrChan)
                 
                 allENCByiEta[ieta][(iphi-1)*chan + chan] = scanFitResults[1][vfat][chan]
                 allEffPedByiEta[ieta][(iphi-1)*chan + chan] = effectivePedestals[vfat][chan]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `gFitSummary_VFATX` plots where being made with a mis-matched x-axis due to an array indexing bug.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Before the `gFitSummary_VFATX` plots used an incorrect x-axis due to an array indexing issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Re-ran old analysis to confirm fix was made correctly.

### Screenshots (if appropriate):
#### Before Bug Fix
<img width="1194" alt="bug_fitsummary" src="https://user-images.githubusercontent.com/6432141/38659697-dfff817e-3e2a-11e8-8df0-b9a3b54f1259.png">

Notice the channels with the very narrow s-curves are assigned the wrong strip number in the `gFitSummary_VFAT5` plot.

#### With Bug Fix
<img width="1135" alt="corrected_fitsummary" src="https://user-images.githubusercontent.com/6432141/38659595-868dcce0-3e2a-11e8-86bb-39184841d6fb.png">

Notice in each case the 2D histogram uses the "correct" x-axis mapping (e.g. `strip` to `vfatCH`) but  `gFitSummary_VFAT5` plot is only correct in the second case. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
