### PR TITLE
Bug Fix: Fixed an import error in gemPlotter.py

### DIFF
--- a/anautilities.py
+++ b/anautilities.py
@@ -434,6 +434,8 @@ def parseListOfScanDatesFile(filename, alphaLabels=False, delim='\t'):
         if i==0:
             if len(analysisList) == 3:
                 strIndepVar = analysisList[2]
+            elif len(analysisList) == 2:
+                strIndepVar = analysisList[1]
             continue
 
         cName = analysisList[0]

--- a/macros/gemPlotter.py
+++ b/macros/gemPlotter.py
@@ -175,7 +175,7 @@ def arbitraryPlotter2D(anaType, listDataPtTuples, rootFileName, treeName, branch
 
 if __name__ == '__main__':
     from anaInfo import tree_names
-    from anautilities import parsedListOfScanDates
+    from anautilities import parseListOfScanDatesFile
     from gempython.utils.wrappers import envCheck
     from macros.plotoptions import parser
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
An typo in an import caused `gemPlotter.py` to crash.  Additionally if a 2 column file was specified as the `listOfScanDates.txt` file the independent variable name (e.g. `scandate`) was not properly stored.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
`gemPlotter.py` crashed due to typo in import.

Output files were not properly labeled as `<dep. var>_vs_<indep. var>` in the case of a 2-column input file.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Re-ran old analysis:

```
gemPlotter.py -ilistOfScanDates_Trim.txt --anaType=trimAna --branchName=trimDAC --vfat=12 --make2D --alphaLabels
```

### Screenshots (if appropriate):
<img width="589" alt="screen shot 2018-04-19 at 11 49 48" src="https://user-images.githubusercontent.com/6432141/38984744-cd390aa4-43c7-11e8-84af-bee17e711ac6.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
