### PR TITLE
add DAC scan analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ preprpm: default
 	@cp -rf anaSBit*.py $(ScriptDir)
 	@cp -rf anaXDAQ*.py $(ScriptDir)
 	@cp -rf ana_scans.py $(ScriptDir)
+	@cp -rf anaDACScan.py $(ScriptDir)
 	@cp -rf anaXDAQLatency.py $(ScriptDir)
 	@cp -rf packageFiles4Docker.py $(ScriptDir)
 	-cp -rf README.md LICENSE CHANGELOG.md MANIFEST.in requirements.txt $(PackageDir)

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -40,6 +40,10 @@ Arguments
 
     Name of the output root file. Default is DACFitData.root.
 
+.. option:: --output_txtfile_filename
+
+    Name of output text file that will contain the nominal DAC values in tab-delimited format. Default is NominalDACValues.txt.
+
 Example
 -------
 
@@ -185,12 +189,12 @@ if __name__ == '__main__':
         #Use Ohm's law to convert the currents to voltages. The VFAT3 team told us that a 20k ohm resistor was used.
         if nominalDacValues[nameX][1][1] == "A":
 
+            calibrated_ADC_value = calibrated_ADC_value/20000.0
+            calibrated_ADC_error = calibrated_ADC_value/20000.0
+
             if nameX != 'CFG_IREF':
                 calibrated_ADC_value -= nominalDacValues['CFG_IREF'][0] 
             
-            calibrated_ADC_value = calibrated_ADC_value*20000.0
-            calibrated_ADC_error = calibrated_ADC_value*20000.0
-
         #the reversal of x and y is intended - we want to plot the nameX variable on the y-axis and the nameY variable on the x-axis
         #the nameX variable is the DAC register that is scanned, and we want to determine its nominal value
         if args.assignXErrors:

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -79,7 +79,6 @@ if __name__ == '__main__':
     r.TH1.SetDefaultSumw2(False)
     r.gROOT.SetBatch(True)
     r.gStyle.SetOptStat(1111111)
-    r.gStyle.SetDrawOption
     
     dacScanFile = r.TFile(args.infilename)
 

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -122,7 +122,7 @@ if __name__ == '__main__':
         print("Error: unexpected value of nameX: '%s'"%nameX)
         exit(1)
 
-    #the nominal reference current is 10 uA and it has a scaling    
+    #the nominal reference current is 10 uA and it has a scaling factor of 0.5   
     nominal_iref = 10/0.5
 
     nominal = nominalDacValues[nameX][0]/nominalDacScalingFactors[nameX]

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -188,15 +188,15 @@ if __name__ == '__main__':
     for oh in ohArray:
         for vfat in range(0,24):
             dict_RawADCvsDAC_Graphs[oh][vfat] = r.TGraphErrors()
-            dict_RawADCvsDAC_Graphs[oh][vfat].GetXaxis().SetTitle(nameX)
-            dict_RawADCvsDAC_Graphs[oh][vfat].GetYaxis().SetTitle(nameY)
+            dict_RawADCvsDAC_Graphs[oh][vfat].GetXaxis().SetTitle(nameY)
+            dict_RawADCvsDAC_Graphs[oh][vfat].GetYaxis().SetTitle(nameX)
             dict_DACvsADC_Graphs[oh][vfat] = r.TGraphErrors()
             #the reversal of x and y is intended - we want to plot the nameX variable on the y-axis and the nameY variable on the x-axis
             if nominalDacValues[nameX][1][len(nominalDacValues[nameX][1])-1] == 'A':
-                dict_DACvsADC_Graphs[oh][vfat].GetXaxis().SetTitle(nameY + " (uA)")
+                dict_DACvsADC_Graphs[oh][vfat].GetXaxis().SetTitle(nameX + " (uA)")
             else:
-                dict_DACvsADC_Graphs[oh][vfat].GetXaxis().SetTitle(nameY + " (mV)")
-            dict_DACvsADC_Graphs[oh][vfat].GetYaxis().SetTitle(nameX)
+                dict_DACvsADC_Graphs[oh][vfat].GetXaxis().SetTitle(nameX + " (mV)")
+            dict_DACvsADC_Graphs[oh][vfat].GetYaxis().SetTitle(nameY)
 
     outputFiles = {}         
              

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -1,8 +1,60 @@
 #!/usr/bin/env python
 
