### PR TITLE
Install the man pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,6 +101,7 @@ after_script: skip
     - gem install github_changelog_generator
   script:
     - echo 'Running build stage on docker container $DOCKER_CONTAINER_ID'
+    - docker exec -ti $DOCKER_CONTAINER_ID /bin/bash -eic "sudo pip install -Ur /home/daqbuild/${REPO_NAME}/requirements-dev.txt" || travis_terminate 1
     - docker exec -ti $DOCKER_CONTAINER_ID /bin/bash -eic "cd /home/daqbuild/${REPO_NAME}; make" || travis_terminate 1
     - docker exec -ti $DOCKER_CONTAINER_ID /bin/bash -eic "cd /home/daqbuild/${REPO_NAME}; make rpm" || travis_terminate 1
     - docker exec -ti $DOCKER_CONTAINER_ID /bin/bash -eic "cd /home/daqbuild/${REPO_NAME}; rpm -q --filesbypkg -p rpm/*.rpm"

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,10 @@ preprpm: default man
 	@cp -rf ana_scans.py $(ScriptDir)
 	@cp -rf anaXDAQLatency.py $(ScriptDir)
 	@cp -rf packageFiles4Docker.py $(ScriptDir)
+	-rm -rf $(ManDir)
 	$(MakeDir) $(ManDir)
 	@cp -rf doc/_build/man/* $(ManDir)
+	gzip $(ManDir)/*
 	-cp -rf README.md LICENSE CHANGELOG.md MANIFEST.in requirements.txt $(PackageDir)
 	-cp -rf README.md LICENSE CHANGELOG.md MANIFEST.in requirements.txt pkg
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ LongPackage  := gemplotting
 PackageName  := $(Namespace)_$(ShortPackage)
 PackageDir   := pkg/$(Namespace)/$(ShortPackage)
 ScriptDir    := pkg/$(Namespace)/scripts
+ManDir       := pkg/man
 
 # Explicitly define the modules that are being exported (for PEP420 compliance)
 PythonModules = ["$(Namespace).$(ShortPackage)", \
@@ -45,7 +46,7 @@ default:
 # need to ensure that the python only stuff is packaged into RPMs
 .PHONY: clean preprpm
 _rpmprep: preprpm
-preprpm: default
+preprpm: default man
 	@if ! [ -e pkg/installrpm.sh ]; then \
 		cp -rf config/scriptlets/installrpm.sh pkg/; \
 	fi
@@ -56,12 +57,15 @@ preprpm: default
 	@cp -rf ana_scans.py $(ScriptDir)
 	@cp -rf anaXDAQLatency.py $(ScriptDir)
 	@cp -rf packageFiles4Docker.py $(ScriptDir)
+	$(MakeDir) $(ManDir)
+	@cp -rf doc/_build/man/* $(ManDir)
 	-cp -rf README.md LICENSE CHANGELOG.md MANIFEST.in requirements.txt $(PackageDir)
 	-cp -rf README.md LICENSE CHANGELOG.md MANIFEST.in requirements.txt pkg
 
 clean:
 	-rm -rf $(ScriptDir)
 	-rm -rf $(PackageDir)
+	-rm -rf $(ManDir)
 	-rm -f  pkg/$(Namespace)/__init__.py
 	-rm -f  pkg/README.md
 	-rm -f  pkg/LICENSE

--- a/pkg/setup.cfg
+++ b/pkg/setup.cfg
@@ -4,7 +4,7 @@ name = gempython_gemplotting
 author = GEM Online Systems Group
 author_email = cms-gem-online-sw@cern.ch
 summary = __summary__
-license = MIT
+license = GNU General Public License v3 (GPLv3)
 description-file = gempython/gemplotting/README.md
 home-page = https://cms-gem-daq-project.github.io/gem-plotting-tools
 project_urls =
@@ -20,7 +20,8 @@ classifier =
     Topic :: Data Acquisition
     Topic :: Scientific
     Topic :: Utilities
-    License :: OSI Approved :: MIT
+    License :: OSI Approved :: GNU General Public License (GPL)
+    License :: OSI Approved :: GNU General Public License (GPLv3)
     Operating System :: POSIX
     Operating System :: Unix
     Programming Language :: Python [files]

--- a/pkg/setup.py
+++ b/pkg/setup.py
@@ -60,11 +60,11 @@ def getdatafiles():
     # Man files
     man_sections = {}
     for file in listdir(mandir):
-        print('Found man page: {}'.format(file))
+        print('Found man page: %s' % file)
         section = file.split('.')[-2]
         man_sections[section] = man_sections.get(section, []) + [join(mandir, file)]
     for section in man_sections:
-        data_files.append(('share/man/man{}'.format(section), man_sections[section]))
+        data_files.append(('share/man/man%s' % section, man_sections[section]))
 
     return data_files
 

--- a/pkg/setup.py
+++ b/pkg/setup.py
@@ -75,5 +75,5 @@ setup(name             = '__packagename__',
           'setuptools>=25.0'
       ],
       install_requires = getreqs(),
-      license          = 'MIT',
+      license          = 'GNU General Public License v3 (GPLv3)',
 )

--- a/pkg/setup.py
+++ b/pkg/setup.py
@@ -61,7 +61,7 @@ def getdatafiles():
     man_sections = {}
     for file in listdir(mandir):
         print('Found man page: %s' % file)
-        section = file.split('.')[-1]
+        section = file.split('.')[-2]
         man_sections[section] = man_sections.get(section, []) + [join(mandir, file)]
     for section in man_sections:
         data_files.append(('share/man/man%s' % section, man_sections[section]))

--- a/pkg/setup.py
+++ b/pkg/setup.py
@@ -7,6 +7,7 @@ from os.path import isfile,join
 scriptdir  = 'gempython/scripts'
 scriptpath = '/opt/cmsgemos/bin'
 scripts    = listdir(scriptdir)
+mandir     = 'man'
 
 def readme():
     with open('README.md') as f:
@@ -53,6 +54,20 @@ __builddate__='{6:s}'
 """.format(__version__,__release__,__buildtag__,__gitrev__,__gitver__,__packager__,__builddate__))
     return '{0:s}'.format(__version__)
 
+def getdatafiles():
+    data_files = []
+
+    # Man files
+    man_sections = {}
+    for file in listdir(mandir):
+        print('Found man page: %s' % file)
+        section = file.split('.')[-1]
+        man_sections[section] = man_sections.get(section, []) + [join(mandir, file)]
+    for section in man_sections:
+        data_files.append(('share/man/man%s' % section, man_sections[section]))
+
+    return data_files
+
 setup(name             = '__packagename__',
       version          = getVersion(),
       # use_scm_version  = True,
@@ -66,6 +81,7 @@ setup(name             = '__packagename__',
       url              = 'https://cms-gem-daq-project.github.io/gem-plotting-tools',
       # namespace_package = "gempython",
       # packages         = __pythonmodules__, # for PEP420 native namespace util
+      data_files       = getdatafiles(),
       packages           = find_packages(), # for pkgutil namespace method
       include_package_data = True,
       package_data     = getpkgdata(),

--- a/pkg/setup.py
+++ b/pkg/setup.py
@@ -60,11 +60,11 @@ def getdatafiles():
     # Man files
     man_sections = {}
     for file in listdir(mandir):
-        print('Found man page: %s' % file)
+        print('Found man page: {}'.format(file))
         section = file.split('.')[-2]
         man_sections[section] = man_sections.get(section, []) + [join(mandir, file)]
     for section in man_sections:
-        data_files.append(('share/man/man%s' % section, man_sections[section]))
+        data_files.append(('share/man/man{}'.format(section), man_sections[section]))
 
     return data_files
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,7 @@
 importlib
 setuptools>25,<=38
 pip>8,<10.1
-sphinx
+sphinx<1.5; python_version == '2.6'
+babel<2.6; python_version == '2.6' # It's a sphinx dep that gets updated otherwise
+sphinx; python_version >= '2.7'
 sphinxcontrib-napoleon


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR modifies the Makefile and setup script to install the man pages. They are installed at `$BASE/share/man`, where `$BASE` is as follows:

* `$VIRTUAL_ENV` when installed within a virtualenv
* `/usr` when installed system-wide

Man pages in the virtualenv can be accessed by setting the correct `$MANPATH`.

[outdated]
*A side-effect of this change is that I figured out how to modify the default `setuptools` install location. All scripts and macros are now installed in `$BASE/bin`. This means that `virtualenv` can take care of updating the `$PATH` (system-wide installs still need a setup script).*
[/outdated]

Another side-effect is that I corrected the license information in the package metadata. It was saying "MIT" while the `LICENSE` file always contained the text of GPLv3 (there is no way to change back to MIT without contacting every single contributor).

The setup script and developer documentation will need to be updated to use the `$MANPATH`.

### Downsides

* The `man` pages produced when the package is not installed may not be completely accurate. This is a problem for `make rpm` since it doesn't work inside a `virtualenv`.
* [outdated]*Macros and scripts are present twice in the package: under `bin/` and under `gempython/...`. I couldn't figure out why.*[/outdated]
* CI is broken :cry:

As a result of these downsides and my inability to fix them shortly, this PR is provided more as a list of commits to be cherry-picked.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
* #138
* [outdated] *Comment in `setup.py`:*
   ```
   would prefer to use this for executables, if one can control the install location
   to be user defined rather than /usr/bin
   ```
   *The preferred method (native support from `setuptools`) is now used.* [/outdated]

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* The `pip` and `rpm` packages were built, the former from a `virtualenv` and the latter on `gem904daq01`.
* The `pip` package was installed; scripts and man pages are correctly installed and have the correct permissions.
* It was checked that the `rpm` package contains all files.
* The `man` pages built in each environment were (quickly) checked.

Since I don't have access to a `rpm`-based machine and I don't want to install one, I couldn't check that the `rpm` package installs cleanly.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
