### PR TITLE
New Features: Analyzing checkSbitMappingAndRate.py data

### DIFF
--- a/anaSBitMonitor.py
+++ b/anaSBitMonitor.py
@@ -39,7 +39,7 @@ if __name__ == '__main__':
     ratesUsed = np.unique(initInfo['ratePulsed'])
 
     print('Initializing histograms')
-    from gempython.utils.nesteddict import nesteddict as ndict
+    from gempython.utils.nesteddict import nesteddict as ndict, flatten
 
     # Summary plots - 2D
     dict_h_vfatObsVsVfatPulsed = ndict() #Keys as: [isValid][calEnable][rate]
@@ -70,8 +70,10 @@ if __name__ == '__main__':
         for calEnable in calEnableValues:
             if calEnable:
                 strCalStatus="calEnabled"
+                strPulsedOrUnmasked="Pulsed"
             else:
                 strCalStatus="calDisabled"
+                strPulsedOrUnmasked="Unmasked"
 
             postScript = "{0}_{1}".format(strValidity,strCalStatus)
 
@@ -83,7 +85,7 @@ if __name__ == '__main__':
                 # 2D Observables
                 dict_h_vfatObsVsVfatPulsed[isValid][calEnable][rate] = r.TH2F(
                         "h_vfatObservedVsVfatPulsed_{0}_{1}Hz".format(postScript,int(rate)),
-                        "Summmary - Rate {0} Hz;VFAT Pulsed;VFAT Observed".format(int(rate)),
+                        "Summmary - Rate {0} Hz;VFAT {1};VFAT Observed".format(int(rate),strPulsedOrUnmasked),
                         24,-0.5,23.5,24,-0.5,23.5)
                 dict_h_vfatObsVsVfatPulsed[isValid][calEnable][rate].Sumw2()
 
@@ -99,6 +101,8 @@ if __name__ == '__main__':
                     dict_g_rateObsCTP7VsRatePulsed[isValid][vfat] = r.TGraphErrors()
                     dict_g_rateObsCTP7VsRatePulsed[isValid][vfat].SetName(
                             "g_rateObsCTP7VsRatePulsed_vfat{0}_{1}".format(vfat,strValidity))
+                    dict_g_rateObsCTP7VsRatePulsed[isValid][vfat].SetTitle(
+                            "VFAT {0};Rate Pulsed #left(Hz#right);Rate Observed #left(Hz#right)".format(vfat))
                     dict_g_rateObsCTP7VsRatePulsed[isValid][vfat].SetLineColor(r.kBlue)
                     dict_g_rateObsCTP7VsRatePulsed[isValid][vfat].SetLineWidth(2)
                     dict_g_rateObsCTP7VsRatePulsed[isValid][vfat].SetMarkerColor(r.kBlue)
@@ -108,6 +112,8 @@ if __name__ == '__main__':
                     dict_g_rateObsFPGAVsRatePulsed[isValid][vfat] = r.TGraphErrors()
                     dict_g_rateObsFPGAVsRatePulsed[isValid][vfat].SetName(
                             "g_rateObsFPGAVsRatePulsed_vfat{0}_{1}".format(vfat,strValidity))
+                    dict_g_rateObsFPGAVsRatePulsed[isValid][vfat].SetTitle(
+                            "VFAT {0};Rate Pulsed #left(Hz#right);Rate Observed #left(Hz#right)".format(vfat))
                     dict_g_rateObsFPGAVsRatePulsed[isValid][vfat].SetLineColor(r.kRed)
                     dict_g_rateObsFPGAVsRatePulsed[isValid][vfat].SetLineWidth(2)
                     dict_g_rateObsFPGAVsRatePulsed[isValid][vfat].SetMarkerColor(r.kRed)
@@ -117,6 +123,8 @@ if __name__ == '__main__':
                     dict_g_rateObsVFATVsRatePulsed[isValid][vfat] = r.TGraphErrors()
                     dict_g_rateObsVFATVsRatePulsed[isValid][vfat].SetName(
                             "g_rateObsVFATVsRatePulsed_vfat{0}_{1}".format(vfat,strValidity))
+                    dict_g_rateObsVFATVsRatePulsed[isValid][vfat].SetTitle(
+                            "VFAT {0};Rate Pulsed #left(Hz#right);Rate Observed #left(Hz#right)".format(vfat))
                     dict_g_rateObsVFATVsRatePulsed[isValid][vfat].SetLineColor(r.kGreen)
                     dict_g_rateObsVFATVsRatePulsed[isValid][vfat].SetLineWidth(2)
                     dict_g_rateObsVFATVsRatePulsed[isValid][vfat].SetMarkerColor(r.kGreen)
@@ -146,7 +154,7 @@ if __name__ == '__main__':
                         # 2D Obs
                         dict_h_sbitObsVsChanPulsed[isValid][calEnable][rate][vfat] = r.TH2F(
                                 "h_sbitObsVsChanPulsed_vfat{0}_{1}_{2}Hz".format(vfat,postScript,int(rate)),
-                                "VFAT{0} - Rate {1} Hz;Channel Pulsed;SBIT Observed".format(vfat,int(rate)),
+                                "VFAT{0} - Rate {1} Hz;Channel {2};SBIT Observed".format(vfat,int(rate),strPulsedOrUnmasked),
                                 128,-0.5,127.5,64,-0.5,63.5)
                         dict_h_sbitObsVsChanPulsed[isValid][calEnable][rate][vfat].Sumw2()
 
@@ -177,7 +185,7 @@ if __name__ == '__main__':
         vfatSBIT = entry.vfatSBIT
         vfatN = entry.vfatN
         vfatObs = entry.vfatObserved
-        
+
         if( (evtNum % 1000) == 0 and lastPrintedEvt != evtNum):
             lastPrintedEvt = evtNum
             print("processed {0} events so far".format(entry.evtNum))