-"""
-anaDACScan
-==============
+r"""
+``anaDACScan`` -- analyzes DAC scan data
+========================================
+
+Synopsis
+--------
+
+**anaDACScan.py** [*OPTIONS*]
+
+Description
+-----------
+
+This script reads in calibration information and DAC scan data, performs a fit for each VFAT, computes the DAC value corresponding to the nominal current or voltage for each VFAT, and reports the results.
+
+
+Arguments
+---------
+
+.. program:: anaDACScan.py
+
+.. option:: infilename
+
+    Name of the input file root.
+
+.. option:: --assignXErrors  
+
+    Use the dacValX_Err values stored in the input file
+
+.. option:: --calFileList
+  
+    Provide a file containing a list of calFiles in the format: 
+    OH1 calFileOH1
+    OH2 calFileOH2
+    OH3 calFileOH3
+
+.. option:: --outfilename
+
+    Name of the output root file. Default is DACFitData.root.
+
+Example
+-------
+
+.. code-block:: bash
+
+    anaDACScan.py /afs/cern.ch/user/d/dorney/public/v3Hack/dacScanV3.root  --calFileList calibration.txt --assignXErrors
+
+
+Environment
+-----------
+
+
+Internals
+---------
+
+
 """
 
 if __name__ == '__main__':

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -67,7 +67,7 @@ if __name__ == '__main__':
     parser.add_argument('infilename', type=str, help="Filename from which input information is read", metavar='infilename')
     parser.add_argument("--calFileList", type=str, help="File specifying which calFile to use for each OH. Format: 0 /path/to/my/cal/file.txt<newline> 1 /path/to/my/cal/file.txt<newline>...", metavar="calFileList")
     parser.add_argument('-o','--outfilename', dest='outfilename', type=str, default="DACFitData.root", help="Filename to which output information is written", metavar='outfilename')
-    parser.add_argument('-t','--output_txtfile_filename_base', dest='output_txtfile_filename', type=str, default="NominalDACValues.txt", help="Name of output text file that will contain the nominal DAC values in tab-delimited format", metavar='output_txtfile_filename')
+    parser.add_argument('-t','--output_txtfile_filename', dest='output_txtfile_filename', type=str, default="NominalDACValues.txt", help="Name of output text file that will contain the nominal DAC values in tab-delimited format", metavar='output_txtfile_filename')
     parser.add_argument('--assignXErrors', dest='assignXErrors', action='store_true', help="Whether to assign errors for the X variable (which is actually plotted on the y-axis)")
 
     args = parser.parse_args()
@@ -188,8 +188,8 @@ if __name__ == '__main__':
             if nameX != 'CFG_IREF':
                 calibrated_ADC_value -= nominalDacValues['CFG_IREF'][0] 
             
-            calibrated_ADC_value = calibrated_ADC_value/20000.0
-            calibrated_ADC_error = calibrated_ADC_value/20000.0
+            calibrated_ADC_value = calibrated_ADC_value*20000.0
+            calibrated_ADC_error = calibrated_ADC_value*20000.0
 
         #the reversal of x and y is intended - we want to plot the nameX variable on the y-axis and the nameY variable on the x-axis
         #the nameX variable is the DAC register that is scanned, and we want to determine its nominal value

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -25,7 +25,7 @@ Arguments
 
 .. option:: --assignXErrors  
 
-    If this flag is set, the dacValX_Err values stored in the input file when constructing the plots. If this flag is not set, the error associated with the dacValX values is always taken to be 0. The dacValY_err values are always used.
+    If this flag is set, the dacValX_Err values stored in the input file are used when constructing the plots and performing the fits. If this flag is not set, the error associated with the dacValX values is always taken to be 0. Note that these errors are actually errors on the variable plotted on the y-axis in the DAC vs ADC plots. The dacValY_Err values, which would correspond to the errors on the x-axis in the DAC vs ADC plots, cannot be used because fits do not converge when they are used. 
 
 .. option:: --calFileList
   
@@ -231,13 +231,13 @@ if __name__ == '__main__':
         if args.assignXErrors:
             dict_DACvsADC_Graphs[oh][vfat].SetPoint(dict_DACvsADC_Graphs[oh][vfat].GetN(),calibrated_ADC_value,event.dacValX)
             dict_RawADCvsDAC_Graphs[oh][vfat].SetPoint(dict_RawADCvsDAC_Graphs[oh][vfat].GetN(),event.dacValY,event.dacValX)
-            dict_DACvsADC_Graphs[oh][vfat].SetPointError(dict_DACvsADC_Graphs[oh][vfat].GetN()-1,calibrated_ADC_error,event.dacValX_Err)
-            dict_RawADCvsDAC_Graphs[oh][vfat].SetPointError(dict_RawADCvsDAC_Graphs[oh][vfat].GetN()-1,event.dacValY_Err,event.dacValX_Err)
+            dict_DACvsADC_Graphs[oh][vfat].SetPointError(dict_DACvsADC_Graphs[oh][vfat].GetN()-1,0,event.dacValX_Err)
+            dict_RawADCvsDAC_Graphs[oh][vfat].SetPointError(dict_RawADCvsDAC_Graphs[oh][vfat].GetN()-1,0,event.dacValX_Err)
         else:
             dict_DACvsADC_Graphs[oh][vfat].SetPoint(dict_DACvsADC_Graphs[oh][vfat].GetN(),calibrated_ADC_value,event.dacValX)
             dict_RawADCvsDAC_Graphs[oh][vfat].SetPoint(dict_RawADCvsDAC_Graphs[oh][vfat].GetN(),event.dacValY,event.dacValX)
-            dict_DACvsADC_Graphs[oh][vfat].SetPointError(dict_DACvsADC_Graphs[oh][vfat].GetN()-1,calibrated_ADC_error,0)
-            dict_RawADCvsDAC_Graphs[oh][vfat].SetPointError(dict_RawADCvsDAC_Graphs[oh][vfat].GetN()-1,event.dacValY_Err,0)
+            dict_DACvsADC_Graphs[oh][vfat].SetPointError(dict_DACvsADC_Graphs[oh][vfat].GetN()-1,0,0)
+            dict_RawADCvsDAC_Graphs[oh][vfat].SetPointError(dict_RawADCvsDAC_Graphs[oh][vfat].GetN()-1,0,0)
 
     # Fit the TGraphErrors objects    
     for oh in ohArray:

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -237,33 +237,36 @@ if __name__ == '__main__':
              dacVal_branch[0] = dict_dacVals[oh][vfat]
              tree_dacVals[oh].Fill() 
              
-    # Write out the dacVal results to both a file and the terminal         
+    # Write out the dacVal results to a root file, a text file, and the terminal
+    outputTxtFiles_dacVals = {}    
+            
+    if scandate == 'noscandate':
+        outputTxtFiles_dacVals[oh] = open(elogPath+"/"+chamber_config[oh]+"/"+args.output_txtfile_filename,'w')
+    else:    
+        outputTxtFiles_dacVals[oh] = open(dataPath+"/"+chamber_config[oh]+"/dacScans/"+scandate+"/"+args.output_txtfile_filename,'w')
+
     print( "| OH | vfatN | dacVal |")
     print( "| :-: | :---: | :----: |")        
     
     for oh in ohArray:
         outputFiles[oh].cd()
+        outputFiles[oh].mkdir("Summary")
+        outputFiles[oh].cd("Summary")
         graph_dacVals[oh].Write("dacVals")
         tree_dacVals[oh].Write("dacVals")
         for vfat in range(0,24):
+            outputFiles[oh].cd()
+            outputFiles[oh].mkdir("VFAT"+str(vfat))
+            outputFiles[oh].cd("VFAT"+str(vfat))
+            dict_DACvsADC_Graphs[oh][vfat].Write()
+            outputFiles[oh].cd("../")
+            outputTxtFiles_dacVals[oh].write(str(vfat)+"\t"+str(dict_dacVals[oh][vfat])+"\n")
             print("| {0} | {1}  | {2} | ".format(
                 oh,
                 vfat,
                 dict_dacVals[oh][vfat]
             ))
 
-    outputTxtFiles_dacVals = {}    
-            
-    # Write out the results to a txt file in tab-delimited format
-    if scandate == 'noscandate':
-        outputTxtFiles_dacVals[oh] = open(elogPath+"/"+chamber_config[oh]+"/"+args.output_txtfile_filename,'w')
-    else:    
-        outputTxtFiles_dacVals[oh] = open(dataPath+"/"+chamber_config[oh]+"/dacScans/"+scandate+"/"+args.output_txtfile_filename,'w')
-
-    for oh in ohArray:
-        for vfat in range(0,24):
-            outputTxtFiles_dacVals[oh].write(str(vfat)+"\t"+str(dict_dacVals[oh][vfat])+"\n")
-            
     # Make plots        
     for oh in ohArray:
         canv_Summary = make3x8Canvas('canv_Summary',dict_DACvsADC_Graphs[oh],'AP',dict_DACvsADC_Funcs[oh],'')
@@ -272,4 +275,5 @@ if __name__ == '__main__':
         else:
             canv_Summary.SaveAs(dataPath+"/"+chamber_config[oh]+"/dacScans/"+scandate+"/SummaryOH.png")
         outputFiles[oh].cd()
+        outputFiles[oh].cd("Summary")
         canv_Summary.Write()

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -25,7 +25,7 @@ Arguments
 
 .. option:: --assignXErrors  
 
-    Use the dacValX_Err values stored in the input file
+    If this flag is set, the dacValX_Err values stored in the input file when constructing the plots. If this flag is not set, the error associated with the dacValX values is always taken to be 0. The dacValY_err values are always used.
 
 .. option:: --calFileList
   
@@ -69,7 +69,7 @@ if __name__ == '__main__':
     parser.add_argument('infilename', type=str, help="Filename from which input information is read", metavar='infilename')
     parser.add_argument("--calFileList", type=str, help="File specifying which calFile to use for each OH. Format: 0 /path/to/my/cal/file.txt<newline> 1 /path/to/my/cal/file.txt<newline>...", metavar="calFileList")
     parser.add_argument('-o','--outfilename', dest='outfilename', type=str, default="DACFitData.root", help="Filename to which output information is written", metavar='outfilename')
-    parser.add_argument('--assignXErrors', dest='assignXErrors', action='store_true', help="Whether to assign errors for the X variable (which is actually plotted on the y-axis)")
+    parser.add_argument('--assignXErrors', dest='assignXErrors', action='store_true', help="dacValY_Err values are always used, but dacValX_Err values are used if and only if this flag is set")
 
     args = parser.parse_args()
 

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -192,7 +192,7 @@ if __name__ == '__main__':
             dict_RawADCvsDAC_Graphs[oh][vfat].GetYaxis().SetTitle(nameY)
             dict_DACvsADC_Graphs[oh][vfat] = r.TGraphErrors()
             #the reversal of x and y is intended - we want to plot the nameX variable on the y-axis and the nameY variable on the x-axis
-            if nominalDacValues['CFG_IREF'][1][1] == 'A':
+            if nominalDacValues[nameX][1][1] == 'A':
                 dict_DACvsADC_Graphs[oh][vfat].GetXaxis().SetTitle(nameY + " (uA)")
             else:
                 dict_DACvsADC_Graphs[oh][vfat].GetXaxis().SetTitle(nameY + " (mV)")

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -46,7 +46,7 @@ Example
 
 .. code-block:: bash
 
-    anaDACScan.py /afs/cern.ch/user/d/dorney/public/v3Hack/dacScanV3.root  --calFileList calibration.txt --assignXErrors
+    anaDACScan.py /path/to/input.root  --calFileList calibration.txt --assignXErrors
 
 
 Environment

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -260,6 +260,7 @@ if __name__ == '__main__':
                 
                 if maxVfat3DACSize[dacSelect][1] == nameX:
                     maxDacValue = int(maxVfat3DACSize[dacSelect][0])
+                    break
                     
             #evaluate the fitted function at the nominal current or voltage value and convert to an integer
             nominalDacValue = int(dict_DACvsADC_Funcs[oh][vfat].Eval(nominal))

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -1,0 +1,82 @@
+#!/bin/env python
+
+"""
+anaDACScan
+==============
+"""
+
+import argparse
+import numpy as np
+import root_numpy as rp
+import ROOT as r
+
+from gempython.gemplotting.utils.anautilities import parseCalFile
+
+from gempython.utils.nesteddict import nesteddict
+
+from gempython.gemplotting.utils.anautilities import make3x8Canvas
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(description='Arguments to supply to anaDACScan.py')
+
+    parser.add_argument('infilename', metavar='infilename', type=str, help="Filename from which input information is read")
+#    parser.add_argument("calFile", metavar="calFile", type=str,help="File specifying CAL_DAC/VCAL to fC equations per VFAT")
+    parser.add_argument('-o','--outfilename', metavar='outfilename', type=str, help="Filename to which output information is written", default="DACFitData.root")
+
+    args = parser.parse_args()
+
+    print("Analyzing: '%s'"%args.infilename)
+
+    # Set default histogram behavior
+    r.TH1.SetDefaultSumw2(False)
+    r.gROOT.SetBatch(True)
+    r.gStyle.SetOptStat(1111111)
+
+    dacScanFile = r.TFile(args.infilename)
+    
+    # Determine which links present
+    list_bNames = ['link']
+    ohArray = rp.tree2array(tree=dacScanFile.dacScanTree, branches=list_bNames)
+    ohArray = np.unique(ohArray['link'])
+
+    # Determine which DAC was scanned and against which ADC
+    nameX = ""
+    nameY = ""
+    for event in dacScanFile.dacScanTree:
+        nameX = event.nameX.data()
+        nameY = event.nameY.data()
+        break # all entries will be the same
+
+    # Initialize nested dictionaries
+    dict_dacScanResults = nesteddict()
+    dict_dacScanFuncs = nesteddict()
+
+    # Get ADC0 or ADC1 calibration
+    # tuple_calInfo = parseCalFile(args.calFile)
+    
+    # Initialize a TGraphErrors for each vfat
+    for link in ohArray:
+        for vfat in range(0,24):
+             dict_dacScanResults[link][vfat] = r.TGraphErrors()
+             
+    # Loop over events in the tree and fill plots         
+    for event in dacScanFile.dacScanTree:
+        link = event.link
+        vfat = event.vfatN
+
+        dict_dacScanResults[link][vfat].SetPoint(dict_dacScanResults[link][vfat].GetN(),event.dacValY,event.dacValX)
+        dict_dacScanResults[link][vfat].SetPointError(dict_dacScanResults[link][vfat].GetN()-1,event.dacValY_Err,event.dacValX_Err)
+
+    # Fit the TGraphErrors objects    
+    for oh in ohArray:
+        for vfat in range(0,24):
+            dict_dacScanFuncs[oh][vfat] = r.TF1("DAC Scan Function","[0]*x+[1]")
+            dict_dacScanResults[oh][vfat].Fit(dict_dacScanFuncs[oh][vfat]) 
+
+    # Determine DAC values to achieve recommended bias voltage and current settings        
+
+    # Make plots        
+    for oh in ohArray:
+        canv_Summary = make3x8Canvas('canv_Summary',dict_dacScanResults[oh],'AP',dict_dacScanFuncs[oh],'')
+        canv_Summary.SaveAs("SummaryOH"+str(oh)+".png")

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -25,7 +25,7 @@ Arguments
 
 .. option:: --assignXErrors  
 
-    If this flag is set, the dacValX_Err values stored in the input file are used when constructing the plots and performing the fits. If this flag is not set, the error associated with the dacValX values is always taken to be 0. Note that these errors are actually errors on the variable plotted on the y-axis in the DAC vs ADC plots. The dacValY_Err values, which would correspond to the errors on the x-axis in the DAC vs ADC plots, cannot be used because fits do not converge when they are used. 
+    If this flag is set then an uncertain on the DAC register value is assumed, otherwise the DAC register value is assumed to be a fixed unchanging value (almost always the case). 
 
 .. option:: --calFileList
   
@@ -69,7 +69,7 @@ if __name__ == '__main__':
     parser.add_argument('infilename', type=str, help="Filename from which input information is read", metavar='infilename')
     parser.add_argument("--calFileList", type=str, help="File specifying which calFile to use for each OH. Format: 0 /path/to/my/cal/file.txt<newline> 1 /path/to/my/cal/file.txt<newline>...", metavar="calFileList")
     parser.add_argument('-o','--outfilename', dest='outfilename', type=str, default="DACFitData.root", help="Filename to which output information is written", metavar='outfilename')
-    parser.add_argument('--assignXErrors', dest='assignXErrors', action='store_true', help="dacValY_Err values are always used, but dacValX_Err values are used if and only if this flag is set")
+    parser.add_argument('--assignXErrors', dest='assignXErrors', action='store_true', help="If this flag is set then an uncertain on the DAC register value is assumed, otherwise the DAC register value is assumed to be a fixed unchanging value (almost always the case).")
 
     args = parser.parse_args()
 
@@ -163,7 +163,7 @@ if __name__ == '__main__':
     #for each OH, check if calibration files were provided, if not search for the calFile in the $DATA_PATH, if it is not there, then skip that OH for the rest of the script
     for oh in ohArray:
         if oh not in calInfo.keys():
-            calAdcCalFile = "{0}/{1}/calFile_calAdc_{1}.txt".format(dataPath,chamber_config[oh])
+            calAdcCalFile = "{0}/{1}/calFile_{2}_{1}.txt".format(dataPath,chamber_config[oh],nameY)
             calAdcCalFileExists = os.path.isfile(calAdcCalFile)
             if not calAdcCalFileExists:
                 print("Skipping OH{0}, detector {1}, missing CFG_CAL_DAC Calibration file:\n\t{2}".format(

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -79,7 +79,8 @@ if __name__ == '__main__':
     r.TH1.SetDefaultSumw2(False)
     r.gROOT.SetBatch(True)
     r.gStyle.SetOptStat(1111111)
-
+    r.gStyle.SetDrawOption
+    
     dacScanFile = r.TFile(args.infilename)
 
     import numpy as np
@@ -188,15 +189,16 @@ if __name__ == '__main__':
     for oh in ohArray:
         for vfat in range(0,24):
             dict_RawADCvsDAC_Graphs[oh][vfat] = r.TGraphErrors()
-            dict_RawADCvsDAC_Graphs[oh][vfat].GetXaxis().SetTitle(nameY)
-            dict_RawADCvsDAC_Graphs[oh][vfat].GetYaxis().SetTitle(nameX)
+            dict_RawADCvsDAC_Graphs[oh][vfat].GetXaxis().SetTitle(nameX)
+            dict_RawADCvsDAC_Graphs[oh][vfat].GetYaxis().SetTitle(nameY)
             dict_DACvsADC_Graphs[oh][vfat] = r.TGraphErrors()
             #the reversal of x and y is intended - we want to plot the nameX variable on the y-axis and the nameY variable on the x-axis
+            dict_DACvsADC_Graphs[oh][vfat].GetYaxis().SetTitle(nameX)
             if nominalDacValues[nameX][1][len(nominalDacValues[nameX][1])-1] == 'A':
-                dict_DACvsADC_Graphs[oh][vfat].GetXaxis().SetTitle(nameX + " (uA)")
+                dict_DACvsADC_Graphs[oh][vfat].GetXaxis().SetTitle(nameY + " (#muA)")
             else:
-                dict_DACvsADC_Graphs[oh][vfat].GetXaxis().SetTitle(nameX + " (mV)")
-            dict_DACvsADC_Graphs[oh][vfat].GetYaxis().SetTitle(nameY)
+                dict_DACvsADC_Graphs[oh][vfat].GetXaxis().SetTitle(nameY + " (mV)")
+
 
     outputFiles = {}         
              
@@ -244,6 +246,8 @@ if __name__ == '__main__':
         for vfat in range(0,24):
             #use a fifth degree polynomial to do the fit
             dict_DACvsADC_Funcs[oh][vfat] = r.TF1("DAC Scan Function","[0]*x^5+[1]*x^4+[2]*x^3+[3]*x^2+[4]*x+[5]")
+            dict_DACvsADC_Funcs[oh][vfat].SetLineWidth(1)
+            dict_DACvsADC_Funcs[oh][vfat].SetLineStyle(3)
             dict_DACvsADC_Graphs[oh][vfat].Fit(dict_DACvsADC_Funcs[oh][vfat],"Q") 
 
     # Determine DAC values to achieve recommended bias voltage and current settings
@@ -251,6 +255,9 @@ if __name__ == '__main__':
     dict_dacVals = nesteddict()
     for oh in ohArray:
         graph_dacVals[oh] = r.TGraph()
+        graph_dacVals[oh].SetMinimum(0)
+        graph_dacVals[oh].GetXaxis().SetTitle("VFATN")
+        graph_dacVals[oh].GetYaxis().SetTitle("nominal DAC value")
         for vfat in range(0,24):
 
             maxDacValue = 255
@@ -311,7 +318,7 @@ if __name__ == '__main__':
 
     # Make plots        
     for oh in ohArray:
-        canv_Summary = make3x8Canvas('canv_Summary',dict_DACvsADC_Graphs[oh],'AP',dict_DACvsADC_Funcs[oh],'')
+        canv_Summary = make3x8Canvas('canv_Summary',dict_DACvsADC_Graphs[oh],'APE1',dict_DACvsADC_Funcs[oh],'')
         if scandate == 'noscandate':
             canv_Summary.SaveAs(elogPath+"/"+chamber_config[oh]+"/Summary.png")
         else:

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -191,13 +191,22 @@ if __name__ == '__main__':
         
     # Determine DAC values to achieve recommended bias voltage and current settings
     graph_dacVals = {}
+    tree_dacVals = {}
     dict_dacVals = nesteddict()
     for oh in ohArray:
         graph_dacVals[oh] = r.TGraph()
+        tree_dacVals[oh] = r.TTree()
+        vfatN_branch = np.zeros(1, dtype=int)
+        dacVal_branch = np.zeros(1, dtype=int)
+        tree_dacVals[oh].Branch('vfatN',vfatN_branch,'vfatN/i')
+        tree_dacVals[oh].Branch('dacVal',dacVal_branch,'dacVal/i')
         for vfat in range(0,24):
              dict_dacVals[oh][vfat] = dict_dacScanResults[oh][vfat].Eval(nominal)
-             graph_dacVals[oh].SetPoint(graph_dacVals[oh].GetN(),vfat,dict_dacVals[oh][vfat]) 
-
+             graph_dacVals[oh].SetPoint(graph_dacVals[oh].GetN(),vfat,dict_dacVals[oh][vfat])
+             vfatN_branch[0] = vfat
+             dacVal_branch[0] = dict_dacVals[oh][vfat]
+             tree_dacVals[oh].Fill() 
+             
     # Write out the dacVal results to both a file and the terminal         
     print( "| OH | vfatN | dacVal |")
     print( "| -- | ----- | ------ |")        
@@ -205,6 +214,7 @@ if __name__ == '__main__':
     for oh in ohArray:
         outputFiles[oh].cd()
         graph_dacVals[oh].Write("dacValsOH"+str(oh))
+        tree_dacVals[oh].Write("dacValsOH"+str(oh))
         for vfat in range(0,24):
             print("| {0} | {1}  | {2} | ".format(
                 oh,

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -185,13 +185,13 @@ if __name__ == '__main__':
     # Initialize a TGraphErrors for each vfat
     for oh in ohArray:
         for vfat in range(0,24):
-             dict_DACvsADC_Graphs[oh][vfat] = r.TGraphErrors()
-             dict_RawADCvsDAC_Graphs[oh][vfat] = r.TGraphErrors()
-             #the reversal of x and y is intended - we want to plot the nameX variable on the y-axis and the nameY variable on the x-axis
-             dict_DACvsADC_Graphs[oh][vfat].GetXaxis().SetTitle(nameY)
-             dict_DACvsADC_Graphs[oh][vfat].GetYaxis().SetTitle(nameX)
-             dict_RawADCvsDAC_Graphs[oh][vfat].GetXaxis().SetTitle(nameY)
-             dict_RawADCvsDAC_Graphs[oh][vfat].GetYaxis().SetTitle(nameX)
+            dict_RawADCvsDAC_Graphs[oh][vfat] = r.TGraphErrors()
+            dict_RawADCvsDAC_Graphs[oh][vfat].GetXaxis().SetTitle(nameX)
+            dict_RawADCvsDAC_Graphs[oh][vfat].GetYaxis().SetTitle(nameY)
+            dict_DACvsADC_Graphs[oh][vfat] = r.TGraphErrors()
+            #the reversal of x and y is intended - we want to plot the nameX variable on the y-axis and the nameY variable on the x-axis
+            dict_DACvsADC_Graphs[oh][vfat].GetXaxis().SetTitle(nameY)
+            dict_DACvsADC_Graphs[oh][vfat].GetYaxis().SetTitle(nameX)
 
     outputFiles = {}         
              
@@ -269,7 +269,7 @@ if __name__ == '__main__':
                 print('Warning: the nominal DAC value that was found from the fit is larger than the maximum value that the DAC register will hold')
 
             if nominalDacValue < 0:
-                print('Warning: the nominal DAC value is that was found from the fit is less than 0')                
+                print('Warning: the nominal DAC value that was found from the fit is less than 0')                
             
             dict_dacVals[oh][vfat] = int(dict_DACvsADC_Funcs[oh][vfat].Eval(nominal))
             graph_dacVals[oh].SetPoint(graph_dacVals[oh].GetN(),vfat,dict_dacVals[oh][vfat])
@@ -295,6 +295,7 @@ if __name__ == '__main__':
             outputFiles[oh].mkdir("VFAT"+str(vfat))
             outputFiles[oh].cd("VFAT"+str(vfat))
             dict_DACvsADC_Graphs[oh][vfat].Write("DACvsADC")
+            dict_RawADCvsDAC_Graphs[oh][vfat].Write("RawADCvsDAC")
             outputFiles[oh].cd("../")
             outputTxtFiles_dacVals[oh].write(str(vfat)+"\t"+str(dict_dacVals[oh][vfat])+"\n")
             print("| {0} | {1}  | {2} | ".format(

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -71,7 +71,6 @@ if __name__ == '__main__':
     parser.add_argument('infilename', type=str, help="Filename from which input information is read", metavar='infilename')
     parser.add_argument("--calFileList", type=str, help="File specifying which calFile to use for each OH. Format: 0 /path/to/my/cal/file.txt<newline> 1 /path/to/my/cal/file.txt<newline>...", metavar="calFileList")
     parser.add_argument('-o','--outfilename', dest='outfilename', type=str, default="DACFitData.root", help="Filename to which output information is written", metavar='outfilename')
-    parser.add_argument('-t','--output_txtfile_filename', dest='output_txtfile_filename', type=str, default="NominalDACValues.txt", help="Name of output text file that will contain the nominal DAC values in tab-delimited format", metavar='output_txtfile_filename')
     parser.add_argument('--assignXErrors', dest='assignXErrors', action='store_true', help="Whether to assign errors for the X variable (which is actually plotted on the y-axis)")
 
     args = parser.parse_args()
@@ -255,9 +254,9 @@ if __name__ == '__main__':
     outputTxtFiles_dacVals = {}    
             
     if scandate == 'noscandate':
-        outputTxtFiles_dacVals[oh] = open(elogPath+"/"+chamber_config[oh]+"/"+args.output_txtfile_filename,'w')
+        outputTxtFiles_dacVals[oh] = open(elogPath+"/"+chamber_config[oh]+"/NominalDACValues.txt",'w')
     else:    
-        outputTxtFiles_dacVals[oh] = open(dataPath+"/"+chamber_config[oh]+"/dacScans/"+scandate+"/"+args.output_txtfile_filename,'w')
+        outputTxtFiles_dacVals[oh] = open(dataPath+"/"+chamber_config[oh]+"/dacScans/"+scandate+"/NominalDACValues.txt",'w')
 
     print( "| OH | vfatN | dacVal |")
     print( "| :-: | :---: | :----: |")        

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -254,11 +254,12 @@ if __name__ == '__main__':
         tree_dacVals[oh].Branch('vfatN',vfatN_branch,'vfatN/i')
         tree_dacVals[oh].Branch('dacVal',dacVal_branch,'dacVal/i')
         for vfat in range(0,24):
-             dict_dacVals[oh][vfat] = dict_DACvsADC_Funcs[oh][vfat].Eval(nominal)
-             graph_dacVals[oh].SetPoint(graph_dacVals[oh].GetN(),vfat,dict_dacVals[oh][vfat])
-             vfatN_branch[0] = vfat
-             dacVal_branch[0] = dict_dacVals[oh][vfat]
-             tree_dacVals[oh].Fill() 
+            #evaluate the fitted function at the nominal current or voltage value and convert to an integer
+            dict_dacVals[oh][vfat] = int(dict_DACvsADC_Funcs[oh][vfat].Eval(nominal))
+            graph_dacVals[oh].SetPoint(graph_dacVals[oh].GetN(),vfat,dict_dacVals[oh][vfat])
+            vfatN_branch[0] = vfat
+            dacVal_branch[0] = dict_dacVals[oh][vfat]
+            tree_dacVals[oh].Fill() 
              
     # Write out the dacVal results to a root file, a text file, and the terminal
     outputTxtFiles_dacVals = {}    

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -98,15 +98,22 @@ if __name__ == '__main__':
     ohArray = rp.tree2array(tree=dacScanFile.dacScanTree, branches=list_bNames)
     ohArray = np.unique(ohArray['link'])
     
-    dataPath = os.getenv("DATA_PATH") 
+    dataPath = os.getenv("DATA_PATH")
+    elogPath = os.getenv("ELOG_PATH") 
     
     if len(args.infilename.split('/')) > 1 and len(args.infilename.split('/')[len(args.infilename.split('/')) - 2].split('.')) == 5:
         scandate = args.infilename.split('/')[len(args.infilename.split('/')) - 2]
     else:    
         scandate = 'noscandate'
-
+        
     for oh in ohArray:
-        os.system("mkdir -p "+ dataPath+"/"+chamber_config[oh]+"/dacScans/"+scandate)
+        if scandate == 'noscandate':
+            os.system("mkdir -p "+ elogPath+"/"+chamber_config[oh])
+        else:
+            os.system("mkdir -p "+ dataPath+"/"+chamber_config[oh]+"/dacScans/"+scandate)
+
+        
+
             
     # Determine which DAC was scanned and against which ADC
     nameX = ""
@@ -163,8 +170,11 @@ if __name__ == '__main__':
 
     outputFiles = {}         
              
-    for oh in ohArray:         
-        outputFiles[oh] = r.TFile(dataPath+"/"+chamber_config[oh]+"/dacScans/"+scandate+"/"+args.outfilename,'recreate')
+    for oh in ohArray:
+        if scandate == 'noscandate':
+            outputFiles[oh] = r.TFile(elogPath+"/"+chamber_config[oh]+"/"+args.outfilename,'recreate')
+        else:    
+            outputFiles[oh] = r.TFile(dataPath+"/"+chamber_config[oh]+"/dacScans/"+scandate+"/"+args.outfilename,'recreate')
              
     # Loop over events in the tree and fill plots
     for event in dacScanFile.dacScanTree:
@@ -233,6 +243,9 @@ if __name__ == '__main__':
     # Make plots        
     for oh in ohArray:
         canv_Summary = make3x8Canvas('canv_Summary',dict_dacScanResults[oh],'AP',dict_dacScanFuncs[oh],'')
-        canv_Summary.SaveAs(dataPath+"/"+chamber_config[oh]+"/dacScans/"+scandate+"/SummaryOH"+str(oh)+".png")
+        if scandate == 'noscandate':
+            canv_Summary.SaveAs(elogPath+"/"+chamber_config[oh]+"/SummaryOH"+str(oh)+".png")
+        else:
+            canv_Summary.SaveAs(dataPath+"/"+chamber_config[oh]+"/dacScans/"+scandate+"/SummaryOH"+str(oh)+".png")
         outputFiles[oh].cd()
         canv_Summary.Write()

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -14,7 +14,6 @@ Description
 
 This script reads in calibration information and DAC scan data, performs a fit for each VFAT, computes the DAC value corresponding to the nominal current or voltage for each VFAT, and reports the results.
 
-
 Arguments
 ---------
 
@@ -47,16 +46,6 @@ Example
 .. code-block:: bash
 
     anaDACScan.py /path/to/input.root  --calFileList calibration.txt --assignXErrors
-
-
-Environment
------------
-
-
-Internals
----------
-
-
 """
 
 if __name__ == '__main__':
