### PR TITLE
Bug Fix: initial guess for scurve mean position was range limited 

### DIFF
--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -25,6 +25,7 @@ class ScanDataFitter(DeadChannelFinder):
         self.Nev = ndict()
         self.scanFuncs  = ndict()
         self.scanHistos = ndict()
+        self.scanHistosChargeBins = ndict()
         self.scanCount  = ndict()
         self.scanFitResults   = ndict()
 
@@ -58,6 +59,10 @@ class ScanDataFitter(DeadChannelFinder):
                             self.calDAC2Q_m[vfat]*1+self.calDAC2Q_b[vfat],self.calDAC2Q_m[vfat]*253+self.calDAC2Q_b[vfat])
                     self.scanHistos[vfat][ch] = r.TH1D('scurve_vfat%i_chan%i_h'%(vfat,ch),'scurve_vfat%i_chan%i_h'%(vfat,ch),
                             254,self.calDAC2Q_m[vfat]*0.5+self.calDAC2Q_b[vfat],self.calDAC2Q_m[vfat]*254.5+self.calDAC2Q_b[vfat])
+                    pass
+                self.scanHistosChargeBins[vfat][ch] = [self.scanHistos[vfat][ch].GetXaxis().GetBinLowEdge(binX) for binX in range(1,self.scanHistos[vfat][ch].GetNbinsX()+2) ] #Include overflow
+                pass
+            pass
 
         self.fitValid = [ np.zeros(128, dtype=bool) for vfat in range(24) ]
 
@@ -80,7 +85,14 @@ class ScanDataFitter(DeadChannelFinder):
         else:
             if(event.vcal > 250):
                 self.scanCount[event.vfatN][event.vfatCH] += event.Nhits
-        self.scanHistos[event.vfatN][event.vfatCH].Fill(charge,event.Nhits)
+                pass
+            pass
+
+        from gempython.gemplotting.utils.anautilities import first_index_gt
+        from math import sqrt
+        chargeBin = first_index_gt(self.scanHistosChargeBins[event.vfatN][event.vfatCH], charge)-1
+        self.scanHistos[event.vfatN][event.vfatCH].SetBinContent(chargeBin,event.Nhits)
+        self.scanHistos[event.vfatN][event.vfatCH].SetBinError(chargeBin,sqrt(event.Nhits))
         self.Nev[event.vfatN][event.vfatCH] = event.Nev
 
         return
@@ -152,9 +164,9 @@ class ScanDataFitter(DeadChannelFinder):
                 stepN = 0
                 
                 if debug:
-                    print "| vfatN | vfatCH | isVFAT3 | p0_low | p0 | p0_high | p1_low | p1 | p1_high | p2_low | p2 | p2_high |"
-                    print "| ----- | ------ | ------- | ------ | -- | ------- | ------ | -- | ------- | ------ | -- | ------- |"
-                while(stepN < 15):
+                    print "| stepN | vfatN | vfatCH | isVFAT3 | p0_low | p0 | p0_high | p1_low | p1 | p1_high | p2_low | p2 | p2_high |"
+                    print "| ----- | ----- | ------ | ------- | ------ | -- | ------- | ------ | -- | ------- | ------ | -- | ------- |"
+                while(stepN < 30):
                     #rand = max(0.0, random.Gaus(10, 5)) # do not accept negative numbers
                     rand = abs(random.Gaus(10, 5)) # take positive definite numbers
 
@@ -190,7 +202,8 @@ class ScanDataFitter(DeadChannelFinder):
                     
                     if debug:
                         if self.isVFAT3:
-                            print "| %i | %i | %i | %f | %f | %f | %f | %f | %f | %f | %f | %f |"%(
+                            print "| %i | %i | %i | %i | %f | %f | %f | %f | %f | %f | %f | %f | %f |"%(
+                                        stepN,
                                         vfat,
                                         ch,
                                         self.isVFAT3,
@@ -205,7 +218,8 @@ class ScanDataFitter(DeadChannelFinder):
                                         self.calDAC2Q_m[vfat]*(1)+self.calDAC2Q_b[vfat]
                                     )
                         else:
-                            print "| %i | %i | %i | %f | %f | %f | %f | %f | %f | %f | %f | %f |"%(
+                            print "| %i | %i | %i | %i | %f | %f | %f | %f | %f | %f | %f | %f | %f |"%(
+                                        stepN,
                                         vfat,
                                         ch,
                                         self.isVFAT3,
@@ -246,6 +260,22 @@ class ScanDataFitter(DeadChannelFinder):
                         MinChi2Temp = fitChi2
                         pass
                     if (MinChi2Temp < 50): break
+                    pass
+                if debug:
+                    print("Converged fit results:")
+                    print "| stepN | vfatN | vfatCH | isVFAT3 | p0 | p1 | p2 | Chi2 | NDF | NormChi2"
+                    print "| ----- | ----- | ------ | ------- | -- | -- | -- | Chi2 | NDF | NormChi2"
+                    print "| %i | %i | %i | %i | %f | %f | %f | %f | %i | %f |"%(
+                            stepN,
+                            vfat,
+                            ch,
+                            self.isVFAT3,
+                            self.scanFitResults[0][vfat][ch],
+                            self.scanFitResults[1][vfat][ch],
+                            self.scanFitResults[2][vfat][ch],
+                            self.scanFitResults[3][vfat][ch],
+                            self.scanFitResults[5][vfat][ch],
+                            self.scanFitResults[3][vfat][ch] / self.scanFitResults[5][vfat][ch])
                     pass
                 pass
             pass

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -180,7 +180,7 @@ class ScanDataFitter(DeadChannelFinder):
                     # Provide an initial guess
                     init_guess_p0 = self.calDAC2Q_m[vfat]*(8+stepN*8)+self.calDAC2Q_b[vfat]
                     init_guess_p1 = abs(self.calDAC2Q_m[vfat]*rand)  #self.calDAC2Q_m[vfat] might be negative (e.g. VFAT3 case)
-                    init_guess_p2 = init_guess_p0
+                    init_guess_p2 = 0.
                     init_guess_p3 = self.Nev[vfat][ch]/2.
 
                     fitTF1.SetParameter(0, init_guess_p0)
@@ -192,13 +192,14 @@ class ScanDataFitter(DeadChannelFinder):
                     if self.isVFAT3:
                         fitTF1.SetParLimits(0, self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat], self.calDAC2Q_m[vfat]*(1)+self.calDAC2Q_b[vfat])
                         fitTF1.SetParLimits(1, self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat], self.calDAC2Q_m[vfat]*(128)+self.calDAC2Q_b[vfat])
-                        fitTF1.SetParLimits(2, self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat], self.calDAC2Q_m[vfat]*(1)+self.calDAC2Q_b[vfat])
+                        fitTF1.SetParLimits(2, 0, self.Nev[vfat][ch])
                     else:
                         fitTF1.SetParLimits(0, 0.01, self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat])
                         fitTF1.SetParLimits(1, 0.0,  self.calDAC2Q_m[vfat]*(128)+self.calDAC2Q_b[vfat])
-                        fitTF1.SetParLimits(2, 0.0,  self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat])
+                        fitTF1.SetParLimits(2, 0, self.Nev[vfat][ch])
+                        pass
 
-                    fitTF1.SetParLimits(3, 0.0,  self.Nev[vfat][ch] * 2.)
+                    fitTF1.SetParLimits(3, 0.75*init_guess_p3, 1.25*init_guess_p3)
                     
                     if debug:
                         if self.isVFAT3:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Found that in some cases scurve fitting was hitting the number of max iterations and not converging on the true fit parameter values.  This was especially true when scurve mean position was at low values of charge.  This PR addresses this concern.

Additionally poisson error bars for scurves are now assigned in scurve fit process addressing [this](https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/61#issuecomment-376870516) comment of #61.

Finally additionally debugging info is now provided when `debug` is set to True.  Namely the printing of the converged values after the fitting procedure for a channel completes. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Previously the scurve fitting procedure was failing to converge on the true fit parameters due to the initial guess never being close enough to the true value.  The limitation of `stepN < 15` was causing only half the possible values of `scurve_mean` to be scanned.  This was leading to the fit results poorly describing the histogram as shown:

<img width="1311" alt="screen shot 2018-06-13 at 10 50 22" src="https://user-images.githubusercontent.com/6432141/41348995-bcce1912-6f0e-11e8-8373-23b334328aa8.png">

Note here the central value (error bar) of the black points represents the scurve mean (sigma) value.  Clearly you can see a large number of scurves are not being fit correctly when the scurve mean position is low.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Re-analysis of scurve data.  After allowing `stepN` to proceed to 30 this enables the CAL_DAC/VCAL value to go from 0 to 256 (previously was limited to 0 to 128). 

### Screenshots (if appropriate):
After this change you can see the scurve histograms are more well described by the fits:

<img width="873" alt="screen shot 2018-06-13 at 13 23 43" src="https://user-images.githubusercontent.com/6432141/41349076-02862cec-6f0f-11e8-9802-846753af3591.png">

Again the black point's central value (error bar) represents the scurve mean (sigma) value.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
