### PR TITLE
Maintenance: Update CFG_CAL_DAC to Charge Conversion for v3

### DIFF
--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -42,9 +42,16 @@ def fill2DScurveSummaryPlots(scurveTree, vfatHistos, vfatChanLUT, vfatHistosPanP
     for vfat in vfatHistos:
         listOfBinEdgesY[vfat] = [ vfatHistos[vfat].GetYaxis().GetBinLowEdge(binY) 
                 for binY in range(1,vfatHistos[vfat].GetNbinsY()+2) ] #Include overflow
-        
+        pass
+
+    # check current pulse?
+    checkCurrentPulse = False
+    listOfBranchNames = [branch.GetName() for branch in inF.scurveTree.GetListOfBranches() ]
+    if "isCurrentPulse" in listOfBranchNames:
+        checkCurrentPulse = True
+        pass
+
     # Fill Histograms
-    checkCurrentPulse = ("isCurrentPulse" in scurveTree.GetListOfBranches())
     for event in scurveTree:
         if chanMasks is not None:
             if chanMasks[event.vfatN][event.vfatCH]:
@@ -55,7 +62,7 @@ def fill2DScurveSummaryPlots(scurveTree, vfatHistos, vfatChanLUT, vfatHistosPanP
         
         # Determine charge
         charge = calDAC2Q_m[event.vfatN]*event.vcal+calDAC2Q_b[event.vfatN]
-        if checkCurrentPulse: #v3 electronics
+        if checkCurrentPulse: #Potentially v3 electronics
             if event.isCurrentPulse:
                 #Q = CAL_DUR * CAL_DAC * 10nA * CAL_FS
                 charge = (1./ 40079000) * event.vcal * (10 * 1e-9) * dict_calSF[event.calSF] * 1e15
@@ -147,6 +154,8 @@ if __name__ == '__main__':
                       help="Physical filename of a custom, non-default, channel mapping (optional)", metavar="extChanMapping")
     parser.add_option("-f", "--fit", action="store_true", dest="performFit",
                       help="Fit scurves and save fit information to output TFile", metavar="performFit")
+    parser.add_option("--isVFAT3", action="store_true", dest="isVFAT3",
+                      help="Provide this argument if input data was acquired from vfat3", metavar="isVFAT3")
     parser.add_option("--IsTrimmed", action="store_true", dest="IsTrimmed",
                       help="If the data is from a trimmed scan, plot the value it tried aligning to", metavar="IsTrimmed")
     parser.add_option("--zscore", type="float", dest="zscore", default=3.5,
@@ -209,14 +218,14 @@ if __name__ == '__main__':
         vSummaryPlots[vfat] = r.TH2D('vSummaryPlots%i'%vfat,
                 'VFAT %i;Channels;VCal #left(fC#right)'%vfat,
                 128,-0.5,127.5,256,
-                calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
-                calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
+                calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat],
+                calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat])
         vSummaryPlots[vfat].GetYaxis().SetTitleOffset(1.5)
         vSummaryPlotsNoMaskedChan[vfat] = r.TH2D('vSummaryPlotsNoMaskedChan%i'%vfat,
                 'VFAT %i;Channels;VCal #left(fC#right)'%vfat,
                 128,-0.5,127.5,256,
-                calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
-                calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
+                calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat],
+                calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat])
         vSummaryPlotsNoMaskedChan[vfat].GetYaxis().SetTitleOffset(1.5)
         if not (options.channels or options.PanPin):
             vSummaryPlots[vfat].SetXTitle('Strip')
@@ -226,26 +235,26 @@ if __name__ == '__main__':
             vSummaryPlots[vfat] = r.TH2D('vSummaryPlots%i'%vfat,
                     'VFAT %i_0-63;63 - Panasonic Pin;VCal #left(fC#right)'%vfat,
                     64,-0.5,63.5,256,
-                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
-                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
+                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat],
+                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat])
             vSummaryPlots[vfat].GetYaxis().SetTitleOffset(1.5)
             vSummaryPlotsNoMaskedChan[vfat] = r.TH2D('vSummaryPlotsNoMaskedChan%i'%vfat,
                     'VFAT %i_0-63;63 - Panasonic Pin;VCal #left(fC#right)'%vfat,
                     64,-0.5,63.5,256,
-                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
-                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
+                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat],
+                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat])
             vSummaryPlotsNoMaskedChan[vfat].GetYaxis().SetTitleOffset(1.5)
             vSummaryPlotsPanPin2[vfat] = r.TH2D('vSummaryPlotsPanPin2_%i'%vfat,
                     'vSummaryPlots%i_64-127;127 - Panasonic Pin;VCal #left(fC#right)'%vfat,
                     64,-0.5,63.5,256,
-                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
-                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
+                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat],
+                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat])
             vSummaryPlotsPanPin2[vfat].GetYaxis().SetTitleOffset(1.5)
             vSummaryPlotsNoMaskedChanPanPin2[vfat] = r.TH2D('vSummaryPlotsNoMaskedChanPanPin2_%i'%vfat,
                     'vSummaryPlots%i_64-127;127 - Panasonic Pin;VCal #left(fC#right)'%vfat,
                     64,-0.5,63.5,256,
-                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat],
-                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat])
+                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat],
+                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat])
             vSummaryPlotsNoMaskedChanPanPin2[vfat].GetYaxis().SetTitleOffset(1.5)
             pass
         for chan in range (0,128):