@@ -111,9 +100,6 @@ if __name__ == '__main__':
             os.system("mkdir -p "+ elogPath+"/"+chamber_config[oh])
         else:
             os.system("mkdir -p "+ dataPath+"/"+chamber_config[oh]+"/dacScans/"+scandate)
-
-        
-
             
     # Determine which DAC was scanned and against which ADC
     nameX = ""

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -138,15 +138,23 @@ if __name__ == '__main__':
      
     nominal = nominalDacValues[nameX][0]
 
-    #convert all voltages to mV
-    if nominalDacValues[nameX][1] == "V" or nominalDacValues[nameX][1] == "A":
+    #convert all voltages to mV and currents to uA
+    if nominalDacValues[nameX][1] == "V":
         nominal *= pow(10.0,3)
-    elif nominalDacValues[nameX][1][0] == 'm':
+    elif nominalDacValues[nameX][1] == 'mV':
         pass
-    elif nominalDacValues[nameX][1][0] == 'u':
+    elif nominalDacValues[nameX][1] == 'uV':
         nominal *= pow(10.0,-3)
-    elif nominalDacValues[nameX][1][0] == 'n':
+    elif nominalDacValues[nameX][1] == 'nV':
         nominal *= pow(10.0,-6)
+    elif nominalDacValues[nameX][1] == "A":
+        nominal *= pow(10.0,6)
+    elif nominalDacValues[nameX][1] == 'mA':
+        nominal *= pow(10.0,3)
+    elif nominalDacValues[nameX][1] == 'uA':
+        pass
+    elif nominalDacValues[nameX][1] == 'nA':
+        nominal *= pow(10.0,-3)
     else:
         print("Error: unexpected units: '%s'"%nominalDacValues[nameX][1])
         exit(1)

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -217,7 +217,7 @@ if __name__ == '__main__':
              
     # Write out the dacVal results to both a file and the terminal         
     print( "| OH | vfatN | dacVal |")
