### PR TITLE
WIP: Fixed issue w/vfatID only storing 16 bit numbers

### DIFF
--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -483,7 +483,7 @@ if __name__ == '__main__':
             myT.Branch( 'trimRange', trimRange, 'trimRange/I' )
         vfatCH = array( 'i', [ 0 ] )
         myT.Branch( 'vfatCH', vfatCH, 'vfatCH/I' )
-        vfatID = array( 'i', [-1] )
+        vfatID = array( 'I', [-1] )
         myT.Branch( 'vfatID', vfatID, 'vfatID/I' ) #Hex Chip ID of VFAT
         vfatN = array( 'i', [ 0 ] )
         myT.Branch( 'vfatN', vfatN, 'vfatN/I' )

--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -483,7 +483,7 @@ if __name__ == '__main__':
             myT.Branch( 'trimRange', trimRange, 'trimRange/I' )
         vfatCH = array( 'i', [ 0 ] )
         myT.Branch( 'vfatCH', vfatCH, 'vfatCH/I' )
-        vfatID = array( 'I', [-1] )
+        vfatID = array( 'I', [0] )
         myT.Branch( 'vfatID', vfatID, 'vfatID/I' ) #Hex Chip ID of VFAT
         vfatN = array( 'i', [ 0 ] )
         myT.Branch( 'vfatN', vfatN, 'vfatN/I' )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed issue w/vfatID only storing 16 bit numbers.
Due to the vfat bit slip problem you can get a chip ID that has a number that is larger than 16 bits.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Allow VFAT ID to take up to 32 bit numbers 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Change was trivial.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
