### PR TITLE
improvements to anaDACScan.py: replace out-of-range DAC values, improve handling of whitespace/newlines in calibration file

### DIFF
--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -288,14 +288,10 @@ if __name__ == '__main__':
             #evaluate the fitted function at the nominal current or voltage value and convert to an integer
             nominalDacValue = int(dict_DACvsADC_Funcs[oh][vfat].Eval(nominal))
             
-            if nominalDacValue > maxDacValue:
-                print('Warning: Fitted DAC value > the maximum value of the register. It will be replaced by the maximum value of the register.')
-                nominalDacValue = maxDacValue
+            if nominalDacValue < 0 or nominalDacValue > maxDacValue:
+                print('Warning: The fitted DAC value, '+str(nominalDacValue)+', is outside of the range that the register can hold: [0,'+str(maxDacValue)+']. It will be replaced by '+str(max(0,min(maxDacValue,nominalDacValue)))+'.')
+                nominalDacValue = max(0,min(maxDacValue,nominalDacValue))
 
-            if nominalDacValue < 0:
-                print('Warning: Fitted DAC value < 0. It will be replaced by 0.')
-                nominalDacValue = 0
-            
             dict_dacVals[oh][vfat] = nominalDacValue
             graph_dacVals[oh].SetPoint(graph_dacVals[oh].GetN(),vfat,dict_dacVals[oh][vfat])
              

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -156,9 +156,9 @@ if __name__ == '__main__':
         for line in open(args.calFileList):
             if line[0] == "#":
                 continue
-            line = line.strip(' ').strip('\n')
-            first = line.split(' ')[0].strip(' ')
-            second = line.split(' ')[1].strip(' ')
+            line = line.strip()
+            first = line.split()[0]
+            second = line.split()[1]
             tuple_calInfo = parseCalFile(second)
             calInfo[int(first)] = {'slope' : tuple_calInfo[0], 'intercept' : tuple_calInfo[1]}
 
@@ -289,12 +289,14 @@ if __name__ == '__main__':
             nominalDacValue = int(dict_DACvsADC_Funcs[oh][vfat].Eval(nominal))
             
             if nominalDacValue > maxDacValue:
-                print('Warning: the nominal DAC value that was found from the fit is larger than the maximum value that the DAC register will hold')
+                print('Warning: Fitted DAC value > the maximum value of the register. It will be replaced by the maximum value of the register.')
+                nominalDacValue = maxDacValue
 
             if nominalDacValue < 0:
-                print('Warning: the nominal DAC value that was found from the fit is less than 0')                
+                print('Warning: Fitted DAC value < 0. It will be replaced by 0.')
+                nominalDacValue = 0
             
-            dict_dacVals[oh][vfat] = int(dict_DACvsADC_Funcs[oh][vfat].Eval(nominal))
+            dict_dacVals[oh][vfat] = nominalDacValue
             graph_dacVals[oh].SetPoint(graph_dacVals[oh].GetN(),vfat,dict_dacVals[oh][vfat])
              
     # Write out the dacVal results to a root file, a text file, and the terminal

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -286,13 +286,13 @@ if __name__ == '__main__':
                     break
                     
             #evaluate the fitted function at the nominal current or voltage value and convert to an integer
-            nominalDacValue = int(dict_DACvsADC_Funcs[oh][vfat].Eval(nominal))
+            fittedDacValue = int(dict_DACvsADC_Funcs[oh][vfat].Eval(nominal))
+            finalDacValue = max(0,min(maxDacValue,fittedDacValue))
             
-            if nominalDacValue < 0 or nominalDacValue > maxDacValue:
-                print('Warning: The fitted DAC value, '+str(nominalDacValue)+', is outside of the range that the register can hold: [0,'+str(maxDacValue)+']. It will be replaced by '+str(max(0,min(maxDacValue,nominalDacValue)))+'.')
-                nominalDacValue = max(0,min(maxDacValue,nominalDacValue))
-
-            dict_dacVals[oh][vfat] = nominalDacValue
+            if fittedDacValue != finalDacValue:
+                print('Warning: The fitted DAC value, %i, is outside of the range that the register can hold: [0,%i]. It will be replaced by %i.'%(fittedDacValue,maxDacValue,finalDacValue))
+                
+            dict_dacVals[oh][vfat] = finalDacValue
             graph_dacVals[oh].SetPoint(graph_dacVals[oh].GetN(),vfat,dict_dacVals[oh][vfat])
              
     # Write out the dacVal results to a root file, a text file, and the terminal


### PR DESCRIPTION
These are two unrelated but simple improvements to the anaDACScan.py script.

## Description
Currently, anaDACScan.py will just warn the user when the fitted nominal DAC values are below 0 or above the maximum range of the register. This PR replaces the out-of-range nominal DAC values with 0 or the maximum value, in addition to printing a warning.

Currently, the handling of the calibration file would fail if a tab or multiple spaces separated the columns. This can be fixed very easily.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
The replacement of out-of-range nominal DAC values was requested by @bdorney in a gemctp7user PR https://github.com/cms-gem-daq-project/gemctp7user/pull/37#pullrequestreview-168729078. 

The issue with the calibration file handling was obvious.

## How Has This Been Tested?
I have run the updated script successfully on DAC scan data on gem904daq01.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