-    print( "| -- | ----- | ------ |")        
+    print( "| :-: | :---: | :----: |")        
     
     for oh in ohArray:
         outputFiles[oh].cd()

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -197,6 +197,7 @@ if __name__ == '__main__':
             dict_RawADCvsDAC_Graphs[oh][vfat].GetXaxis().SetTitle(nameX)
             dict_RawADCvsDAC_Graphs[oh][vfat].GetYaxis().SetTitle(nameY)
             dict_DACvsADC_Graphs[oh][vfat] = r.TGraphErrors()
+            dict_DACvsADC_Graphs[oh][vfat].SetTitle("VFAT{}".format(vfat))
             dict_DACvsADC_Graphs[oh][vfat].SetMarkerSize(5)
             #the reversal of x and y is intended - we want to plot the nameX variable on the y-axis and the nameY variable on the x-axis
             dict_DACvsADC_Graphs[oh][vfat].GetYaxis().SetTitle(nameX)

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -115,28 +115,17 @@ if __name__ == '__main__':
         print("Error: unexpected value of nameY: '%s'"%nameY)
         exit(1)
 
-    from utils.anaInfo import nominalDacValues    
+    from utils.anaInfo import nominalDacValues
+    from utils.anaInfo import nominalDacScalingFactors
         
     if nameX not in nominalDacValues.keys():
         print("Error: unexpected value of nameX: '%s'"%nameX)
         exit(1)
 
-    nominal_iref = nominalDacValues['CFG_IREF'][0]
+    #the nominal reference current is 10 uA and it has a scaling    
+    nominal_iref = 10/0.5
 
-    #convert all currents to uA 
-    if nominalDacValues['CFG_IREF'][1] == 'A':
-        nominal_iref *= pow(10.0,6)        
-    elif nominalDacValues['CFG_IREF'][1] == 'mA':
-        nominal_iref *= pow(10.0,3)
-    elif nominalDacValues['CFG_IREF'][1] == 'uA':
-        pass
-    elif nominalDacValues['CFG_IREF'][1] == 'nA':
-        nominal_iref *= pow(10.0,-3)
-    else:
-        print("Error: unexpected units for nominal reference current: '%s'"%nominalDacValues['CFG_IREF'][1])
-        exit(1)
-     
-    nominal = nominalDacValues[nameX][0]
+    nominal = nominalDacValues[nameX][0]/nominalDacScalingFactors[nameX]
 
     #convert all voltages to mV and currents to uA
     if nominalDacValues[nameX][1] == "V":

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -40,10 +40,6 @@ Arguments
 
     Name of the output root file. Default is DACFitData.root.
 
-.. option:: --output_txtfile_filename
-
-    Name of output text file that will contain the nominal DAC values in tab-delimited format. Default is NominalDACValues.txt.
-
 Example
 -------
 

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -114,24 +114,8 @@ if __name__ == '__main__':
         print("Error: unexpected value of nameY: '%s'"%nameY)
         exit(1)
 