@@ -278,12 +287,11 @@ if __name__ == '__main__':
     inF = r.TFile(filename+'.root')
 
     # Create the fitter
-    checkCurrentPulse = ("isCurrentPulse" in inF.scurveTree.GetListOfBranches())
     if options.performFit:
         fitter = ScanDataFitter(
                 calDAC2Q_m=calDAC2Q_Slope, 
                 calDAC2Q_b=calDAC2Q_Intercept,
-                isVFAT3=checkCurrentPulse,
+                isVFAT3=options.isVFAT3
                 )
         pass
 
@@ -333,7 +341,7 @@ if __name__ == '__main__':
         print("Fitting Histograms")
         fitSummary = open(filename+'/fitSummary.txt','w')
         fitSummary.write('vfatN/I:vfatID/I:vfatCH/I:fitP0/F:fitP1/F:fitP2/F:fitP3/F\n')
-        scanFitResults = fitter.fit()
+        scanFitResults = fitter.fit(debug=options.debug)
         for vfat in range(0,24):
             for chan in range(0,128):
                 fitSummary.write(

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -59,8 +59,6 @@ def fill2DScurveSummaryPlots(scurveTree, vfatHistos, vfatChanLUT, vfatHistosPanP
             if event.isCurrentPulse:
                 #Q = CAL_DUR * CAL_DAC * 10nA * CAL_FS
                 charge = (1./ 40079000) * event.vcal * (10 * 1e-9) * dict_calSF[event.calSF] * 1e15
-            else:
-                charge = calDAC2Q_m[event.vfatN]*(256-event.vcal)+calDAC2Q_b[event.vfatN]
         
         # Determine the binY that corresponds to this charge value
         chargeBin = first_index_gt(listOfBinEdgesY[event.vfatN], charge)-1

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -191,7 +191,7 @@ class ScanDataFitter(DeadChannelFinder):
                                         self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat],
                                         self.calDAC2Q_m[vfat]*rand,
                                         self.calDAC2Q_m[vfat]*(128)+self.calDAC2Q_b[vfat],
-                                        self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat]
+                                        self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat],
                                         self.calDAC2Q_m[vfat]*(8+stepN*8)+self.calDAC2Q_b[vfat],
                                         self.calDAC2Q_m[vfat]*(1)+self.calDAC2Q_b[vfat]
                                     )

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -152,11 +152,12 @@ class ScanDataFitter(DeadChannelFinder):
                 stepN = 0
                 
                 if debug:
-                    print "| p0_low | p0 | p0_high | p1_low | p1 | p1_high | p2_low | p2 | p2_high |"
-                    print "| ------ | -- | ------- | ------ | -- | ------- | ------ | -- | ------- |"
+                    print "| vfatN | vfatCH | isVFAT3 | p0_low | p0 | p0_high | p1_low | p1 | p1_high | p2_low | p2 | p2_high |"
+                    print "| ----- | ------ | ------- | ------ | -- | ------- | ------ | -- | ------- | ------ | -- | ------- |"
                 while(stepN < 15):
-                    rand = max(0.0, random.Gaus(10, 5)) # do not accept negative numbers
-                    
+                    #rand = max(0.0, random.Gaus(10, 5)) # do not accept negative numbers
+                    rand = abs(random.Gaus(10, 5)) # take positive definite numbers
+
                     # Make sure the input parameters are positive
                     if rand > 100: continue
                     if (self.calDAC2Q_m[vfat]*(8+stepN*8)+self.calDAC2Q_b[vfat]) < 0:
@@ -165,10 +166,15 @@ class ScanDataFitter(DeadChannelFinder):
                     #if (self.calDAC2Q_m[vfat]*(rand)+self.calDAC2Q_b[vfat]) < 0: continue
 
                     # Provide an initial guess