@@ -323,7 +331,7 @@ if __name__ == '__main__':
         saveSummary(dict_h_sbitMulti[isValid][0][0], name="{0}/sbitMulti_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="")
         saveSummary(dict_h_sbitSize[isValid][0][0], name="{0}/sbitSize_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="")
 
-        saveSummary(dict_h_sbitObsVsChanPulsed[isValid][0][0], name="{0}/sbitObsVsChanPulsed_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="COLZ")
+        saveSummary(dict_h_sbitObsVsChanPulsed[isValid][0][0], name="{0}/sbitObsVsChanUnmasked_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="COLZ")
         saveSummary(dict_h_sbitMultiVsSbitSize[isValid][0][0], name="{0}/sbitMultiVsSbitSize_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="COLZ")
         
         for idx,rate in enumerate(ratesUsed):
@@ -457,7 +465,7 @@ if __name__ == '__main__':
 
     arrayPos=0
     list_nameNtype = [('vfatN','i4'),('vfatSBIT','i4'),('sbitSize','i4'),('N_Mismatches','i4')]
-    wrongSBITMapping = np.zeros(len(dict_wrongSbit2ChanMapping), dtype=list_nameNtype)
+    wrongSBITMapping = np.zeros(len(flatten(dict_wrongSbit2ChanMapping)), dtype=list_nameNtype)
     for vfat,dictBadSBits in dict_wrongSbit2ChanMapping.iteritems():
         for sbit,dictSizeCounts in dictBadSBits.iteritems():
             for size,nTimes in dictSizeCounts.iteritems():
@@ -465,6 +473,7 @@ if __name__ == '__main__':
                 wrongSBITMapping[arrayPos]['vfatSBIT'] = sbit
                 wrongSBITMapping[arrayPos]['sbitSize'] = size
                 wrongSBITMapping[arrayPos]['N_Mismatches'] = nTimes
+                arrayPos+=1
     wrongSBITMapping.sort(order=['vfatN','vfatSBIT','sbitSize','N_Mismatches'])
 
     fileMisMappedSbits = open("{0}/MisMappedSbits.txt".format(filename),"w")
@@ -475,12 +484,12 @@ if __name__ == '__main__':
     print("| :---: | :------: | :-------: | :----------: |")
     fileMisMappedSbits.write("| :---: | :------: | :-------: | :----------: |\n")
     for idx in range(0,len(wrongSBITMapping)):
-        print("| {0} | {1} | {2} | {3} | {4} |".format(
+        print("| {0} | {1} | {2} | {3} |".format(
             wrongSBITMapping[idx]['vfatN'],
             wrongSBITMapping[idx]['vfatSBIT'],
             wrongSBITMapping[idx]['sbitSize'],
             wrongSBITMapping[idx]['N_Mismatches']))
-        fileMisMappedSbits.write("| {0} | {1} | {2} | {3} | {4} |\n".format(
+        fileMisMappedSbits.write("| {0} | {1} | {2} | {3} |\n".format(
             wrongSBITMapping[idx]['vfatN'],
             wrongSBITMapping[idx]['vfatSBIT'],
             wrongSBITMapping[idx]['sbitSize'],

--- a/anaSBitMonitor.py
+++ b/anaSBitMonitor.py
@@ -1,0 +1,463 @@
+#!/bin/env python
+
+"""
+anaSbitMonitor.py
+=================
+"""
+
+if __name__ == '__main__':
+    import os
+    import sys
+    
+    from gempython.gemplotting.utils.anaoptions import parser
+    #parser.add_option("--badPolThresh",type="int",dest="badPolThresh",default=128,
+    #        help="the mininum number of channels an sbit should be observed for to assume it's polarity is wrong", metavar="badPolThresh")
+    parser.add_option("--checkInvalid",action="store_true", dest="checkInvalid",
+            help="If provided invalid sbits will be considered", metavar="checkInvalid")
+    
+    parser.set_defaults(outfilename="SBitMonitorData.root")
+    (options, args) = parser.parse_args()
+    filename = options.filename[:-5]
+    os.system("mkdir " + options.filename[:-5])
+
+    print filename
+    outfilename = options.outfilename
+
+    import ROOT as r
+    #r.TH1.SetDefaultSumw2(True)
+    r.gROOT.SetBatch(True)
+    outF = r.TFile(filename+'/'+outfilename, 'recreate')
+    inF = r.TFile(filename+'.root')
+
+    # Determine the rates scanned
+    print('Determining rates tested')
+    import numpy as np
+    import root_numpy as rp #note need root_numpy-4.7.2 (may need to run 'pip install root_numpy --upgrade')
+
+    list_bNames = ['calEnable','isValid','ratePulsed']
+    initInfo = rp.tree2array(tree=inF.sbitDataTree, branches=list_bNames)
+    calEnableValues = np.unique(initInfo['calEnable'])
+    isValidValues = np.unique(initInfo['isValid'])
+    ratesUsed = np.unique(initInfo['ratePulsed'])
+
+    print('Initializing histograms')
+    from gempython.utils.nesteddict import nesteddict as ndict
+
+    # Summary plots - 2D
+    dict_h_vfatObsVsVfatPulsed = ndict() #Keys as: [isValid][calEnable][rate]
+
+    # VFAT lvl plots - 1D
+    dict_h_sbitMulti = ndict() #Keys as: [isValid][calEnable][rate][vfat]
+    dict_h_sbitSize = ndict() #Keys as: [isValid][calEnable][rate][vfat]
+
+    # VFAT lvl plots - 2D 
+    dict_g_rateObsCTP7VsRatePulsed = ndict() #Keys as: [isValid][vfat]
+    dict_g_rateObsFPGAVsRatePulsed = ndict() #Keys as: [isValid][vfat]
+    dict_g_rateObsVFATVsRatePulsed = ndict() #Keys as: [isValid][vfat]
+    dict_h_chanVsRatePulsed_ZRateObs = ndict() #Z axis is rate observed; Keys as: [isValid][calEnable][vfat]
+    dict_h_sbitObsVsChanPulsed = ndict() #Keys as: [isValid][calEnable][rate][vfat]
+    dict_h_sbitMultiVsSbitSize = ndict() #Keys as: [isValid][calEnable][rate][vfat]
+
+    rateMap = {}
+    from gempython.gemplotting.utils.anautilities import formatSciNotation
+    for isValid in isValidValues:
+        if not isValid and not options.checkInvalid:
+            continue
+
+        if isValid:
+            strValidity="validSbits"
+        else:
+            strValidity="invalidSbits"
+
+        for calEnable in calEnableValues:
+            if calEnable:
+                strCalStatus="calEnabled"
+            else:
+                strCalStatus="calDisabled"
+
+            postScript = "{0}_{1}".format(strValidity,strCalStatus)
+
+            # Summary Case
+            for rate in ratesUsed:
+                if ( not ( (calEnable and rate > 0) or (not calEnable and rate == 0.0) ) ):
+                    continue
+
+                # 2D Observables
+                dict_h_vfatObsVsVfatPulsed[isValid][calEnable][rate] = r.TH2F(
+                        "h_vfatObservedVsVfatPulsed_{0}_{1}Hz".format(postScript,int(rate)),
+                        "Summmary - Rate {0} Hz;VFAT Pulsed;VFAT Observed".format(int(rate)),
+                        24,-0.5,23.5,24,-0.5,23.5)
+                dict_h_vfatObsVsVfatPulsed[isValid][calEnable][rate].Sumw2()
+
+            for vfat in range(0,24):
+                dict_h_chanVsRatePulsed_ZRateObs[isValid][calEnable][vfat] = r.TH2F(
+                        "h_chanVsRatePulsed_ZRateObs_vfat{0}_{1}".format(vfat,postScript),
+                        "VFAT{0};Rate #left(Hz#right);Channel",
+                        len(ratesUsed),0,len(ratesUsed),
+                        128,-0.5,127.5)
+
+                # Overall Rate Observed by CTP7
+                if calEnable:
+                    dict_g_rateObsCTP7VsRatePulsed[isValid][vfat] = r.TGraphErrors()
+                    dict_g_rateObsCTP7VsRatePulsed[isValid][vfat].SetName(
+                            "g_rateObsCTP7VsRatePulsed_vfat{0}_{1}".format(vfat,strValidity))
+                    dict_g_rateObsCTP7VsRatePulsed[isValid][vfat].SetLineColor(r.kBlue)
+                    dict_g_rateObsCTP7VsRatePulsed[isValid][vfat].SetLineWidth(2)
+                    dict_g_rateObsCTP7VsRatePulsed[isValid][vfat].SetMarkerColor(r.kBlue)
+                    dict_g_rateObsCTP7VsRatePulsed[isValid][vfat].SetMarkerStyle(22)
+
+                    # Overall Rate Observed by OH FPGA
+                    dict_g_rateObsFPGAVsRatePulsed[isValid][vfat] = r.TGraphErrors()
+                    dict_g_rateObsFPGAVsRatePulsed[isValid][vfat].SetName(
+                            "g_rateObsFPGAVsRatePulsed_vfat{0}_{1}".format(vfat,strValidity))
+                    dict_g_rateObsFPGAVsRatePulsed[isValid][vfat].SetLineColor(r.kRed)
+                    dict_g_rateObsFPGAVsRatePulsed[isValid][vfat].SetLineWidth(2)
+                    dict_g_rateObsFPGAVsRatePulsed[isValid][vfat].SetMarkerColor(r.kRed)
+                    dict_g_rateObsFPGAVsRatePulsed[isValid][vfat].SetMarkerStyle(23)
+
+                    # Per VFAT Rate Observed by OH
+                    dict_g_rateObsVFATVsRatePulsed[isValid][vfat] = r.TGraphErrors()
+                    dict_g_rateObsVFATVsRatePulsed[isValid][vfat].SetName(
+                            "g_rateObsVFATVsRatePulsed_vfat{0}_{1}".format(vfat,strValidity))
+                    dict_g_rateObsVFATVsRatePulsed[isValid][vfat].SetLineColor(r.kGreen)
+                    dict_g_rateObsVFATVsRatePulsed[isValid][vfat].SetLineWidth(2)
+                    dict_g_rateObsVFATVsRatePulsed[isValid][vfat].SetMarkerColor(r.kGreen)
+                    dict_g_rateObsVFATVsRatePulsed[isValid][vfat].SetMarkerStyle(24)
+
+                for binX,rate in enumerate(ratesUsed):
+                    if vfat == 0: # Summary Case
+                        # Set bin labels
+                        rateMap[rate]=binX+1 # Used later to translate rate to bin position
+                    dict_h_chanVsRatePulsed_ZRateObs[isValid][calEnable][vfat].GetXaxis().SetBinLabel(binX+1,formatSciNotation(str(rate)))
+
+                    # VFAT level
+                    if (calEnable or (not calEnable and rate == 0.0)):
+                        # 1D Obs
+                        dict_h_sbitMulti[isValid][calEnable][rate][vfat] = r.TH1F(
+                                "h_sbitMulti_vfat{0}_{1}_{2}Hz".format(vfat,postScript,int(rate)),
+                                "VFAT{0} - Rate {1} Hz;SBIT Multiplicity;N".format(vfat,int(rate)),
+                                9,-0.5,8.5)
+                        dict_h_sbitMulti[isValid][calEnable][rate][vfat].Sumw2()
+
+                        dict_h_sbitSize[isValid][calEnable][rate][vfat] = r.TH1F(
+                                "h_sbitSize_vfat{0}_{1}_{2}Hz".format(vfat,postScript,int(rate)),
+                                "VFAT{0} - Rate {1} Hz;SBIT Size;N".format(vfat,int(rate)),
+                                8,-0.5,7.5)
+                        dict_h_sbitSize[isValid][calEnable][rate][vfat].Sumw2()
+
+                        # 2D Obs
+                        dict_h_sbitObsVsChanPulsed[isValid][calEnable][rate][vfat] = r.TH2F(
+                                "h_sbitObsVsChanPulsed_vfat{0}_{1}_{2}Hz".format(vfat,postScript,int(rate)),
+                                "VFAT{0} - Rate {1} Hz;Channel Pulsed;SBIT Observed".format(vfat,int(rate)),
+                                128,-0.5,127.5,64,-0.5,63.5)
+                        dict_h_sbitObsVsChanPulsed[isValid][calEnable][rate][vfat].Sumw2()
+
+                        dict_h_sbitMultiVsSbitSize[isValid][calEnable][rate][vfat] = r.TH2F(
+                                "h_sbitMultiVsSbitSize_vfat{0}_{1}_{2}Hz".format(vfat,postScript,int(rate)),
+                                "VFAT{0} - Rate {1} Hz;SBIT Size;SBIT Multiplicity".format(vfat,int(rate)),
+                                8,-0.5,7.5,9,-0.5,8.5)
+                        dict_h_sbitMultiVsSbitSize[isValid][calEnable][rate][vfat].Sumw2()
+
+    print("Looping over events and filling histograms")
+    dict_validSbitsPerEvt = ndict()
+    dict_listSbitSizesPerEvt = ndict()
+    dict_wrongPolarity = ndict() # Keys [vfatN][vfatSBIT] = [ list of vfatCH values ]
+    from math import floor, sqrt
+    lastPrintedEvt = 0
+    for entry in inF.sbitDataTree:
+        # Get Values from tree for readability
+        calEnable = entry.calEnable
+        evtNum = entry.evtNum
+        isValid = entry.isValid
+        rate = entry.ratePulsed
+        rateObsCTP7 = entry.rateObservedCTP7
+        rateObsFPGA = entry.rateObservedFPGA
+        rateObsVFAT = entry.rateObservedVFAT
+        sbitSize = entry.sbitClusterSize
+        vfatCH = entry.vfatCH
+        vfatSBIT = entry.vfatSBIT
+        vfatN = entry.vfatN
+        vfatObs = entry.vfatObserved
+        
+        if( (evtNum % 1000) == 0 and lastPrintedEvt != evtNum):
+            lastPrintedEvt = evtNum
+            print("processed {0} events so far".format(entry.evtNum))
+
+        # Skip this event because it's invaldi?
+        if not isValid and not options.checkInvalid:
+            continue
+
+        # Track if sbit is mismatched
+        if (vfatSBIT != floor(vfatCH/2)):
+            if (len(dict_wrongPolarity[vfatN][vfatSBIT]) > 0): 
+                dict_wrongPolarity[vfatN][vfatSBIT].append(vfatCH)
+            else:
+                dict_wrongPolarity[vfatN][vfatSBIT] = [ vfatCH ]
+
+        # Summary Plots
+        dict_h_vfatObsVsVfatPulsed[isValid][calEnable][rate].Fill(vfatN,vfatObs)
+
+        # Track sbit multiplicity
+        if evtNum in dict_validSbitsPerEvt[isValid][calEnable][rate][vfatN].keys():
+            if isValid:
+                dict_validSbitsPerEvt[isValid][calEnable][rate][vfatN][evtNum]+=1
+        else:                                                                 
+            if isValid:                                                       
+                dict_validSbitsPerEvt[isValid][calEnable][rate][vfatN][evtNum]=1
+            else:                                                             
+                dict_validSbitsPerEvt[isValid][calEnable][rate][vfatN][evtNum]=0
+
+        # Store sbit size
+        if evtNum in dict_listSbitSizesPerEvt[isValid][calEnable][rate][vfatN].keys():
+            if isValid:
+                dict_listSbitSizesPerEvt[isValid][calEnable][rate][vfatN][evtNum].append(sbitSize)
+        else:                                                                    
+            if isValid:                                                          
+                dict_listSbitSizesPerEvt[isValid][calEnable][rate][vfatN][evtNum] = [sbitSize]
+            else:                                                                
+                dict_listSbitSizesPerEvt[isValid][calEnable][rate][vfatN][evtNum] = []
+
+        # VFAT lvl plots - 1D
+        dict_h_sbitSize[isValid][calEnable][rate][vfatN].Fill(sbitSize)
+
+        # VFAT lvl plots - 2D
+        newPt = dict_g_rateObsCTP7VsRatePulsed[isValid][vfatN].GetN()
+        dict_g_rateObsCTP7VsRatePulsed[isValid][vfatN].SetPoint(
+                newPt,
+                rate,
+                rateObsCTP7)
+        dict_g_rateObsCTP7VsRatePulsed[isValid][vfatN].SetPointError(
+                newPt,
+                0,
+                sqrt(rateObsCTP7))
+
+        newPt = dict_g_rateObsFPGAVsRatePulsed[isValid][vfatN].GetN()
+        dict_g_rateObsFPGAVsRatePulsed[isValid][vfatN].SetPoint(
+                newPt,
+                rate,
+                rateObsFPGA)
+        dict_g_rateObsFPGAVsRatePulsed[isValid][vfatN].SetPointError(
+                newPt,
+                0,
+                sqrt(rateObsFPGA))
+
+        newPt = dict_g_rateObsVFATVsRatePulsed[isValid][vfatN].GetN()
+        dict_g_rateObsVFATVsRatePulsed[isValid][vfatN].SetPoint(
+                newPt,
+                rate,
+                rateObsVFAT)
+        dict_g_rateObsVFATVsRatePulsed[isValid][vfatN].SetPointError(
+                newPt,
+                0,
+                sqrt(rateObsVFAT))
+
+        #dict_h_chanVsRatePulsed_ZRateObs
+
+        dict_h_sbitObsVsChanPulsed[isValid][calEnable][rate][vfatN].Fill(vfatCH,vfatSBIT)
+
+    print("Filling multiplicity distributions")
+    for isValid in isValidValues:
+        if not isValid and not options.checkInvalid:
+            continue
+        
+        for calEnable in calEnableValues:
+            for rate in ratesUsed:
+                for vfat in range(0,24):
+                    for event,multi in dict_validSbitsPerEvt[isValid][calEnable][rate][vfat].iteritems():
+                        dict_h_sbitMulti[isValid][calEnable][rate][vfat].Fill(multi)
+
+                        for size in dict_listSbitSizesPerEvt[isValid][calEnable][rate][vfat][event]:
+                            dict_h_sbitMultiVsSbitSize[isValid][calEnable][rate][vfat].Fill(size,multi)
+    
+    print("Making summary plots")
+    from gempython.gemplotting.utils.anautilities import make3x8Canvas, saveSummary
+    for isValid in isValidValues:
+        if not isValid and not options.checkInvalid:
+            continue
+        
+        if isValid:
+            strValidity="validSbits"
+        else:
+            strValidity="invalidSbits"
+
+        # All Rates
+        rateCanvas = make3x8Canvas(
+                name="rateObservedVsRatePulsed_{0}".format(strValidity),
+                initialContent=dict_g_rateObsCTP7VsRatePulsed[isValid],
+                initialDrawOpt="APE1",
+                secondaryContent=dict_g_rateObsFPGAVsRatePulsed[isValid],
+                secondaryDrawOpt="PE1")
+        rateCanvas = make3x8Canvas(
+                name="",
+                secondaryContent=dict_g_rateObsVFATVsRatePulsed[isValid],
+                secondaryDrawOpt="PE1",
+                canv=rateCanvas)
+        
+        # Make the legend
+        rateLeg = r.TLegend(0.5,0.5,0.9,0.9)
+        rateLeg.AddEntry(
+                dict_g_rateObsCTP7VsRatePulsed[isValid][0],
+                "CTP7 Rate",
+                "LPE")
+        rateLeg.AddEntry(
+                dict_g_rateObsFPGAVsRatePulsed[isValid][0],
+                "FPGA Rate",
+                "LPE")
+        rateLeg.AddEntry(
+                dict_g_rateObsVFATVsRatePulsed[isValid][0],
+                "VFAT Rate",
+                "LPE")
+
+        rateCanvas.cd(1)
+        rateLeg.Draw("same")
+
+        # Save Canvas
+        rateCanvas.SaveAs("{0}/rateObservedVsRatePulsed_{1}.png".format(filename,strValidity))
+
+        # CalDisable rate 0 case
+        saveSummary(dict_h_sbitMulti[isValid][0][0], name="{0}/sbitMulti_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="")
+        saveSummary(dict_h_sbitSize[isValid][0][0], name="{0}/sbitSize_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="")
+
+        saveSummary(dict_h_sbitObsVsChanPulsed[isValid][0][0], name="{0}/sbitObsVsChanPulsed_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="COLZ")
+        saveSummary(dict_h_sbitMultiVsSbitSize[isValid][0][0], name="{0}/sbitMultiVsSbitSize_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="COLZ")
+        
+        for idx,rate in enumerate(ratesUsed):
+            # Sum over all rates
+            if rate > 0:
+                if (-1 not in dict_h_vfatObsVsVfatPulsed[isValid][1].keys()):
+                    name = dict_h_vfatObsVsVfatPulsed[isValid][1][rate].GetName()
+                    title = dict_h_vfatObsVsVfatPulsed[isValid][1][rate].GetTitle()
+                    dict_h_vfatObsVsVfatPulsed[isValid][1][-1] = dict_h_vfatObsVsVfatPulsed[isValid][1][rate].Clone(name.replace("{0}Hz".format(int(rate)),"SumOfAllRates"))
+                    dict_h_vfatObsVsVfatPulsed[isValid][1][-1].SetTitle(title.replace("Rate {0} Hz".format(int(rate)), "Sum of All Rates"))
+                else:
+                    dict_h_vfatObsVsVfatPulsed[isValid][1][-1].Add(dict_h_vfatObsVsVfatPulsed[isValid][1][rate])
+
+                cloneExists = { vfat:False for vfat in range(0,24) }
+                for vfat in range(0,24):
+                    if ( not cloneExists[vfat] ):
+                        cloneExists[vfat] = True
+
+                        name = dict_h_sbitMulti[isValid][1][rate][vfat].GetName()
+                        title = dict_h_sbitMulti[isValid][1][rate][vfat].GetTitle()
+                        dict_h_sbitMulti[isValid][1][-1][vfat] = dict_h_sbitMulti[isValid][1][rate][vfat].Clone(name.replace("{0}Hz".format(int(rate)),"SumOfAllRates"))
+                        dict_h_sbitMulti[isValid][1][-1][vfat].SetTitle(title.replace("Rate {0} Hz".format(int(rate)), "Sum of All Rates"))
+                        
+                        name = dict_h_sbitSize[isValid][1][rate][vfat].GetName()
+                        title = dict_h_sbitSize[isValid][1][rate][vfat].GetTitle()
+                        dict_h_sbitSize[isValid][1][-1][vfat] = dict_h_sbitSize[isValid][1][rate][vfat].Clone(name.replace("{0}Hz".format(int(rate)),"SumOfAllRates"))
+                        dict_h_sbitSize[isValid][1][-1][vfat].SetTitle(title.replace("Rate {0} Hz".format(int(rate)), "Sum of All Rates"))
+
+                        name = dict_h_sbitObsVsChanPulsed[isValid][1][rate][vfat].GetName()
+                        title = dict_h_sbitObsVsChanPulsed[isValid][1][rate][vfat].GetTitle()
+                        dict_h_sbitObsVsChanPulsed[isValid][1][-1][vfat] = dict_h_sbitObsVsChanPulsed[isValid][1][rate][vfat].Clone(name.replace("{0}Hz".format(int(rate)),"SumOfAllRates"))
+                        dict_h_sbitObsVsChanPulsed[isValid][1][-1][vfat].SetTitle(title.replace("Rate {0} Hz".format(int(rate)), "Sum of All Rates"))
+
+                        name = dict_h_sbitMultiVsSbitSize[isValid][1][rate][vfat].GetName()
+                        title = dict_h_sbitMultiVsSbitSize[isValid][1][rate][vfat].GetTitle()
+                        dict_h_sbitMultiVsSbitSize[isValid][1][-1][vfat] = dict_h_sbitMultiVsSbitSize[isValid][1][rate][vfat].Clone(name.replace("{0}Hz".format(int(rate)),"SumOfAllRates"))
+                        dict_h_sbitMultiVsSbitSize[isValid][1][-1][vfat].SetTitle(title.replace("Rate {0} Hz".format(int(rate)), "Sum of All Rates"))
+                    else:
+                        dict_h_sbitMulti[isValid][1][-1][vfat].Add(dict_h_sbitMulti[isValid][1][rate][vfat])
+                        dict_h_sbitSize[isValid][1][-1][vfat].Add(dict_h_sbitSize[isValid][1][rate][vfat])
+                        dict_h_sbitObsVsChanPulsed[isValid][1][-1][vfat].Add(dict_h_sbitObsVsChanPulsed[isValid][1][rate][vfat])
+                        dict_h_sbitMultiVsSbitSize[isValid][1][-1][vfat].Add(dict_h_sbitMultiVsSbitSize[isValid][1][rate][vfat])
+        
+                saveSummary(dict_h_sbitMulti[isValid][1][-1], name="{0}/sbitMulti_{1}_calEnabled_SumOfAllRates.png".format(filename,strValidity), drawOpt="")
+                saveSummary(dict_h_sbitSize[isValid][1][-1], name="{0}/sbitSize_{1}_calEnabled_SumOfAllRates.png".format(filename,strValidity), drawOpt="")
+
+                saveSummary(dict_h_sbitObsVsChanPulsed[isValid][1][-1], name="{0}/sbitObsVsChanPulsed_{1}_calEnabled_SumOfAllRates.png".format(filename,strValidity), drawOpt="COLZ")
+                saveSummary(dict_h_sbitMultiVsSbitSize[isValid][1][-1], name="{0}/sbitMultiVsSbitSize_{1}_calEnabled_SumOfAllRates.png".format(filename,strValidity), drawOpt="COLZ")
+
+    print("Storing TObjects in output TFile")
+    # Per VFAT Plots
+    for vfat in range(0,24):
+        dirVFAT = outF.mkdir("VFAT{0}".format(vfat))
+
+        for isValid in isValidValues:
+            if not isValid and not options.checkInvalid:
+                continue
+
+            if isValid:
+                strValidity="validSbits"
+            else:
+                strValidity="invalidSbits"
+            dirIsValid = dirVFAT.mkdir(strValidity)
+            dirIsValid.cd()
+            dict_g_rateObsCTP7VsRatePulsed[isValid][vfat].Write()
+            dict_g_rateObsFPGAVsRatePulsed[isValid][vfat].Write()
+            dict_g_rateObsVFATVsRatePulsed[isValid][vfat].Write()
+
+            for calEnable in calEnableValues:
+                if calEnable:
+                    strCalStatus="calEnabled"
+                else:
+                    strCalStatus="calDisabled"
+
+                dirCalStatus = dirIsValid.mkdir(strCalStatus)
+                if calEnable:
+                    dirCalStatus.cd()
+                    dict_h_sbitMulti[isValid][calEnable][-1][vfat].Write()
+                    dict_h_sbitSize[isValid][calEnable][-1][vfat].Write()
+                    dict_h_sbitObsVsChanPulsed[isValid][calEnable][-1][vfat].Write()
+                    dict_h_sbitMultiVsSbitSize[isValid][calEnable][-1][vfat].Write()
+
+                for rate in ratesUsed:
+                    if ( not ( (calEnable and rate > 0) or (not calEnable and rate == 0.0) ) ):
+                        continue
+
+                    dirRate = dirCalStatus.mkdir("{0}Hz".format(int(rate)))
+                    dirRate.cd()
+                    dict_h_sbitMulti[isValid][calEnable][rate][vfat].Write()
+                    dict_h_sbitSize[isValid][calEnable][rate][vfat].Write()
+                    dict_h_sbitObsVsChanPulsed[isValid][calEnable][rate][vfat].Write()
+                    dict_h_sbitMultiVsSbitSize[isValid][calEnable][rate][vfat].Write()
+
+    # Summary Plots
+    dirSummary = outF.mkdir("Summary")
+    for isValid in isValidValues:
+        if not isValid and not options.checkInvalid:
+            continue
+
+        if isValid:
+            strValidity="validSbits"
+        else:
+            strValidity="invalidSbits"
+        dirIsValid = dirSummary.mkdir(strValidity)
+
+        for calEnable in calEnableValues:
+            if calEnable:
+                strCalStatus="calEnabled"
+            else:
+                strCalStatus="calDisabled"
+
+            dirCalStatus = dirIsValid.mkdir(strCalStatus)
+
+            if calEnable:
+                dirCalStatus.cd()
+                dict_h_vfatObsVsVfatPulsed[isValid][calEnable][-1].Write() 
+
+            for rate in ratesUsed:
+                if ( not ( (calEnable and rate > 0) or (not calEnable and rate == 0.0) ) ):
+                    continue
+
+                dirRate = dirCalStatus.mkdir("{0}Hz".format(int(rate)))
+                dirRate.cd()
+                dict_h_vfatObsVsVfatPulsed[isValid][calEnable][rate].Write() 
+
+    # Close input TFile
+    inF.Close()
+    
+    # Close output TFile
+    outF.Close()
+                
+    print("List Of Mis-mapped Sbits")
+    print("| vfatN | vfatSBIT | N_Mismatches |")
+    print("| :---: | :------: | :----------: |")
+    for vfat,dictBadSBits in dict_wrongPolarity.iteritems():
+        for sbit,chanList in dictBadSBits.iteritems():
+            print("| {0} | {1} | {2} |".format(
+                vfat,
+                sbit,
+                len(chanList)))
+
+    print("\nDone")

--- a/anaSBitThresh.py
+++ b/anaSBitThresh.py
@@ -8,7 +8,6 @@ anaSBitThresh
 if __name__ == '__main__':
     import os
     import sys
-    from optparse import OptionParser
     from gempython.utils.nesteddict import nesteddict as ndict
 
     from gempython.gemplotting.utils.anaoptions import parser

--- a/anaSBitThresh.py
+++ b/anaSBitThresh.py
@@ -7,7 +7,6 @@ anaSBitThresh
 
 if __name__ == '__main__':
     import os
-    import sys
     from gempython.utils.nesteddict import nesteddict as ndict
 
     from gempython.gemplotting.utils.anaoptions import parser

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -825,7 +825,7 @@ if __name__ == '__main__':
                         chan,
                         trim_list[vfat][chan],
                         trimPolarity_list[vfat][chan],
-                        mask[vfat][chan],
+                        masks[vfat][chan],
                         maskReasons[vfat][chan]))
         else:
             confF.write('vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:mask/I:maskReason/I\n')

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -211,8 +211,9 @@ if __name__ == '__main__':
     vSummaryPlotsNoMaskedChanPanPin2 = ndict()
     vthr_list = getEmptyPerVFATList() 
     trim_list = getEmptyPerVFATList() 
-    trimrange_list = getEmptyPerVFATList()
-    
+    trimRange_list = getEmptyPerVFATList()
+    trimPolarity_list = getEmptyPerVFATList()
+
     # Set default histogram behavior
     r.TH1.SetDefaultSumw2(False)
     r.gROOT.SetBatch(True)
@@ -272,7 +273,10 @@ if __name__ == '__main__':
         for chan in range (0,128):
             vthr_list[vfat].append(0)
             trim_list[vfat].append(0)
-            trimrange_list[vfat].append(0)
+            if options.isVFAT3:
+                trimPolarity_list[vfat].append(0)
+            else:
+                trimRange_list[vfat].append(0)
             pass
         pass
     
@@ -319,7 +323,11 @@ if __name__ == '__main__':
             vthr_list[event.vfatN][event.vfatCH] = abs(event.vth2 - event.vth1)
             pass
         trim_list[event.vfatN][event.vfatCH] = event.trimDAC
-        trimrange_list[event.vfatN][event.vfatCH] = event.trimRange
+        if options.isVFAT3:
+            #placegolder
+            trimPolarity_list[event.vfatN][event.vfatCH] = event.trimPolarity
+        else:
+            trimRange_list[event.vfatN][event.vfatCH] = event.trimRange
         
         # store event count
         if nPulses < 0:
@@ -469,8 +477,12 @@ if __name__ == '__main__':
         myT.Branch( 'trimDAC', trimDAC, 'trimDAC/I' )
         threshold = array( 'f', [ 0 ] )
         myT.Branch( 'threshold', threshold, 'threshold/F')
-        trimRange = array( 'i', [ 0 ] )
-        myT.Branch( 'trimRange', trimRange, 'trimRange/I' )
+        if options.isVFAT3:
+            trimPolarity = array( 'i', [ 0 ] )
+            myT.Branch('trimPolarity', trimPolarity, 'trimPolarity/I' )
+        else:
+            trimRange = array( 'i', [ 0 ] )
+            myT.Branch( 'trimRange', trimRange, 'trimRange/I' )
         vfatCH = array( 'i', [ 0 ] )
         myT.Branch( 'vfatCH', vfatCH, 'vfatCH/I' )
         vfatID = array( 'i', [-1] )
@@ -535,13 +547,16 @@ if __name__ == '__main__':
                 ndf[0] = int(scanFitResults[5][vfat][chan])
                 Nhigh[0] = int(scanFitResults[4][vfat][chan])
                 noise[0] = scanFitResults[1][vfat][chan]
-                panPin[0] = dict_vfatChanLUT[vfat]["PanPin"][chan] 
+                panPin[0] = dict_vfatChanLUT[vfat]["PanPin"][chan]
                 ped_eff[0] = effectivePedestals[vfat][chan]
                 pedestal[0] = scanFitResults[2][vfat][chan]
                 ROBstr[0] = dict_vfatChanLUT[vfat]["Strip"][chan]
                 threshold[0] = scanFitResults[0][vfat][chan]
                 trimDAC[0] = trim_list[vfat][chan]
-                trimRange[0] = trimrange_list[vfat][chan] 
+                if options.isVFAT3:
+                    trimPolarity[0] = trimPolarity_list[vfat][chan]
+                else:
+                    trimRange[0] = trimRange_list[vfat][chan]
                 vfatCH[0] = chan
                 vfatID[0] = dict_vfatID[vfat]
                 vfatN[0] = vfat
@@ -800,20 +815,30 @@ if __name__ == '__main__':
         saveSummaryByiEta(encSummaryPlotsByiEta, '%s/ScurveSigmaSummaryByiEta.png'%filename, None, drawOpt="AP")
 
         confF = open(filename+'/chConfig.txt','w')
-        confF.write('vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:mask/I:maskReason/I\n')
-        for vfat in range(0,24):
-            for chan in range (0, 128):
-                confF.write('%i\t%i\t%i\t%i\t%i\t%i\n'%(
-                    vfat,
-                    dict_vfatID[vfat],
-                    chan,
-                    trim_list[vfat][chan],
-                    masks[vfat][chan],
-                    maskReasons[vfat][chan]))
-                pass
-            pass
+        if options.isVFAT3:
+            confF.write('vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:trimPolarity/I:mask/I:maskReason/I\n')
+            for vfat in range(0,24):
+                for chan in range(0, 128):
+                    confF.write('%i\t%i\t%i\t%i\t%i\t%i\t%i\n'%(
+                        vfat,
+                        dict_vfatID[vfat],
+                        chan,
+                        trim_list[vfat][chan],
+                        trimPolarity_list[vfat][chan],
+                        mask[vfat][chan],
+                        maskReasons[vfat][chan]))
+        else:
+            confF.write('vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:mask/I:maskReason/I\n')
+            for vfat in range(0,24):
+                for chan in range (0, 128):
+                    confF.write('%i\t%i\t%i\t%i\t%i\t%i\n'%(
+                        vfat,
+                        dict_vfatID[vfat],
+                        chan,
+                        trim_list[vfat][chan],
+                        masks[vfat][chan],
+                        maskReasons[vfat][chan]))
         confF.close()
-        pass
 
     # Make 1D Plot for each VFAT showing all scurves
     # Don't use the ones stored in fitter since this may not exist (e.g. options.performFit = false)

--- a/mapping/chamberInfo.py
+++ b/mapping/chamberInfo.py
@@ -101,12 +101,18 @@ chamber_vfatDACSettings = {
     #        #Set the Latency - 10x10 PMT on R&D Setup
     #        "CFG_LATENCY":98,
     #        #Correct the bug in the shaper
-    #        "CFG_PT":7,
-    #        #Updated DAC settings from Flavio
-    #        "CFG_BIAS_SH_I_BDIFF":150,
-    #        "CFG_BIAS_SH_I_BFCAS":250,
-    #        "CFG_BIAS_SD_I_BDIFF":255,
-    #        "CFG_BIAS_SD_I_BFCAS":255,
+    #        #"CFG_PT":0xf,
+    #        "CFG_PT":3,
+    #        #VFAT3a DAC settings
+    #        #"CFG_BIAS_SH_I_BDIFF":150,
+    #        #"CFG_BIAS_SH_I_BFCAS":250,
+    #        #"CFG_BIAS_SD_I_BDIFF":255,
+    #        #"CFG_BIAS_SD_I_BFCAS":255,
+    #        #VFAT3b DAC settings
+    #        "CFG_BIAS_SH_I_BDIFF":80,
+    #        "CFG_BIAS_SH_I_BFCAS":130,
+    #        "CFG_BIAS_SD_I_BDIFF":140,
+    #        "CFG_BIAS_SD_I_BFCAS":135,
     #        #Provide a slight offset to the ZCC comparator baseline voltage
     #        "CFG_THR_ZCC_DAC":10,
     #        #High VFAT3 preamp gain
@@ -136,7 +142,8 @@ chamber_vfatDACSettings = {
     #        #Set the Latency - 10x10 PMT on R&D Setup
     #        "CFG_LATENCY":98,
     #        #Correct the bug in the shaper
-    #        "CFG_PT":7,
+    #        #"CFG_PT":0xf,
+    #        "CFG_PT":3,
     #        #Updated DAC settings from Flavio
     #        "CFG_BIAS_SH_I_BDIFF":150,
     #        "CFG_BIAS_SH_I_BFCAS":250,

--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -44,6 +44,17 @@ def first_index_gt(data_list, value):
     except StopIteration: 
         return len(data_list)
 
+def formatSciNotation(value, digits=2):
+    """
+    Returns a string formated in scientific notation with a number of digits to the
+    right of the decimal place equal to the digits value
+    """
+    from decimal import Decimal
+
+    sciNotation = '%.{0}E'.format(digits)
+
+    return sciNotation % Decimal(value)
+
 def get2DMapOfDetector(vfatChanLUT, obsData, mapName, zLabel):
     """
     Generates a 2D map of the detector as a TH2D. Y-axis will be ieta. X-axis will be ROBstr (strip),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Work in progress, need to update documentation for `sphinx`.

Provides an analysis tool `anaSBitMonitor.py` that analyzes data taken with `checkSbitMappingAndRate.py`.

Additionally the `chConfig.txt` file created by `anaUltraScurve.py` and `anaUltraThreshold.py` will now confirm to the format given in `trimChamberV3.py` for VFAT3 (the user should supply the option `--isVFAT3`).  The default preserves the VFAT2 format.  Change is backwards compatible.

### `checkSbitMappingAndRate.py`
Relevant help menu parameters are:

```
(py2.7) [dorney@gem904daq01]~/scratch0/CMS_GEM/CMS_GEM_DAQ% anaSBitMonitor.py -h
Usage: anaSBitMonitor.py [options]

Options:
  -h, --help            show this help message and exit
  -d, --debug           print extra debugging information
  -i filename, --infilename=filename
                        Specify Input Filename
  --checkInvalid        If provided invalid sbits will be considered
```

Example call, considering only valid sbits:

```
anaSBitMonitor.py -i SBitData.root
```

And if wanting to also consider sbits marked as invalid:

```
anaSBitMonitor.py -i SBitData.root --checkInvalid
```

Using the `--debug` tab will print a table displaying the sbit's observed by the CTP7's `SBIT_MONITOR` for all events.

Additionally it will print a table at the end of the analysis which will show the `(vfat,sbit)` pair in which a particular sbit was observed and that sbit did *not* match the channel being pulsed and the number of times a mismatch was observed.  The correct mapping should always follow `sbit = floor(chan/2)`.  Example:

| vfatN | vfatSBIT | N_Mismatches |
| :---: | :------: | :----------: |
| 19 | 5 | 1 |
| 23 | 16 | 806 |
| 23 | 17 | 733 |
| 23 | 18 | 37 |
| 23 | 19 | 1453 |
| 23 | 20 | 43 |
| 23 | 22 | 127 |
| 23 | 23 | 14753 |
| 23 | 63 | 6983 |
| 4 | 49 | 2 |
| 4 | 52 | 1 |
| 4 | 54 | 1 |
| 4 | 56 | 3 |
| 4 | 57 | 2 |
| 4 | 58 | 6 |
| 4 | 60 | 3 |
| 4 | 61 | 1 |
| 4 | 62 | 4 |
| 4 | 63 | 2 |
| 6 | 32 | 42204 |
| 6 | 27 | 2294 |
| 6 | 24 | 13274 |
| 6 | 25 | 1888 |
| 6 | 26 | 12657 |
| 6 | 63 | 7125 |
| 6 | 28 | 7459 |
| 6 | 29 | 68 |
| 6 | 30 | 2775 |
| 6 | 31 | 4106 |
| 7 | 24 | 50400 |
| 7 | 56 | 50400 | 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Need a tool to analyze data taken with `checkSbitMappingAndRate.py`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the analysis.

### Screenshots (if appropriate):

Plot of sbit mapping when no pulses sent:
![sbitsize_validsbits_caldisabled_0hz](https://user-images.githubusercontent.com/6432141/44219737-16c82700-a17d-11e8-89ce-e5336b0ec78f.png)
Plot of sbit mapping when calpulse is used:
![sbitsize_validsbits_calenabled_sumofallrates](https://user-images.githubusercontent.com/6432141/44219738-16c82700-a17d-11e8-8112-1c4b920dca0f.png)

Plot of rate observed vs. rate pulsed (as we can see the OH see's nothing...not a SW bug, but FW):
![rateobservedvsratepulsed_validsbits](https://user-images.githubusercontent.com/6432141/44219801-395a4000-a17d-11e8-81ab-ea40316fcf4f.png)

Plot of VFAT pulsed vs. VFAT observed:
![vfatobsvsvfatpulsed_validsbits_calenabled_sumofallrates](https://user-images.githubusercontent.com/6432141/44219819-437c3e80-a17d-11e8-82ae-640db10e0f08.png)

Additional plots are made, but these are the most important.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