-    nominalDacValues = {
-        "CFG_IREF":(10,"uA"),
-        "CFG_BIAS_PRE_I_BIT":(150,"uA"),
-        "CFG_BIAS_PRE_I_BLCC":(25,"nA"),
-        "CFG_BIAS_SH_I_BFCAS":(26,"uA"),
-        "CFG_BIAS_SH_I_BDIFF":(16,"uA"),
-        "CFG_BIAS_SD_I_BDIFF":(28,"uA"),
-        "CFG_BIAS_SD_I_BFCAS":(27,"uA"),
-        "CFG_BIAS_SD_I_BSF":(30,"uA"),
-        "CFG_BIAS_CFD_DAC_1":(20,"uA"),
-        "CFG_BIAS_CFD_DAC_2":(20,"uA"),
-        "CFG_HYST":(100,"nA"),
-        "CFG_THR_ARM_DAC":(3.2,"uA"),
-        "CFG_THR_ZCC_DAC":(275,"nA"),
-        "CFG_BIAS_PRE_VREF":(430,'mV'),
-        "CFG_ADC_VREF":(400,'mV')
-    }
-            
+    from utils.anaInfo import nominalDacValues    
+        
     if nameX not in nominalDacValues.keys():
         print("Error: unexpected value of nameX: '%s'"%nameX)
         exit(1)

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -192,7 +192,7 @@ if __name__ == '__main__':
             dict_RawADCvsDAC_Graphs[oh][vfat].GetYaxis().SetTitle(nameY)
             dict_DACvsADC_Graphs[oh][vfat] = r.TGraphErrors()
             #the reversal of x and y is intended - we want to plot the nameX variable on the y-axis and the nameY variable on the x-axis
-            if nominalDacValues[nameX][1][1] == 'A':
+            if nominalDacValues[nameX][1][len(nominalDacValues[nameX][1])-1] == 'A':
                 dict_DACvsADC_Graphs[oh][vfat].GetXaxis().SetTitle(nameY + " (uA)")
             else:
                 dict_DACvsADC_Graphs[oh][vfat].GetXaxis().SetTitle(nameY + " (mV)")
@@ -216,7 +216,7 @@ if __name__ == '__main__':
         calibrated_ADC_error=calInfo[oh]['slope'][vfat]*event.dacValY_Err
 
         #Use Ohm's law to convert the currents to voltages. The VFAT3 team told us that a 20 kOhm resistor was used.
-        if nominalDacValues[nameX][1][1] == "A":
+        if nominalDacValues[nameX][1][len(nominalDacValues[nameX][1])-1] == "A":
 
             #V (mV) = I (uA) R (kOhm)
             #V (10^-3) = I (10^-6) R (10^3)

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -58,6 +58,8 @@ if __name__ == '__main__':
     
     from gempython.gemplotting.mapping.chamberInfo import chamber_config
 
+    from gempython.tools.amc_user_functions_xhal import maxVfat3DACSize
+    
     import os
     
     import argparse
@@ -246,7 +248,28 @@ if __name__ == '__main__':
     for oh in ohArray:
         graph_dacVals[oh] = r.TGraph()
         for vfat in range(0,24):
+
+            maxDacValue = 255
+            
+            for dacSelect in maxVfat3DACSize.keys():
+
+                #the registers CFG_THR_ARM_DAC and CFG_THR_ZCC_DAC could correspond to voltages or currents
+                #we will use voltages until a way of distinguishing the two cases is implemented 
+                if dacSelect == 14 or dacSelect == 15:
+                    continue
+                
+                if maxVfat3DACSize[dacSelect][1] == nameX:
+                    maxDacValue = int(maxVfat3DACSize[dacSelect][0])
+                    
             #evaluate the fitted function at the nominal current or voltage value and convert to an integer
+            nominalDacValue = int(dict_DACvsADC_Funcs[oh][vfat].Eval(nominal))
+            
+            if nominalDacValue > maxDacValue:
+                print('Warning: the nominal DAC value that was found from the fit is larger than the maximum value that the DAC register will hold')
+
+            if nominalDacValue < 0:
+                print('Warning: the nominal DAC value is that was found from the fit is less than 0')                
+            
             dict_dacVals[oh][vfat] = int(dict_DACvsADC_Funcs[oh][vfat].Eval(nominal))
             graph_dacVals[oh].SetPoint(graph_dacVals[oh].GetN(),vfat,dict_dacVals[oh][vfat])
              

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -211,6 +211,10 @@ if __name__ == '__main__':
         calibrated_ADC_value=calInfo[oh]['slope'][vfat]*event.dacValY+calInfo[oh]['intercept'][vfat]
         calibrated_ADC_error=calInfo[oh]['slope'][vfat]*event.dacValY_Err+calInfo[oh]['intercept'][vfat]
 
+        #from Table 29 of the VFAT3 manual, we are guessing the calibrated voltage is in mV
+        calibrated_ADC_value /= 1000.0
+        calibrated_ADC_error /= 1000.0
+        
         #Use Ohm's law to convert the currents to voltages. The VFAT3 team told us that a 20k ohm resistor was used.
         if nominalDacValues[nameX][1][1] == "A":
 

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -280,11 +280,12 @@ if __name__ == '__main__':
              
     # Write out the dacVal results to a root file, a text file, and the terminal
     outputTxtFiles_dacVals = {}    
-            
-    if scandate == 'noscandate':
-        outputTxtFiles_dacVals[oh] = open(elogPath+"/"+chamber_config[oh]+"/NominalDACValues.txt",'w')
-    else:    
-        outputTxtFiles_dacVals[oh] = open(dataPath+"/"+chamber_config[oh]+"/dacScans/"+scandate+"/NominalDACValues.txt",'w')
+
+    for oh in ohArray:
+        if scandate == 'noscandate':
+            outputTxtFiles_dacVals[oh] = open(elogPath+"/"+chamber_config[oh]+"/NominalDACValues.txt",'w')
+        else:    
+            outputTxtFiles_dacVals[oh] = open(dataPath+"/"+chamber_config[oh]+"/dacScans/"+scandate+"/NominalDACValues.txt",'w')
 
     print( "| OH | vfatN | dacVal |")
     print( "| :-: | :---: | :----: |")        

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -84,7 +84,6 @@ if __name__ == '__main__':
 
     import root_numpy as rp
     import numpy as np
-    import ROOT as r
     list_bNames = ['vfatN','link','dacValY']
     vfatArray = rp.tree2array(tree=dacScanFile.dacScanTree,branches=list_bNames)
     ohArray = np.unique(vfatArray['link'])

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -230,12 +230,12 @@ if __name__ == '__main__':
         #the nameX variable is the DAC register that is scanned, and we want to determine its nominal value
         if args.assignXErrors:
             dict_DACvsADC_Graphs[oh][vfat].SetPoint(dict_DACvsADC_Graphs[oh][vfat].GetN(),calibrated_ADC_value,event.dacValX)
-            dict_RawADCvsDAC_Graphs[oh][vfat].SetPoint(dict_RawADCvsDAC_Graphs[oh][vfat].GetN(),event.dacValY,event.dacValX)
+            dict_RawADCvsDAC_Graphs[oh][vfat].SetPoint(dict_RawADCvsDAC_Graphs[oh][vfat].GetN(),event.dacValX,event.dacValY)
             dict_DACvsADC_Graphs[oh][vfat].SetPointError(dict_DACvsADC_Graphs[oh][vfat].GetN()-1,0,event.dacValX_Err)
-            dict_RawADCvsDAC_Graphs[oh][vfat].SetPointError(dict_RawADCvsDAC_Graphs[oh][vfat].GetN()-1,0,event.dacValX_Err)
+            dict_RawADCvsDAC_Graphs[oh][vfat].SetPointError(dict_RawADCvsDAC_Graphs[oh][vfat].GetN()-1,event.dacValX_Err,0)
         else:
             dict_DACvsADC_Graphs[oh][vfat].SetPoint(dict_DACvsADC_Graphs[oh][vfat].GetN(),calibrated_ADC_value,event.dacValX)
-            dict_RawADCvsDAC_Graphs[oh][vfat].SetPoint(dict_RawADCvsDAC_Graphs[oh][vfat].GetN(),event.dacValY,event.dacValX)
+            dict_RawADCvsDAC_Graphs[oh][vfat].SetPoint(dict_RawADCvsDAC_Graphs[oh][vfat].GetN(),event.dacValX,event.dacValY)
             dict_DACvsADC_Graphs[oh][vfat].SetPointError(dict_DACvsADC_Graphs[oh][vfat].GetN()-1,0,0)
             dict_RawADCvsDAC_Graphs[oh][vfat].SetPointError(dict_RawADCvsDAC_Graphs[oh][vfat].GetN()-1,0,0)
 

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -205,7 +205,7 @@ if __name__ == '__main__':
         vfat = event.vfatN
 
         calibrated_ADC_value=calInfo[oh]['slope'][vfat]*event.dacValY+calInfo[oh]['intercept'][vfat]
-        calibrated_ADC_error=calInfo[oh]['slope'][vfat]*event.dacValY_Err+calInfo[oh]['intercept'][vfat]
+        calibrated_ADC_error=calInfo[oh]['slope'][vfat]*event.dacValY_Err
 
         #from Table 29 of the VFAT3 manual, we are guessing the calibrated voltage is in mV
         calibrated_ADC_value /= 1000.0

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -10,6 +10,8 @@ from gempython.gemplotting.utils.anautilities import parseCalFile
 from gempython.utils.nesteddict import nesteddict
 from gempython.gemplotting.utils.anautilities import make3x8Canvas
 
+from gempython.gemplotting.mapping.chamberInfo import chamber_config
+
 import argparse
 
 if __name__ == '__main__':
@@ -31,8 +33,6 @@ if __name__ == '__main__':
     r.gStyle.SetOptStat(1111111)
 
     dacScanFile = r.TFile(args.infilename)
-
-    outputFile = r.TFile(args.outfilename,'recreate')
 
     import numpy as np
     import root_numpy as rp
@@ -71,6 +71,11 @@ if __name__ == '__main__':
     for link in ohArray:
         for vfat in range(0,24):
              dict_dacScanResults[link][vfat] = r.TGraphErrors()
+
+    outputFiles = {}         
+             
+    for link in ohArray:         
+        outputFiles[link] = r.TFile("$DATA_PATH/"+chamber_config[link]+"/dacScans/scandate/"+args.outfilename,'recreate')
              
     # Loop over events in the tree and fill plots
     for event in dacScanFile.dacScanTree:
@@ -120,7 +125,7 @@ if __name__ == '__main__':
     print( "| -- | ----- | ------ |")        
     
     for oh in ohArray:
-        outputFile.cd()
+        outputFiles[oh].cd()
         graph_dacVals[oh].Write("dacValsOH"+str(oh))
         for vfat in range(0,24):
             print("| {0} | {1}  | {2} | ".format(
@@ -132,6 +137,6 @@ if __name__ == '__main__':
     # Make plots        
     for oh in ohArray:
         canv_Summary = make3x8Canvas('canv_Summary',dict_dacScanResults[oh],'AP',dict_dacScanFuncs[oh],'')
-        canv_Summary.SaveAs("SummaryOH"+str(oh)+".png")
-        outputFile.cd()
+        canv_Summary.SaveAs("$DATA_PATH/"+chamber_config[oh]+"/dacScans/scandate/SummaryOH"+str(oh)+".png")
+        outputFiles[oh].cd()
         canv_Summary.Write()

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -176,7 +176,6 @@ if __name__ == '__main__':
                     calDacCalFile))
                 ohArray = np.delete(ohArray,(oh))
 
