### PR TITLE
Bug Fix:  Bad histo range and superfluous warning message printing in anaUltraScurve.py

### DIFF
--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -154,7 +154,7 @@ if __name__ == '__main__':
                       help="Physical filename of a custom, non-default, channel mapping (optional)", metavar="extChanMapping")
     parser.add_option("-f", "--fit", action="store_true", dest="performFit",
                       help="Fit scurves and save fit information to output TFile", metavar="performFit")
-    parser.add_option("--isVFAT3", action="store_true", dest="isVFAT3",
+    parser.add_option("--isVFAT3", action="store_true", dest="isVFAT3", default=False,
                       help="Provide this argument if input data was acquired from vfat3", metavar="isVFAT3")
     parser.add_option("--IsTrimmed", action="store_true", dest="IsTrimmed",
                       help="If the data is from a trimmed scan, plot the value it tried aligning to", metavar="IsTrimmed")

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -215,17 +215,24 @@ if __name__ == '__main__':
 
     # Initialize distributions
     for vfat in range(0,24):
+        if options.isVFAT3:
+            yMin_Charge = calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat]
+            yMax_Charge = calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat]
+        else:
+            yMin_Charge = calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat]
+            yMax_Charge = calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat]
+            pass
         vSummaryPlots[vfat] = r.TH2D('vSummaryPlots%i'%vfat,
                 'VFAT %i;Channels;VCal #left(fC#right)'%vfat,
                 128,-0.5,127.5,256,
-                calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat],
-                calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat])
+                yMin_Charge,
+                yMax_Charge)
         vSummaryPlots[vfat].GetYaxis().SetTitleOffset(1.5)
         vSummaryPlotsNoMaskedChan[vfat] = r.TH2D('vSummaryPlotsNoMaskedChan%i'%vfat,
                 'VFAT %i;Channels;VCal #left(fC#right)'%vfat,
                 128,-0.5,127.5,256,
-                calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat],
-                calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat])
+                yMin_Charge,
+                yMax_Charge)
         vSummaryPlotsNoMaskedChan[vfat].GetYaxis().SetTitleOffset(1.5)
         if not (options.channels or options.PanPin):
             vSummaryPlots[vfat].SetXTitle('Strip')
@@ -235,26 +242,26 @@ if __name__ == '__main__':
             vSummaryPlots[vfat] = r.TH2D('vSummaryPlots%i'%vfat,
                     'VFAT %i_0-63;63 - Panasonic Pin;VCal #left(fC#right)'%vfat,
                     64,-0.5,63.5,256,
-                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat],
-                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat])
+                    yMin_Charge,
+                    yMax_Charge)
             vSummaryPlots[vfat].GetYaxis().SetTitleOffset(1.5)
             vSummaryPlotsNoMaskedChan[vfat] = r.TH2D('vSummaryPlotsNoMaskedChan%i'%vfat,
                     'VFAT %i_0-63;63 - Panasonic Pin;VCal #left(fC#right)'%vfat,
                     64,-0.5,63.5,256,
-                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat],
-                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat])
+                    yMin_Charge,
+                    yMax_Charge)
             vSummaryPlotsNoMaskedChan[vfat].GetYaxis().SetTitleOffset(1.5)
             vSummaryPlotsPanPin2[vfat] = r.TH2D('vSummaryPlotsPanPin2_%i'%vfat,
                     'vSummaryPlots%i_64-127;127 - Panasonic Pin;VCal #left(fC#right)'%vfat,
                     64,-0.5,63.5,256,
-                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat],
-                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat])
+                    yMin_Charge,
+                    yMax_Charge)
             vSummaryPlotsPanPin2[vfat].GetYaxis().SetTitleOffset(1.5)
             vSummaryPlotsNoMaskedChanPanPin2[vfat] = r.TH2D('vSummaryPlotsNoMaskedChanPanPin2_%i'%vfat,
                     'vSummaryPlots%i_64-127;127 - Panasonic Pin;VCal #left(fC#right)'%vfat,
                     64,-0.5,63.5,256,
-                    calDAC2Q_Slope[vfat]*255.5+calDAC2Q_Intercept[vfat],
-                    calDAC2Q_Slope[vfat]*-0.5+calDAC2Q_Intercept[vfat])
+                    yMin_Charge,
+                    yMax_Charge)
             vSummaryPlotsNoMaskedChanPanPin2[vfat].GetYaxis().SetTitleOffset(1.5)
             pass
         for chan in range (0,128):

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -192,11 +192,11 @@ class ScanDataFitter(DeadChannelFinder):
                     if self.isVFAT3:
                         fitTF1.SetParLimits(0, self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat], self.calDAC2Q_m[vfat]*(1)+self.calDAC2Q_b[vfat])
                         fitTF1.SetParLimits(1, self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat], self.calDAC2Q_m[vfat]*(128)+self.calDAC2Q_b[vfat])
-                        fitTF1.SetParLimits(2, 0, self.Nev[vfat][ch])
+                        fitTF1.SetParLimits(2, -0.01, self.Nev[vfat][ch])
                     else:
-                        fitTF1.SetParLimits(0, 0.01, self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat])
+                        fitTF1.SetParLimits(0, -0.01, self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat])
                         fitTF1.SetParLimits(1, 0.0,  self.calDAC2Q_m[vfat]*(128)+self.calDAC2Q_b[vfat])
-                        fitTF1.SetParLimits(2, 0, self.Nev[vfat][ch])
+                        fitTF1.SetParLimits(2, -0.01, self.Nev[vfat][ch])
                         pass
 
                     fitTF1.SetParLimits(3, 0.75*init_guess_p3, 1.25*init_guess_p3)
@@ -214,9 +214,9 @@ class ScanDataFitter(DeadChannelFinder):
                                         self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat],
                                         init_guess_p1,
                                         self.calDAC2Q_m[vfat]*(128)+self.calDAC2Q_b[vfat],
-                                        self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat],
+                                        -0.01,
                                         init_guess_p2,
-                                        self.calDAC2Q_m[vfat]*(1)+self.calDAC2Q_b[vfat]
+                                        self.Nev[vfat][ch]
                                     )
                         else:
                             print "| %i | %i | %i | %i | %f | %f | %f | %f | %f | %f | %f | %f | %f |"%(
@@ -224,15 +224,15 @@ class ScanDataFitter(DeadChannelFinder):
                                         vfat,
                                         ch,
                                         self.isVFAT3,
-                                        0.01,
+                                        -0.01,
                                         init_guess_p0,
                                         self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat],
                                         0.0,
                                         init_guess_p1,
                                         self.calDAC2Q_m[vfat]*(128)+self.calDAC2Q_b[vfat],
-                                        0.0,
+                                        -0.01,
                                         init_guess_p2,
-                                        self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat]
+                                        self.Nev[vfat][ch]
                                     )
 
                     # Fit


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When not supplying the `--isVFAT3` option (e.g. for v2b electronics) the y-axis range of histograms made by `anaUltraScurve.py` was incorrect (e.g. min = max and max = min).  Additionally superfluous message printing during fitting due to poor choice of parameter limits is addressed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Couldn't analyze v2b electronics.  Annoyed by meaningless message spam.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Re-analyzed old data.

### Screenshots (if appropriate):
<img width="695" alt="scurve_burned_vfat2_by_vfatchannels" src="https://user-images.githubusercontent.com/6432141/41730185-779404f6-757b-11e8-82e4-c0c8f7119746.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
