### PR TITLE
Bug Fix: anaDACScan.py capitalization inconsistency and file extension problem

### DIFF
--- a/doc/man/anaDACScan.rst
+++ b/doc/man/anaDACScan.rst
@@ -1,4 +1,4 @@
-.. automodule:: anaDACScan.py
+.. automodule:: anaDACScan
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
The name of the `.rst` file associated with `anaDACScan.py` should be consistent with the the index `rst` file. Also, the file extension `.py` should not be used to identify the script in that file.

## Description
The name of the file `.rst` file associated with `anaDACScan.py` was changed from `anaDACscan.rst` to `anaDACScan.rst`. Also, in that file `anaDACScan.py` was changed to `anaDACScan` in the first line.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
The rpm does not compile due to this bug, as reported in https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/164

## How Has This Been Tested?
Yes, I have checked that the rpm compiles now.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