-
     if len(ohArray) == 0:
         print('No OHs with a calFile, exiting.')
         exit(1)
@@ -244,22 +243,13 @@ if __name__ == '__main__':
 
     # Determine DAC values to achieve recommended bias voltage and current settings
     graph_dacVals = {}
-    tree_dacVals = {}
     dict_dacVals = nesteddict()
     for oh in ohArray:
         graph_dacVals[oh] = r.TGraph()
-        tree_dacVals[oh] = r.TTree()
-        vfatN_branch = np.zeros(1, dtype=int)
-        dacVal_branch = np.zeros(1, dtype=int)
-        tree_dacVals[oh].Branch('vfatN',vfatN_branch,'vfatN/i')
-        tree_dacVals[oh].Branch('dacVal',dacVal_branch,'dacVal/i')
         for vfat in range(0,24):
             #evaluate the fitted function at the nominal current or voltage value and convert to an integer
             dict_dacVals[oh][vfat] = int(dict_DACvsADC_Funcs[oh][vfat].Eval(nominal))
             graph_dacVals[oh].SetPoint(graph_dacVals[oh].GetN(),vfat,dict_dacVals[oh][vfat])
-            vfatN_branch[0] = vfat
-            dacVal_branch[0] = dict_dacVals[oh][vfat]
-            tree_dacVals[oh].Fill() 
              
     # Write out the dacVal results to a root file, a text file, and the terminal
     outputTxtFiles_dacVals = {}    
@@ -276,13 +266,12 @@ if __name__ == '__main__':
         outputFiles[oh].cd()
         outputFiles[oh].mkdir("Summary")
         outputFiles[oh].cd("Summary")
-        graph_dacVals[oh].Write("dacVals")
-        tree_dacVals[oh].Write("dacVals")
+        graph_dacVals[oh].Write("nominalDacValVsVFATX")
         for vfat in range(0,24):
             outputFiles[oh].cd()
             outputFiles[oh].mkdir("VFAT"+str(vfat))
             outputFiles[oh].cd("VFAT"+str(vfat))
