### PR TITLE
Modification in fitting routine used in anaUltraScurve.py

### DIFF
--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -277,7 +277,10 @@ class ScanDataFitter(DeadChannelFinder):
 
                     # Provide an initial guess
                     init_guess_p0 = self.calDAC2Q_m[vfat]*(8+stepN*8)+self.calDAC2Q_b[vfat]
-                    init_guess_p1 = abs(self.calDAC2Q_m[vfat]*rand)  #self.calDAC2Q_m[vfat] might be negative (e.g. VFAT3 case)
+                    if self.isVFAT3:
+                        init_guess_p1 = self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat]+abs(self.calDAC2Q_m[vfat]*rand)  #self.calDAC2Q_m[vfat] might be negative (e.g. VFAT3 case)
+		    else:
+			init_guess_p1 = abs(self.calDAC2Q_m[vfat]*rand)
                     init_guess_p2 = 0.
                     init_guess_p3 = self.Nev[vfat][ch]/2.
 

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -276,11 +276,11 @@ class ScanDataFitter(DeadChannelFinder):
                     #if (self.calDAC2Q_m[vfat]*(rand)+self.calDAC2Q_b[vfat]) < 0: continue
 
                     # Provide an initial guess
-                    init_guess_p0 = self.calDAC2Q_m[vfat]*(8+stepN*8)+self.calDAC2Q_b[vfat]
+                    init_guess_p0 = self.calDAC2Q_m[vfat]*(8+stepN*8)+self.calDAC2Q_b[vfat] 
                     if self.isVFAT3:
                         init_guess_p1 = self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat]+abs(self.calDAC2Q_m[vfat]*rand)  #self.calDAC2Q_m[vfat] might be negative (e.g. VFAT3 case)
-		    else:
-			init_guess_p1 = abs(self.calDAC2Q_m[vfat]*rand)
+                    else:
+                        init_guess_p1 = abs(self.calDAC2Q_m[vfat]*rand)
                     init_guess_p2 = 0.
                     init_guess_p3 = self.Nev[vfat][ch]/2.
 
@@ -338,12 +338,14 @@ class ScanDataFitter(DeadChannelFinder):
 
                     # Fit
                     fitResult = self.scanHistos[vfat][ch].Fit('myERF','SQ')
+                    print 'fitResult: ', fitResult
                     fitEmpty = fitResult.IsEmpty()
                     if fitEmpty:
                         fitTF1.SetLineColor(kOrange-2)
                         # Don't try to fit empty data again
                         break
                     fitValid = fitResult.IsValid()
+                    print 'fitValid? ', fitValid
                     if not fitValid:
                         continue
                     fitChi2 = fitTF1.GetChisquare()

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -337,7 +337,7 @@ class ScanDataFitter(DeadChannelFinder):
                                     )
 
                     # Fit
-                    fitResult = self.scanHistos[vfat][ch].Fit('myERF','SQ') 
+                    fitResult = self.scanHistos[vfat][ch].Fit('myERF','SQ')
                     fitEmpty = fitResult.IsEmpty()
                     if fitEmpty:
                         fitTF1.SetLineColor(kOrange-2)

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -337,15 +337,13 @@ class ScanDataFitter(DeadChannelFinder):
                                     )
 
                     # Fit
-                    fitResult = self.scanHistos[vfat][ch].Fit('myERF','SQ')
-                    print 'fitResult: ', fitResult
+                    fitResult = self.scanHistos[vfat][ch].Fit('myERF','SQ') 
                     fitEmpty = fitResult.IsEmpty()
                     if fitEmpty:
                         fitTF1.SetLineColor(kOrange-2)
                         # Don't try to fit empty data again
                         break
                     fitValid = fitResult.IsValid()
-                    print 'fitValid? ', fitValid
                     if not fitValid:
                         continue
                     fitChi2 = fitTF1.GetChisquare()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The analyzer script ```anaUltraScurve.py``` fits the Scurves with a class ```ScanDataFitter```, defined in ```fitting/fitScanData.py```. A modification is made with regard to the initial guess of the parameter ```p1```, such that this guess will always fall within the prescribed bounds of the fit on ```p1```.

## Description
<!--- Describe your changes in detail -->
The choice of initial guess in the routine for ```p1``` is a the absolute value of the product of ```CAL_DACm``` and a Gaussian random variable with ```mean``` 10 and ```sigma``` 5, which, in some cases, fell below the lower bound of the fit for VFAT3, especially if ```CAL_DACb``` is large. In these cases, the code would then enter an infinite ```while``` loop. The routine is modified such that the initial guess is now the value of the lower bound plus the previously prescribed guess: ```p1_guess --> p1_low + p1_guess```.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
When analyzing Scurves with v3 electronics, the fits on one vfat in particular would not converge and the code got caught in an infinite loop.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This code was tested on 3 sets of Scurves from the following chambers: ```X-S-CERN-0012```, ```X-S-CERN-0011```, (both ```v3``` chambers) and the ```v2b``` chamber ```VII-S-CERN-0001```. The fits converge for all vfats in each case.

The fit results for ```X-S-CERN-0012``` are located in ```/data/bigdisk/GEM-Data-Taking/GE11_QC8/GE11-X-S-CERN-0012/scurve/2018.08.08.09.35/SCurveData/```.

The fit results for ```X-S-CERN-0011``` are located in ```/data/bigdisk/GEM-Data-Taking/GE11_QC8/GE11-X-S-CERN-0011/scurve/2018.08.07.19.00/```.

The fit results for ```VII-S-CERN-0001``` are located in ```/afs/cern.ch/user/b/bstone/public/v2b_scurvefit_test/```.

The ```Summary.png``` and ```fitSummary.png``` files can also be viewed on the Mattermost here: https://mattermost.web.cern.ch/cms-gem-ops/pl/4cm7xex58fnttmfn174q5z84th

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
