### PR TITLE
New Feature: 2D Detector Map

### DIFF
--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -661,7 +661,8 @@ if __name__ == '__main__':
         gDetThresh_All.GetYaxis().SetTitle("Entries / %f fC"%(detThresh_Std/10.))
 
         # Make a thresh map dist for the entire detector
-        hDetMapThresh = get2DMapOfDetector(dict_vfatChanLUT, allThresh, stripChanOrPinType, "threshold #left(fC#right)")
+        hDetMapThresh = get2DMapOfDetector(dict_vfatChanLUT, allThresh, stripChanOrPinType, "threshold")
+        hDetMapThresh.SetZTitle("threshold #left(fC#right)")
 
         # Make a EffPed Summary Dist For the entire Detector
         hDetEffPed_All = r.TH1F("hScurveEffPedDist_All","All VFATs;S-Curve Effective Pedestal #left(N#right);N",
@@ -695,7 +696,9 @@ if __name__ == '__main__':
         gDetENC_All.GetYaxis().SetTitle("Entries / %f fC"%(detENC_Std/10.))
         
         # Make a ENC map dist for the entire detector
-        hDetMapENC = get2DMapOfDetector(dict_vfatChanLUT, allENC, stripChanOrPinType, "noise #left(fC#right)")
+        hDetMapENC = get2DMapOfDetector(dict_vfatChanLUT, allENC, stripChanOrPinType, "noise")
+        hDetMapENC.SetZTitle("noise #left(fC#right)")
+        hDetMapENC.GetZaxis().SetRangeUser(0.5,0.30)
 
         # Make the plots by iEta
         for ieta in range(1,9):

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -142,7 +142,7 @@ if __name__ == '__main__':
     import ROOT as r
     
     from array import array
-    from gempython.gemplotting.utils.anautilities import getEmptyPerVFATList, getMapping, isOutlierMADOneSided, parseCalFile, saveSummary, saveSummaryByiEta
+    from gempython.gemplotting.utils.anautilities import get2DMapOfDetector, getEmptyPerVFATList, getMapping, isOutlierMADOneSided, parseCalFile, saveSummary, saveSummaryByiEta
     from gempython.gemplotting.utils.anaInfo import mappingNames, MaskReason
     from gempython.gemplotting.fitting.fitScanData import ScanDataFitter
     from gempython.utils.nesteddict import nesteddict as ndict
@@ -660,6 +660,9 @@ if __name__ == '__main__':
         gDetThresh_All.GetXaxis().SetTitle("scurve mean pos #left(fC#right)")
         gDetThresh_All.GetYaxis().SetTitle("Entries / %f fC"%(detThresh_Std/10.))
 
+        # Make a thresh map dist for the entire detector
+        hDetMapThresh = get2DMapOfDetector(dict_vfatChanLUT, allThresh, stripChanOrPinType, "threshold #left(fC#right)")
+
         # Make a EffPed Summary Dist For the entire Detector
         hDetEffPed_All = r.TH1F("hScurveEffPedDist_All","All VFATs;S-Curve Effective Pedestal #left(N#right);N",
                                 nPulses+1, -0.5, nPulses+0.5)
@@ -690,7 +693,10 @@ if __name__ == '__main__':
         gDetENC_All.SetName("gScurveSigmaDist_All")
         gDetENC_All.GetXaxis().SetTitle("scurve sigma #left(fC#right)")
         gDetENC_All.GetYaxis().SetTitle("Entries / %f fC"%(detENC_Std/10.))
-    
+        
+        # Make a ENC map dist for the entire detector
+        hDetMapENC = get2DMapOfDetector(dict_vfatChanLUT, allENC, stripChanOrPinType, "noise #left(fC#right)")
+
         # Make the plots by iEta
         for ieta in range(1,9):
             # S-curve mean position (threshold)
@@ -861,10 +867,12 @@ if __name__ == '__main__':
         dirSummary.cd()
         hDetThresh_All.Write()
         gDetThresh_All.Write()
+        hDetMapThresh.Write()
         hDetEffPed_All.Write()
         gDetEffPed_All.Write()
         hDetENC_All.Write()
         gDetENC_All.Write()
+        hDetMapENC.Write()
    
         for ieta in range(1,9):
             dir_iEta = dirSummary.mkdir("ieta%i"%ieta)

--- a/anautilities.py
+++ b/anautilities.py
@@ -69,8 +69,8 @@ def get2DMapOfDetector(vfatChanLUT, obsData, mapName, zLabel):
     for idx in range(3072):
         # Determine vfat, ieta, and iphi
         vfat = idx // 128
-        ieta = chamber_vfatPos2iEtaiPhi[vfatN][0]
-        iphi = chamber_vfatPos2iEtaiPhi[vfatN][1]
+        ieta = chamber_vfatPos2iEtaiPhi[vfat][0]
+        iphi = chamber_vfatPos2iEtaiPhi[vfat][1]
 
         # Determine strip, panasonic pin, or channel
         chan = idx % 128

--- a/mapping/chamberInfo.py
+++ b/mapping/chamberInfo.py
@@ -70,9 +70,11 @@ chamber_iEta2VFATPos = {
         }
 
 chamber_vfatPos2iEta = {}
+chamber_vfatPos2iEtaiPhi = {}
 for ieta, vfatRow in chamber_iEta2VFATPos.iteritems():
     for vfat,phi in vfatRow.iteritems():
         chamber_vfatPos2iEta[vfat] = ieta
+        chamber_vfatPos2iEtaiPhi[vfat] = (ieta,phi)
         pass
     pass
 
@@ -91,7 +93,7 @@ chamber_vfatDACSettings = {
     #        #Set the Latency - 10x10 PMT on R&D Setup
     #        "CFG_LATENCY":98,
     #        #Correct the bug in the shaper
-    #        "CFG_PT":3,
+    #        "CFG_PT":7,
     #        #Updated DAC settings from Flavio
     #        "CFG_BIAS_SH_I_BDIFF":150,
     #        "CFG_BIAS_SH_I_BFCAS":250,
@@ -126,7 +128,7 @@ chamber_vfatDACSettings = {
     #        #Set the Latency - 10x10 PMT on R&D Setup
     #        "CFG_LATENCY":98,
     #        #Correct the bug in the shaper
-    #        "CFG_PT":3,
+    #        "CFG_PT":7,
     #        #Updated DAC settings from Flavio
     #        "CFG_BIAS_SH_I_BDIFF":150,
     #        "CFG_BIAS_SH_I_BFCAS":250,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addresses: https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/120

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Places a given observable, in this case scurve sigma and scurve noise, in a ieta vs. strip/chan map of the detector in a single plot.  Will help people not familiar with 3x8 grid plots to visualize a given observable.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):

<img width="610" alt="screen shot 2018-06-28 at 21 03 23" src="https://user-images.githubusercontent.com/6432141/42055264-ea5c96e2-7b16-11e8-97bd-089639513510.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