-            dict_DACvsADC_Graphs[oh][vfat].Write()
+            dict_DACvsADC_Graphs[oh][vfat].Write("DACvsADC")
             outputFiles[oh].cd("../")
             outputTxtFiles_dacVals[oh].write(str(vfat)+"\t"+str(dict_dacVals[oh][vfat])+"\n")
             print("| {0} | {1}  | {2} | ".format(
@@ -298,6 +287,3 @@ if __name__ == '__main__':
             canv_Summary.SaveAs(elogPath+"/"+chamber_config[oh]+"/Summary.png")
         else:
             canv_Summary.SaveAs(dataPath+"/"+chamber_config[oh]+"/dacScans/"+scandate+"/Summary.png")
-        outputFiles[oh].cd()
-        outputFiles[oh].cd("Summary")
-        canv_Summary.Write()

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -184,7 +184,7 @@ if __name__ == '__main__':
     for oh in ohArray:
         for vfat in range(0,24):
             dict_dacScanFuncs[oh][vfat] = r.TF1("DAC Scan Function","[0]*x+[1]")
-            dict_dacScanResults[oh][vfat].Fit(dict_dacScanFuncs[oh][vfat]) 
+            dict_dacScanResults[oh][vfat].Fit(dict_dacScanFuncs[oh][vfat],"Q") 
 
     nominal = -1        
 

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -124,6 +124,8 @@ if __name__ == '__main__':
 
     if args.calFileList != None:
         for line in open(args.calFileList):
+            if line[0] == "#":
+                continue
             line = line.strip(' ').strip('\n')
             first = line.split(' ')[0].strip(' ')
             second = line.split(' ')[1].strip(' ')

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -1,28 +1,25 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 """
 anaDACScan
 ==============
 """
-
-import argparse
-import numpy as np
-import root_numpy as rp
 import ROOT as r
 
 from gempython.gemplotting.utils.anautilities import parseCalFile
-
 from gempython.utils.nesteddict import nesteddict
-
 from gempython.gemplotting.utils.anautilities import make3x8Canvas
+
+import argparse
 
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description='Arguments to supply to anaDACScan.py')
 
-    parser.add_argument('infilename', metavar='infilename', type=str, help="Filename from which input information is read")
-#    parser.add_argument("calFile", metavar="calFile", type=str,help="File specifying CAL_DAC/VCAL to fC equations per VFAT")
-    parser.add_argument('-o','--outfilename', metavar='outfilename', type=str, help="Filename to which output information is written", default="DACFitData.root")
+    parser.add_argument('infilename', type=str, help="Filename from which input information is read", metavar='infilename')
+    parser.add_argument("calFile", type=str, help="File specifying conversion between DAC to physical units per VFAT", metavar="calFile")
+    parser.add_argument('-o','--outfilename', dest='outfilename', type=str, default="DACFitData.root", help="Filename to which output information is written", metavar='outfilename')
+    parser.add_argument('--assignXErrors', dest='assignXErrors', action='store_true', help="Whether to assign errors for the X variable (which is actually plotted on the y-axis)")
 
     args = parser.parse_args()
 
@@ -34,6 +31,11 @@ if __name__ == '__main__':
     r.gStyle.SetOptStat(1111111)
 
     dacScanFile = r.TFile(args.infilename)
+
+    outputFile = r.TFile(args.outfilename,'recreate')
+
+    import numpy as np
+    import root_numpy as rp
     
     # Determine which links present
     list_bNames = ['link']
@@ -48,25 +50,37 @@ if __name__ == '__main__':
         nameY = event.nameY.data()
         break # all entries will be the same
 
+    if nameY not in ['ADC0', 'ADC1']:
+        print("Error: unexpected value of nameY: '%s'"%nameY)
+        exit(1)
+    
+    tuple_calInfo = parseCalFile(args.calFile)
+    calDAC_Slope = tuple_calInfo[0]
+    calDAC_Intercept = tuple_calInfo[1]
+
     # Initialize nested dictionaries
     dict_dacScanResults = nesteddict()
     dict_dacScanFuncs = nesteddict()
 
-    # Get ADC0 or ADC1 calibration
-    # tuple_calInfo = parseCalFile(args.calFile)
-    
     # Initialize a TGraphErrors for each vfat
     for link in ohArray:
         for vfat in range(0,24):
              dict_dacScanResults[link][vfat] = r.TGraphErrors()
              
-    # Loop over events in the tree and fill plots         
+    # Loop over events in the tree and fill plots
     for event in dacScanFile.dacScanTree:
         link = event.link
         vfat = event.vfatN
 
-        dict_dacScanResults[link][vfat].SetPoint(dict_dacScanResults[link][vfat].GetN(),event.dacValY,event.dacValX)
-        dict_dacScanResults[link][vfat].SetPointError(dict_dacScanResults[link][vfat].GetN()-1,event.dacValY_Err,event.dacValX_Err)
+        calibrated_DAC_value=calDAC_Slope[vfat]*event.dacValX+calDAC_Intercept[vfat]
+        calibrated_DAC_error=calDAC_Slope[vfat]*event.dacValX_Err+calDAC_Intercept[vfat]
+        
+        if args.assignXErrors:
+            dict_dacScanResults[link][vfat].SetPoint(dict_dacScanResults[link][vfat].GetN(),event.dacValY,calibrated_DAC_value)
+            dict_dacScanResults[link][vfat].SetPointError(dict_dacScanResults[link][vfat].GetN()-1,event.dacValY_Err,calibrated_DAC_error)
+        else:    
+            dict_dacScanResults[link][vfat].SetPoint(dict_dacScanResults[link][vfat].GetN(),event.dacValY,calibrated_DAC_value)
+            dict_dacScanResults[link][vfat].SetPointError(dict_dacScanResults[link][vfat].GetN()-1,event.dacValY_Err,0)
 
     # Fit the TGraphErrors objects    
     for oh in ohArray:
@@ -74,9 +88,41 @@ if __name__ == '__main__':
             dict_dacScanFuncs[oh][vfat] = r.TF1("DAC Scan Function","[0]*x+[1]")
             dict_dacScanResults[oh][vfat].Fit(dict_dacScanFuncs[oh][vfat]) 
 
-    # Determine DAC values to achieve recommended bias voltage and current settings        
+    nominal = -1        
 
+    #from Tables 9 and 10 of the VFAT3 manual 
+    if nameX == "CFG_THR_ARM_DAC":
+        nominal = 3.2
+    else:
+        print("Error: unexpected value of nameX: '%s'"%nameX)
+        exit(1)
+        
+    # Determine DAC values to achieve recommended bias voltage and current settings
+    graph_dacVals = {}
+    dict_dacVals = nesteddict()
+    for oh in ohArray:
+        graph_dacVals[oh] = r.TGraph()
+        for vfat in range(0,24):
+             dict_dacVals[oh][vfat] = dict_dacScanResults[oh][vfat].Eval(nominal)
+             graph_dacVals[oh].SetPoint(graph_dacVals[oh].GetN(),vfat,dict_dacVals[oh][vfat]) 
+
+    # Write out the dacVal results to both a file and the terminal         
+    print( "| OH | vfatN | dacVal |")
+    print( "| -- | ----- | ------ |")        
+    
+    for oh in ohArray:
+        outputFile.cd()
+        graph_dacVals[oh].Write("dacValsOH"+str(oh))
+        for vfat in range(0,24):
+            print("| {0} | {1}  | {2} | ".format(
+                oh,
+                vfat,
+                dict_dacVals[oh][vfat]
+            ))
+        
     # Make plots        
     for oh in ohArray:
         canv_Summary = make3x8Canvas('canv_Summary',dict_dacScanResults[oh],'AP',dict_dacScanFuncs[oh],'')
         canv_Summary.SaveAs("SummaryOH"+str(oh)+".png")
+        outputFile.cd()
+        canv_Summary.Write()

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -4,18 +4,19 @@
 anaDACScan
 ==============
 """
-import ROOT as r
-
-from gempython.gemplotting.utils.anautilities import parseCalFile
-from gempython.utils.nesteddict import nesteddict
-from gempython.gemplotting.utils.anautilities import make3x8Canvas
-
-from gempython.gemplotting.mapping.chamberInfo import chamber_config
-
-import argparse
 
 if __name__ == '__main__':
 
+    import ROOT as r
+    
+    from gempython.gemplotting.utils.anautilities import parseCalFile
+    from gempython.utils.nesteddict import nesteddict
+    from gempython.gemplotting.utils.anautilities import make3x8Canvas
+    
+    from gempython.gemplotting.mapping.chamberInfo import chamber_config
+    
+    import argparse
+    
     parser = argparse.ArgumentParser(description='Arguments to supply to anaDACScan.py')
 
     parser.add_argument('infilename', type=str, help="Filename from which input information is read", metavar='infilename')

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -166,13 +166,13 @@ if __name__ == '__main__':
     #for each OH, check if calibration files were provided, if not search for the calFile in the $DATA_PATH, if it is not there, then skip that OH for the rest of the script
     for oh in ohArray:
         if oh not in calInfo.keys():
-            calDacCalFile = "{0}/{1}/calFile_calDac_{1}.txt".format(dataPath,chamber_config[oh])
-            calDacCalFileExists = os.path.isfile(calDacCalFile)
-            if not calDacCalFileExists:
+            calAdcCalFile = "{0}/{1}/calFile_calAdc_{1}.txt".format(dataPath,chamber_config[oh])
+            calAdcCalFileExists = os.path.isfile(calAdcCalFile)
+            if not calAdcCalFileExists:
                 print("Skipping OH{0}, detector {1}, missing CFG_CAL_DAC Calibration file:\n\t{2}".format(
                     oh,
                     chamber_config[oh],
-                    calDacCalFile))
+                    calAdcCalFile))
                 ohArray = np.delete(ohArray,(oh))
 
     if len(ohArray) == 0:

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -31,10 +31,10 @@ Arguments
   
     Provide a file containing a list of calFiles in the following format. Example:: 
 
-    OH1 calFileOH1
-    OH2 calFileOH2
-    OH3 calFileOH3
-    etc
+    0 /path/to/my/cal/file.txt
+    1 /path/to/my/cal/file.txt
+    ...
+    ...
 
 .. option:: --outfilename
 
@@ -65,7 +65,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Arguments to supply to anaDACScan.py')
 
     parser.add_argument('infilename', type=str, help="Filename from which input information is read", metavar='infilename')
-    parser.add_argument("--calFileList", type=str, help="File specifying which calFile to use for each OH. Format: OH1 filenameOH1 <newline> OH2 filenameOH2 <newline> etc", metavar="calFileList")
+    parser.add_argument("--calFileList", type=str, help="File specifying which calFile to use for each OH. Format: 0 /path/to/my/cal/file.txt<newline> 1 /path/to/my/cal/file.txt<newline>...", metavar="calFileList")
     parser.add_argument('-o','--outfilename', dest='outfilename', type=str, default="DACFitData.root", help="Filename to which output information is written", metavar='outfilename')
     parser.add_argument('--assignXErrors', dest='assignXErrors', action='store_true', help="Whether to assign errors for the X variable (which is actually plotted on the y-axis)")
 

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -84,6 +84,8 @@ if __name__ == '__main__':
 
     import numpy as np
     import root_numpy as rp
+
+    dacScanFile.dacScanTree.LoadBaskets()
     
     ohArray = rp.tree2array(tree=dacScanFile.dacScanTree, branches=['link'])
     ohArray = np.unique(ohArray['link'])
@@ -97,7 +99,7 @@ if __name__ == '__main__':
             array = np.unique(array['dacValY'])
             if len(array) == 1 and array[0] == 0:
                 mask.append((oh,vfat))
-    
+
     dataPath = os.getenv("DATA_PATH")
     elogPath = os.getenv("ELOG_PATH") 
     

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -30,10 +30,12 @@ Arguments
 
 .. option:: --calFileList
   
-    Provide a file containing a list of calFiles in the format: 
+    Provide a file containing a list of calFiles in the following format. Example:: 
+
     OH1 calFileOH1
     OH2 calFileOH2
     OH3 calFileOH3
+    etc
 
 .. option:: --outfilename
 
@@ -89,6 +91,11 @@ if __name__ == '__main__':
 
     dacScanFile = r.TFile(args.infilename)
 
+    if len(args.infilename.split('/')) > 1 and len(args.infilename.split('/')[len(args.infilename.split('/')) - 2].split('.')) == 5:
+        scandate = args.infilename.split('/')[len(args.infilename.split('/')) - 2]
+    else:    
+        scandate = 'noscandate'
+    
     import numpy as np
     import root_numpy as rp
     
@@ -134,7 +141,7 @@ if __name__ == '__main__':
                 ohArray = np.delete(ohArray,(oh))
 
 
-    if len(ohArray.keys()) == 0:
+    if len(ohArray) == 0:
         print('No OHs with a calFile, exiting.')
         exit(1)
            
@@ -150,7 +157,7 @@ if __name__ == '__main__':
     outputFiles = {}         
              
     for oh in ohArray:         
-        outputFiles[oh] = r.TFile("$DATA_PATH/"+chamber_config[oh]+"/dacScans/scandate/"+args.outfilename,'recreate')
+        outputFiles[oh] = r.TFile(dataPath+"/"+chamber_config[oh]+"/dacScans/"+scandate+"/"+args.outfilename,'recreate')
              
     # Loop over events in the tree and fill plots
     for event in dacScanFile.dacScanTree:
@@ -208,6 +215,6 @@ if __name__ == '__main__':
     # Make plots        
     for oh in ohArray:
         canv_Summary = make3x8Canvas('canv_Summary',dict_dacScanResults[oh],'AP',dict_dacScanFuncs[oh],'')
-        canv_Summary.SaveAs("$DATA_PATH/"+chamber_config[oh]+"/dacScans/scandate/SummaryOH"+str(oh)+".png")
+        canv_Summary.SaveAs(dataPath+"/"+chamber_config[oh]+"/dacScans/"+scandate+"/SummaryOH"+str(oh)+".png")
         outputFiles[oh].cd()
         canv_Summary.Write()

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -123,9 +123,9 @@ if __name__ == '__main__':
         exit(1)
 
     #the nominal reference current is 10 uA and it has a scaling factor of 0.5   
-    nominal_iref = 10/0.5
+    nominal_iref = 10*0.5
 
-    nominal = nominalDacValues[nameX][0]/nominalDacScalingFactors[nameX]
+    nominal = nominalDacValues[nameX][0]
 
     #convert all voltages to mV and currents to uA
     if nominalDacValues[nameX][1] == "V":
@@ -223,7 +223,9 @@ if __name__ == '__main__':
 
             if nameX != 'CFG_IREF':
                 calibrated_ADC_value -= nominal_iref 
-            
+
+            calibrated_ADC_value /= nominalDacScalingFactors[nameX]    
+                
         #the reversal of x and y is intended - we want to plot the nameX variable on the y-axis and the nameY variable on the x-axis
         #the nameX variable is the DAC register that is scanned, and we want to determine its nominal value
         if args.assignXErrors:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -251,6 +251,8 @@ man_pages = [
      authors, 1),
     ('man/plot_eff', 'plot_eff.py', u'Perform an efficiency analysis',
      authors, 1),
+    ('man/anaDACScan', 'anaDACScan.py', u'Perform a DAC scan analysis',
+     authors, 1),
     ('man/timeHistoryAnalyzer', 'timeHistoryAnalyzer.py', u'Analyze the time evolution of channels',
      authors, 1),
     ('man/clusterAnaScurve', 'clusterAnaScurve.py', u'Analyze S-curves using the LSF cluster',

--- a/doc/man-index.rst
+++ b/doc/man-index.rst
@@ -56,6 +56,7 @@ documented elsewhere.
     * :program:`ana_scans.py`
     * :program:`anaSBitTresh.py`
     * :program:`anaUltraLatency.py`
+    * :program:`anaDACScan.py`
     * :program:`anaUltraScurve.py`
     * :program:`anaUltraThreshold.py`
     * :program:`anaXDAQLatency.py`

--- a/doc/man-index.rst
+++ b/doc/man-index.rst
@@ -15,6 +15,7 @@ Analysis tools
     :maxdepth: 1
 
     man/plot_eff
+    man/anaDACScan
 
 Arbitrary plotting tools
 ------------------------
@@ -56,7 +57,6 @@ documented elsewhere.
     * :program:`ana_scans.py`
     * :program:`anaSBitTresh.py`
     * :program:`anaUltraLatency.py`
-    * :program:`anaDACScan.py`
     * :program:`anaUltraScurve.py`
     * :program:`anaUltraThreshold.py`
     * :program:`anaXDAQLatency.py`

--- a/doc/man/anaDACscan.rst
+++ b/doc/man/anaDACscan.rst
@@ -1,4 +1,4 @@
-.. automodule:: anaDACscan.py
+.. automodule:: anaDACScan.py
     :members:
     :undoc-members:
     :show-inheritance:

--- a/doc/man/anaDACscan.rst
+++ b/doc/man/anaDACscan.rst
@@ -1,0 +1,4 @@
+.. automodule:: anaDACscan.py
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/utils/anaInfo.py
+++ b/utils/anaInfo.py
@@ -12,6 +12,25 @@ Documentation
 
 import string
 
+#: Nominal current and voltage values from Tables 9 and 10 of the VFAT3 manual
+nominalDacValues = {
+        "CFG_IREF":(10,"uA"),
+        "CFG_BIAS_PRE_I_BIT":(150,"uA"),
+        "CFG_BIAS_PRE_I_BLCC":(25,"nA"),
+        "CFG_BIAS_SH_I_BFCAS":(26,"uA"),
+        "CFG_BIAS_SH_I_BDIFF":(16,"uA"),
+        "CFG_BIAS_SD_I_BDIFF":(28,"uA"),
+        "CFG_BIAS_SD_I_BFCAS":(27,"uA"),
+        "CFG_BIAS_SD_I_BSF":(30,"uA"),
+        "CFG_BIAS_CFD_DAC_1":(20,"uA"),
+        "CFG_BIAS_CFD_DAC_2":(20,"uA"),
+        "CFG_HYST":(100,"nA"),
+        "CFG_THR_ARM_DAC":(3.2,"uA"),
+        "CFG_THR_ZCC_DAC":(275,"nA"),
+        "CFG_BIAS_PRE_VREF":(430,'mV'),
+        "CFG_ADC_VREF":(400,'mV')
+}
+
 #: Types of analysis and corresponding analysis tools
 ana_config = {
         "dacScanV3":"dacScanV3.py",

--- a/utils/anaInfo.py
+++ b/utils/anaInfo.py
@@ -13,6 +13,7 @@ Documentation
 import string
 
 #: Nominal current and voltage values from Tables 9 and 10 of the VFAT3 manual
+#: The registers CFG_THR_ARM_DAC CFG_THR_ZCC_DAC may correspond to either a voltage or a current. Below I have used the voltage. Be careful if you have taken a current scan with these registers (dacSelect options 14 or 15).
 nominalDacValues = {
         "CFG_IREF":(10,"uA"),
         "CFG_BIAS_PRE_I_BIT":(150,"uA"),
@@ -25,8 +26,8 @@ nominalDacValues = {
         "CFG_BIAS_CFD_DAC_1":(20,"uA"),
         "CFG_BIAS_CFD_DAC_2":(20,"uA"),
         "CFG_HYST":(100,"nA"),
-        "CFG_THR_ARM_DAC":(3.2,"uA"),
-        "CFG_THR_ZCC_DAC":(275,"nA"),
+        "CFG_THR_ARM_DAC":(64,"mV"),
+        "CFG_THR_ZCC_DAC":(5.5,"mV"),
         "CFG_BIAS_PRE_VREF":(430,'mV'),
         "CFG_ADC_VREF":(1.0,'V')
 }

--- a/utils/anaInfo.py
+++ b/utils/anaInfo.py
@@ -49,8 +49,6 @@ nominalDacScalingFactors = {
         "CFG_ADC_VREF": 1
 }
 
-
-
 #: Types of analysis and corresponding analysis tools
 ana_config = {
         "dacScanV3":"dacScanV3.py",

--- a/utils/anaInfo.py
+++ b/utils/anaInfo.py
@@ -15,7 +15,6 @@ import string
 #: Nominal current and voltage values from Tables 9 and 10 of the VFAT3 manual
 #: The registers CFG_THR_ARM_DAC CFG_THR_ZCC_DAC may correspond to either a voltage or a current. Below I have used the voltage. Be careful if you have taken a current scan with these registers (dacSelect options 14 or 15).
 nominalDacValues = {
-        "CFG_IREF":(10,"uA"),
         "CFG_BIAS_PRE_I_BIT":(150,"uA"),
         "CFG_BIAS_PRE_I_BLCC":(25,"nA"),
         "CFG_BIAS_SH_I_BFCAS":(26,"uA"),
@@ -31,6 +30,26 @@ nominalDacValues = {
         "CFG_BIAS_PRE_VREF":(430,'mV'),
         "CFG_ADC_VREF":(1.0,'V')
 }
+
+#: From Tables 12 and 13 from the VFAT3 manual
+nominalDacScalingFactors = {
+        "CFG_BIAS_PRE_I_BIT":0.2,
+        "CFG_BIAS_PRE_I_BLCC":100,
+        "CFG_BIAS_SH_I_BFCAS":1,
+        "CFG_BIAS_SH_I_BDIFF":1,
+        "CFG_BIAS_SD_I_BDIFF":1,
+        "CFG_BIAS_SD_I_BFCAS":1,
+        "CFG_BIAS_SD_I_BSF":0.25,
+        "CFG_BIAS_CFD_DAC_1":1,
+        "CFG_BIAS_CFD_DAC_2":1,
+        "CFG_HYST":1,
+        "CFG_THR_ARM_DAC":1,
+        "CFG_THR_ZCC_DAC":4,
+        "CFG_BIAS_PRE_VREF":1,
+        "CFG_ADC_VREF": 1
+}
+
+
 
 #: Types of analysis and corresponding analysis tools
 ana_config = {

--- a/utils/anaInfo.py
+++ b/utils/anaInfo.py
@@ -28,7 +28,7 @@ nominalDacValues = {
         "CFG_THR_ARM_DAC":(3.2,"uA"),
         "CFG_THR_ZCC_DAC":(275,"nA"),
         "CFG_BIAS_PRE_VREF":(430,'mV'),
-        "CFG_ADC_VREF":(400,'mV')
+        "CFG_ADC_VREF":(1.0,'V')
 }
 
 #: Types of analysis and corresponding analysis tools


### PR DESCRIPTION
This script analyzes DAC scans. It reads an input file containing DAC and ADC values, performs calibration, performs a fit, and reports the DAC values which should produce the nominal voltage or current as specified in the VFAT3 manual. 3 by 8 plots of the calibrated data and the fit are also produced.

## Description
Pseudo-code, from @bdorney, copied here for convenience from  https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/155:

```
if __name__ == '__main__':
   setup an argparse.ArgumentParser instance
   get arguments from a user
   
   # Determine which links present suggest using root_numpy, something like:
   import root_numpy as rp
   import numpy as np
   bNames = ['link']
   ohArray = rp.tree2array(tree=calTree, branches=bNames)
   ohArray = np.unique(ohArray) # now ohArray will have one entry for each unmasked optohybrid

   # Determine which DAC was scanned and against which ADC
   nameX = ""
   nameY = ""
   for event in calTree:
      nameX = event.nameX
      nameY = event.nameY
      break # all entries will be the same

   # Get ADC0 or ADC1 calibration
   # nameY will either be ADC0 or ADC1, you'll need to load calibration for each link
   # use parseCalFile(...) from gem-plotting-tools/utils/anautilities.py
   # Note this calibration is unique to each (vfat,ohN) pairing
   # In future this is where a DB query based on vfatID would take place 

   # Make output plots, suggest TGraphErrors objects
   # I would suggest you use a nesteddict object (gempython/utils/nesteddict.py) to index these by [oh][vfat]
   for link in ohArray:
      for vfat in range(0,24):
           dict_dacScanResults[link][vfat] = r.TGraphErrors(...) # declare TGraphErrors
           You can get number of points in TGraphErrors by looking at maxVfat3DACSize of amc_user_functions_xhal.py (from cmsgemos PR#206)

   # Loop over events in the tree and fill plots
   for event in calTree:
       assign (dacValX, dacValY, dacValY_Err) to the tgraph for a given (vfat,oh) pair
       Here you need to use the ADCX (for X = 0,1) calibration to convert dacValY & dacValY_Err to physical units
       You also need to identify if nameX corresponds to a bias voltage DAC or a bias current DAC, see VFAT3 manual Table 25: GBL CFG CTR 4 : Monitoring settings
       Note nameX is the register that was scanned during the DAC scan, but we want plots that are Y=nameX (reg scanned) and X=nameY (ADC value), see below 
 
   # Fit the TGraphErrors Objects
   for oh in ohArray
      for vfat in range(0,24):
          dict_dacScanResults[oh][vfat].Fit(...) # linear fitting may not be suitable, polynomial may be required, investigation needed.  Possible try several fits and choose one with best norm chi2
   
    # Determine DAC values to achieve recommended bias voltage and current settings
    See Table 9, Nominal Current column, and the VFAT3a specific note under table 9
    See Table 10, Nominal Voltage column
    Here for each (vfat,oh) you should use the fit function to do a look-up on the nominal value to get the DAC value that will achieve this, e.g.
    dacVal = myTF1.Eval(nominal voltage)
    This then should be printed to terminal as a table, an output file (in either tab-delimited or TTree format) and then as a TGraph object with DAC value vs. VFAT position

    # Make plots
    Make our standard 3x8 grid plot of the DAC scan results, see make3x8Canvas(...), one such grid plot should be made for each entry in ohArray
    Store plots in an output TFile (use TDirectories to organize logically)
    
    Exit
```

Help output:
```
[amlevin@gem904qc8daq gem-plotting-tools]$ ./anaDACScan.py -h
usage: anaDACScan.py [-h] [--calFileList calFileList] [-o outfilename]
                     [--assignXErrors]
                     infilename

Arguments to supply to anaDACScan.py

positional arguments:
  infilename            Filename from which input information is read

optional arguments:
  -h, --help            show this help message and exit
  --calFileList calFileList
                        File specifying which calFile to use for each OH.
                        Format: 0 /path/to/my/cal/file.txt<newline> 1
                        /path/to/my/cal/file.txt<newline>...
  -o outfilename, --outfilename outfilename
                        Filename to which output information is written
  --assignXErrors       dacValY_Err values are always used, but dacValX_Err
                        values are used if and only if this flag is set
```

calFileList example:
```
1 /home/amlevin/gem-plotting-tools/calibration_OH1.txt
```

Example execution:
```
[amlevin@gem904qc8daq gem-plotting-tools]$ ./anaDACScan.py dacScanV3.root  --calFileList calibration.txt 
Analyzing: 'dacScanV3.root'
Warning: the nominal DAC value is that was found from the fit is less than 0
Warning: the nominal DAC value is that was found from the fit is less than 0
Warning: the nominal DAC value is that was found from the fit is less than 0
Warning: the nominal DAC value is that was found from the fit is less than 0
Warning: the nominal DAC value is that was found from the fit is less than 0
Warning: the nominal DAC value is that was found from the fit is less than 0
Warning: the nominal DAC value is that was found from the fit is less than 0
Warning: the nominal DAC value is that was found from the fit is less than 0
Warning: the nominal DAC value is that was found from the fit is less than 0
Warning: the nominal DAC value is that was found from the fit is less than 0
Warning: the nominal DAC value is that was found from the fit is less than 0
| OH | vfatN | dacVal |
| :-: | :---: | :----: |
| 1 | 0  | 120 | 
| 1 | 1  | 120 | 
| 1 | 2  | 120 | 
| 1 | 3  | 120 | 
| 1 | 4  | -87 | 
| 1 | 5  | -82 | 
| 1 | 6  | -98 | 
| 1 | 7  | -75 | 
| 1 | 8  | 120 | 
| 1 | 9  | 120 | 
| 1 | 10  | 120 | 
| 1 | 11  | 120 | 
| 1 | 12  | -72 | 
| 1 | 13  | -100 | 
| 1 | 14  | -76 | 
| 1 | 15  | 120 | 
| 1 | 16  | 120 | 
| 1 | 17  | 120 | 
| 1 | 18  | 120 | 
| 1 | 19  | 120 | 
| 1 | 20  | -85 | 
| 1 | 21  | -97 | 
| 1 | 22  | -111 | 
| 1 | 23  | -104 | 
Info in <TCanvas::Print>: png file Summary.png has been created
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This script was requested in https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/155

## How Has This Been Tested?
I have tested that the script runs on an input file provided by @bdorney: `dacScanV3.root`

### Screenshots (if appropriate):

Output root file structure:
![connection to localhost 10152018-08 16 10](https://user-images.githubusercontent.com/3329216/46933081-cc670780-d052-11e8-9a80-dac676ad24c1.png)

DACvsADC:
![dacvsadc](https://user-images.githubusercontent.com/3329216/46933185-43040500-d053-11e8-9651-b2c127278867.png)

RawADCvsDAC:
![rawadcvsdac](https://user-images.githubusercontent.com/3329216/46933190-48f9e600-d053-11e8-8fd6-8b5d27c9a12e.png)

NominalDacValVsVFATX:
![nominaldacvalvsvfatx](https://user-images.githubusercontent.com/3329216/46933199-531be480-d053-11e8-8f9e-24e58cc9f5be.png)

Summary plot:
![summary](https://user-images.githubusercontent.com/3329216/46922551-f563aa00-d00a-11e8-9109-2df5ecbdae87.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
