### PR TITLE
Fix endDate argument of makeListOfScanDatesFile

### DIFF
--- a/anautilities.py
+++ b/anautilities.py
@@ -377,7 +377,7 @@ def makeListOfScanDatesFile(chamberName, anaType, startDate=None, endDate=None, 
     endDay = datetime.date.today()
     if endDate is not None:
         endDateInfo = [ int(info) for info in endDate.split(".") ]
-        endDat = datetime.date(endDateInfo[0], endDateInfo[1], endDateInfo[2])
+        endDay = datetime.date(endDateInfo[0], endDateInfo[1], endDateInfo[2])
         pass
 
     import os


### PR DESCRIPTION
## Description

A typo prevented it from working correctly.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->

Reported in issue #144.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran `plotTimeSeries.py` with both `--startDate` and `--endDate`, then checked that the contents of `listOfScanDates.txt` were within the specified range.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