-                    fitTF1.SetParameter(0, self.calDAC2Q_m[vfat]*(8+stepN*8)+self.calDAC2Q_b[vfat])
-                    fitTF1.SetParameter(1, self.calDAC2Q_m[vfat]*rand)
-                    fitTF1.SetParameter(2, self.calDAC2Q_m[vfat]*(8+stepN*8)+self.calDAC2Q_b[vfat])
-                    fitTF1.SetParameter(3, self.Nev[vfat][ch]/2.)
+                    init_guess_p0 = self.calDAC2Q_m[vfat]*(8+stepN*8)+self.calDAC2Q_b[vfat]
+                    init_guess_p1 = abs(self.calDAC2Q_m[vfat]*rand)  #self.calDAC2Q_m[vfat] might be negative (e.g. VFAT3 case)
+                    init_guess_p2 = init_guess_p0
+                    init_guess_p3 = self.Nev[vfat][ch]/2.
+
+                    fitTF1.SetParameter(0, init_guess_p0)
+                    fitTF1.SetParameter(1, init_guess_p1)
+                    fitTF1.SetParameter(2, init_guess_p2)
+                    fitTF1.SetParameter(3, init_guess_p3)
 
                     # Set Parameter Limits
                     if self.isVFAT3:
@@ -184,27 +190,33 @@ class ScanDataFitter(DeadChannelFinder):
                     
                     if debug:
                         if self.isVFAT3:
-                            print "| %f | %f | %f | %f | %f | %f | %f | %f | %f |"%(
+                            print "| %i | %i | %i | %f | %f | %f | %f | %f | %f | %f | %f | %f |"%(
+                                        vfat,
+                                        ch,
+                                        self.isVFAT3,
                                         self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat],
-                                        self.calDAC2Q_m[vfat]*(8+stepN*8)+self.calDAC2Q_b[vfat],
+                                        init_guess_p0,
                                         self.calDAC2Q_m[vfat]*(1)+self.calDAC2Q_b[vfat],
                                         self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat],
-                                        self.calDAC2Q_m[vfat]*rand,
+                                        init_guess_p1,
                                         self.calDAC2Q_m[vfat]*(128)+self.calDAC2Q_b[vfat],
                                         self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat],
-                                        self.calDAC2Q_m[vfat]*(8+stepN*8)+self.calDAC2Q_b[vfat],
+                                        init_guess_p2,
                                         self.calDAC2Q_m[vfat]*(1)+self.calDAC2Q_b[vfat]
                                     )
                         else:
-                            print "| %f | %f | %f | %f | %f | %f | %f | %f | %f |"%(
+                            print "| %i | %i | %i | %f | %f | %f | %f | %f | %f | %f | %f | %f |"%(
+                                        vfat,
+                                        ch,
+                                        self.isVFAT3,
                                         0.01,
-                                        self.calDAC2Q_m[vfat]*(8+stepN*8)+self.calDAC2Q_b[vfat],
+                                        init_guess_p0,
                                         self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat],
                                         0.0,
-                                        self.calDAC2Q_m[vfat]*rand,
+                                        init_guess_p1,
                                         self.calDAC2Q_m[vfat]*(128)+self.calDAC2Q_b[vfat],
                                         0.0,
-                                        self.calDAC2Q_m[vfat]*(8+stepN*8)+self.calDAC2Q_b[vfat],
+                                        init_guess_p2,
                                         self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat]
                                     )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `vfat3` team has decided to change the convention for the calibration coefficients `calDAC2Q_m` and `calDAC2Q_b`.  Previously in voltage step mode the "inverted" `CFG_CAL_DAC` register value was used, i.e.:

```
Q = calDAC2Q_m * (256 - CFG_CAL_DAC) + calDAC2Q_b
``` 

Now the raw register value will be used, e.g.:

```
Q = calDAC2Q_m * (CFG_CAL_DAC) + calDAC2Q_b
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Maintenance (updates to the software that are transparent to the user)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
This was reported by Henri who is developing the `vfat3` production testing:

>My idea was to make the fit on the raw register value so the charge equation for the voltage mode would become:
>Q=m*CAL_DAC+b
>which in my mind would be more straight forward and avoid confusion about when the inversion is used and when not.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Took a new scurve and analyzed the data.

### Screenshots (if appropriate):
![summary](https://user-images.githubusercontent.com/6432141/41134595-7182667e-6acd-11e8-81dc-8c6df52d91ed.png)

Note VFAT5 & 12 were masked in this test.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
