### PR TITLE
Update anaDACScans.py to handle files containing multiple DAC Scans 

### DIFF
--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -12,7 +12,7 @@ Synopsis
 Description
 -----------
 
-This script reads in calibration information and DAC scan data, performs a fit for each VFAT, computes the DAC value corresponding to the nominal current or voltage for each VFAT, and reports the results.
+This script reads in ADC0 or ADC1 calibration coefficients and DAC scan data, performs a fit for each VFAT, computes the DAC value corresponding to the nominal current or voltage for each VFAT, and reports the results.
 
 Arguments
 ---------
@@ -29,7 +29,7 @@ Arguments
 
 .. option:: --calFileList
   
-    Provide a file containing a list of calFiles in the following format. Example:: 
+    Provide a file containing a list of calFiles.  The space character is used as a delimiter.  The first column is the link number.  The second is the calibration file (given with full physical filename) for that link number. Example::
 
     0 /path/to/my/cal/file.txt
     1 /path/to/my/cal/file.txt
@@ -40,6 +40,10 @@ Arguments
 
     Name of the output root file. Default is DACFitData.root.
 
+.. option:: --print
+
+    If provided prints a summary table to terminal for each DAC showing for each VFAT position the nominal value that was found
+
 Example
 -------
 
@@ -49,28 +53,18 @@ Example
 """
 
 if __name__ == '__main__':
-
-    import ROOT as r
-    
     from gempython.gemplotting.utils.anautilities import parseCalFile
-    from gempython.utils.nesteddict import nesteddict
     from gempython.gemplotting.utils.anautilities import make3x8Canvas
-    
     from gempython.gemplotting.mapping.chamberInfo import chamber_config
-
-    from gempython.tools.amc_user_functions_xhal import maxVfat3DACSize
-    
-    import os
     
     import argparse
-    
     parser = argparse.ArgumentParser(description='Arguments to supply to anaDACScan.py')
 
     parser.add_argument('infilename', type=str, help="Filename from which input information is read", metavar='infilename')
+    parser.add_argument('--assignXErrors', dest='assignXErrors', action='store_true', help="If this flag is set then an uncertain on the DAC register value is assumed, otherwise the DAC register value is assumed to be a fixed unchanging value (almost always the case).")
     parser.add_argument("--calFileList", type=str, help="File specifying which calFile to use for each OH. Format: 0 /path/to/my/cal/file.txt<newline> 1 /path/to/my/cal/file.txt<newline>...", metavar="calFileList")
     parser.add_argument('-o','--outfilename', dest='outfilename', type=str, default="DACFitData.root", help="Filename to which output information is written", metavar='outfilename')
-    parser.add_argument('--assignXErrors', dest='assignXErrors', action='store_true', help="If this flag is set then an uncertain on the DAC register value is assumed, otherwise the DAC register value is assumed to be a fixed unchanging value (almost always the case).")
-
+    parser.add_argument("-p","--print",dest=printSum, action="store_true", help="If provided prints a summary table to terminal for each DAC showing for each VFAT position the nominal value that was found")
     args = parser.parse_args()
 
     print("Analyzing: '%s'"%args.infilename)
@@ -80,17 +74,25 @@ if __name__ == '__main__':
     r.gROOT.SetBatch(True)
     r.gStyle.SetOptStat(1111111)
     
+    import ROOT as r
     dacScanFile = r.TFile(args.infilename)
 
     import root_numpy as rp
     import numpy as np
-    list_bNames = ['vfatN','link','dacValY']
+    list_bNames = ['vfatN','link','dacValY','nameX']
     vfatArray = rp.tree2array(tree=dacScanFile.dacScanTree,branches=list_bNames)
     ohArray = np.unique(vfatArray['link'])
+    dacNameArray = np.unique(vfatArray['nameX'])
     dict_nonzeroVFATs = {}
     for ohN in ohArray:
         dict_nonzeroVFATs[ohN] = np.unique(vfatArray[np.logical_and(vfatArray['dacValY'] > 0,vfatArray['link'] == ohN)]['vfatN'])
 
+    from gempython.utils.wrappers import envCheck
+
+    envCheck("DATA_PATH")
+    envCheck("ELOG_PATH")
+
+    import os
     dataPath = os.getenv("DATA_PATH")
     elogPath = os.getenv("ELOG_PATH") 
     
@@ -99,78 +101,81 @@ if __name__ == '__main__':
     else:    
         scandate = 'noscandate'
         
+    from gempython.utils.wrappers import runCommand
     for oh in ohArray:
         if scandate == 'noscandate':
-            os.system("mkdir -p "+ elogPath+"/"+chamber_config[oh])
+            runCommand(["mkdir", "-p", "{0}/{1}".format(elogPath,chamber_config[oh])])
+            runCommand(["chmod", "g+rw", "{0}/{1}".format(elogPath,chamber_config[oh])])
         else:
-            os.system("mkdir -p "+ dataPath+"/"+chamber_config[oh]+"/dacScans/"+scandate)
+            runCommand(["mkdir", "-p", "{0}/{1}/dacScans/{2}".format(dataPath,chamber_config[oh],scandate)])
+            runCommand(["chmod", "g+rw", "{0}/{1}/dacScans/{2}".format(dataPath,chamber_config[oh],scandate)])
             
     # Determine which DAC was scanned and against which ADC
-    nameX = ""
-    nameY = ""
+    adcName = ""
     for event in dacScanFile.dacScanTree:
-        nameX = str(event.nameX.data())
-        nameY = str(event.nameY.data())
+        #adcName = str(event.adcName.data())
+        adcName = event.adcName
         break # all entries will be the same
 
-    if nameY not in ['ADC0', 'ADC1']:
-        print("Error: unexpected value of nameY: '%s'"%nameY)
-        exit(1)
+    if adcName not in ['ADC0', 'ADC1']:
+        print("Error: unexpected value of adcName: '%s'"%adcName)
+        exit(os.EX_DATAERR)
 
     from gempython.gemplotting.utils.anaInfo import nominalDacValues, nominalDacScalingFactors
-        
-    if nameX not in nominalDacValues.keys():
-        print("Error: unexpected value of nameX: '%s'"%nameX)
-        exit(1)
+    nominal = {}
+    for idx in len(dacNameArray):
+        dacName = dacNameArray[idx]
+        if dacName not in nominalDacValues.keys():
+            print("Error: unexpected DAC Name: '{}'".format(dacName))
+            exit(os.EX_DATAERR)
+        else:
+            nominal[dacName] = nominalDacValues[dacName][0]
+
+            #convert all voltages to mV and currents to uA
+            if nominalDacValues[dacName][1] == "V":
+                nominal[dacName] *= pow(10.0,3)
+            elif nominalDacValues[dacName][1] == 'mV':
+                pass
+            elif nominalDacValues[dacName][1] == 'uV':
+                nominal[dacName] *= pow(10.0,-3)
+            elif nominalDacValues[dacName][1] == 'nV':
+                nominal[dacName] *= pow(10.0,-6)
+            elif nominalDacValues[dacName][1] == "A":
+                nominal[dacName] *= pow(10.0,6)
+            elif nominalDacValues[dacName][1] == 'mA':
+                nominal[dacName] *= pow(10.0,3)
+            elif nominalDacValues[dacName][1] == 'uA':
+                pass
+            elif nominalDacValues[dacName][1] == 'nA':
+                nominal[dacName] *= pow(10.0,-3)
+            else:
+                print("Error: unexpected units: '%s'"%nominalDacValues[dacName][1])
+                exit(os.EX_DATAERR)
 
     #the nominal reference current is 10 uA and it has a scaling factor of 0.5   
     nominal_iref = 10*0.5
 
-    nominal = nominalDacValues[nameX][0]
-
-    #convert all voltages to mV and currents to uA
-    if nominalDacValues[nameX][1] == "V":
-        nominal *= pow(10.0,3)
-    elif nominalDacValues[nameX][1] == 'mV':
-        pass
-    elif nominalDacValues[nameX][1] == 'uV':
-        nominal *= pow(10.0,-3)
-    elif nominalDacValues[nameX][1] == 'nV':
-        nominal *= pow(10.0,-6)
-    elif nominalDacValues[nameX][1] == "A":
-        nominal *= pow(10.0,6)
-    elif nominalDacValues[nameX][1] == 'mA':
-        nominal *= pow(10.0,3)
-    elif nominalDacValues[nameX][1] == 'uA':
-        pass
-    elif nominalDacValues[nameX][1] == 'nA':
-        nominal *= pow(10.0,-3)
-    else:
-        print("Error: unexpected units: '%s'"%nominalDacValues[nameX][1])
-        exit(1)
-
     calInfo = {}
-
     if args.calFileList != None:
         for line in open(args.calFileList):
             if line[0] == "#":
                 continue
-            line = line.strip()
-            first = line.split()[0]
-            second = line.split()[1]
-            tuple_calInfo = parseCalFile(second)
-            calInfo[int(first)] = {'slope' : tuple_calInfo[0], 'intercept' : tuple_calInfo[1]}
+            dataEntry = (line.strip()).split()
+            link = dataEntry[0]
+            calFile = dataEntry[1]
+            tuple_calInfo = parseCalFile(calFile)
+            calInfo[int(link)] = {'slope' : tuple_calInfo[0], 'intercept' : tuple_calInfo[1]}
 
     #for each OH, check if calibration files were provided, if not search for the calFile in the $DATA_PATH, if it is not there, then skip that OH for the rest of the script
     for oh in ohArray:
         if oh not in calInfo.keys():
-            calAdcCalFile = "{0}/{1}/calFile_{2}_{1}.txt".format(dataPath,chamber_config[oh],nameY)
+            calAdcCalFile = "{0}/{1}/calFile_{2}_{1}.txt".format(dataPath,chamber_config[oh],adcName)
             calAdcCalFileExists = os.path.isfile(calAdcCalFile)
             if not calAdcCalFileExists:
                 print("Skipping OH{0}, detector {1}, missing {2} calibration file:\n\t{3}".format(
                     oh,
                     chamber_config[oh],
-                    nameY,
+                    adcName,
                     calAdcCalFile))
                 ohArray = np.delete(ohArray,(oh))
 
@@ -179,32 +184,34 @@ if __name__ == '__main__':
         exit(1)
            
     # Initialize nested dictionaries
-    dict_DACvsADC_Graphs = nesteddict()
-    dict_RawADCvsDAC_Graphs = nesteddict()
-    dict_DACvsADC_Funcs = nesteddict()
+    from gempython.utils.nesteddict import nesteddict as ndict
+    dict_DACvsADC_Graphs = ndict()
+    dict_RawADCvsDAC_Graphs = ndict()
+    dict_DACvsADC_Funcs = ndict()
 
     # Initialize a TGraphErrors and a TF1 for each vfat
-    for oh in ohArray:
-        for vfat in range(0,24):
-            dict_RawADCvsDAC_Graphs[oh][vfat] = r.TGraphErrors()
-            dict_RawADCvsDAC_Graphs[oh][vfat].GetXaxis().SetTitle(nameX)
-            dict_RawADCvsDAC_Graphs[oh][vfat].GetYaxis().SetTitle(nameY)
-            dict_DACvsADC_Graphs[oh][vfat] = r.TGraphErrors()
-            dict_DACvsADC_Graphs[oh][vfat].SetTitle("VFAT{}".format(vfat))
-            dict_DACvsADC_Graphs[oh][vfat].SetMarkerSize(5)
-            #the reversal of x and y is intended - we want to plot the nameX variable on the y-axis and the nameY variable on the x-axis
-            dict_DACvsADC_Graphs[oh][vfat].GetYaxis().SetTitle(nameX)
-            if nominalDacValues[nameX][1][len(nominalDacValues[nameX][1])-1] == 'A':
-                dict_DACvsADC_Graphs[oh][vfat].GetXaxis().SetTitle(nameY + " (#muA)")
-            else:
-                dict_DACvsADC_Graphs[oh][vfat].GetXaxis().SetTitle(nameY + " (mV)")
-            #we will use a fifth degree polynomial to do the fit
-            dict_DACvsADC_Funcs[oh][vfat] = r.TF1("DAC Scan Function","[0]*x^5+[1]*x^4+[2]*x^3+[3]*x^2+[4]*x+[5]")
-            dict_DACvsADC_Funcs[oh][vfat].SetLineWidth(1)
-            dict_DACvsADC_Funcs[oh][vfat].SetLineStyle(3)
+    for idx in len(dacNameArray):
+        dacName = dacNameArray[idx]
+        for oh in ohArray:
+            for vfat in range(0,24):
+                dict_RawADCvsDAC_Graphs[dacName][oh][vfat] = r.TGraphErrors()
+                dict_RawADCvsDAC_Graphs[dacName][oh][vfat].GetXaxis().SetTitle(dacName)
+                dict_RawADCvsDAC_Graphs[dacName][oh][vfat].GetYaxis().SetTitle(adcName)
+                dict_DACvsADC_Graphs[dacName][oh][vfat] = r.TGraphErrors()
+                dict_DACvsADC_Graphs[dacName][oh][vfat].SetTitle("VFAT{}".format(vfat))
+                dict_DACvsADC_Graphs[dacName][oh][vfat].SetMarkerSize(5)
+                #the reversal of x and y is intended - we want to plot the dacName variable on the y-axis and the adcName variable on the x-axis
+                dict_DACvsADC_Graphs[dacName][oh][vfat].GetYaxis().SetTitle(dacName)
+                if nominalDacValues[dacName][1][len(nominalDacValues[dacName][1])-1] == 'A':
+                    dict_DACvsADC_Graphs[dacName][oh][vfat].GetXaxis().SetTitle(adcName + " (#muA)")
+                else:
+                    dict_DACvsADC_Graphs[dacName][oh][vfat].GetXaxis().SetTitle(adcName + " (mV)")
+                #we will use a fifth degree polynomial to do the fit
+                dict_DACvsADC_Funcs[dacName][oh][vfat] = r.TF1("DAC Scan Function","pol5")
+                dict_DACvsADC_Funcs[dacName][oh][vfat].SetLineWidth(1)
+                dict_DACvsADC_Funcs[dacName][oh][vfat].SetLineStyle(3)
 
     outputFiles = {}         
-             
     for oh in ohArray:
         if scandate == 'noscandate':
             outputFiles[oh] = r.TFile(elogPath+"/"+chamber_config[oh]+"/"+args.outfilename,'recreate')
@@ -223,115 +230,144 @@ if __name__ == '__main__':
         calibrated_ADC_value=calInfo[oh]['slope'][vfat]*event.dacValY+calInfo[oh]['intercept'][vfat]
         calibrated_ADC_error=calInfo[oh]['slope'][vfat]*event.dacValY_Err
 
+        #Get the DAC Name in question
+        dacName = event.nameX
+
         #Use Ohm's law to convert the currents to voltages. The VFAT3 team told us that a 20 kOhm resistor was used.
-        if nominalDacValues[nameX][1][len(nominalDacValues[nameX][1])-1] == "A":
+        if nominalDacValues[dacName][1][len(nominalDacValues[dacName][1])-1] == "A":
 
             #V (mV) = I (uA) R (kOhm)
             #V (10^-3) = I (10^-6) R (10^3)
             calibrated_ADC_value = calibrated_ADC_value/20.0
             calibrated_ADC_error = calibrated_ADC_error/20.0
 
-            if nameX != 'CFG_IREF':
+            if dacName != 'CFG_IREF':
                 calibrated_ADC_value -= nominal_iref 
 
-            calibrated_ADC_value /= nominalDacScalingFactors[nameX]
+            calibrated_ADC_value /= nominalDacScalingFactors[dacName]
                 
-        #the reversal of x and y is intended - we want to plot the nameX variable on the y-axis and the nameY variable on the x-axis
-        #the nameX variable is the DAC register that is scanned, and we want to determine its nominal value
+        #the reversal of x and y is intended - we want to plot the dacName variable on the y-axis and the adcName variable on the x-axis
+        #the dacName variable is the DAC register that is scanned, and we want to determine its nominal value
         if args.assignXErrors:
-            dict_DACvsADC_Graphs[oh][vfat].SetPoint(dict_DACvsADC_Graphs[oh][vfat].GetN(),calibrated_ADC_value,event.dacValX)
-            dict_RawADCvsDAC_Graphs[oh][vfat].SetPoint(dict_RawADCvsDAC_Graphs[oh][vfat].GetN(),event.dacValX,event.dacValY)
-            dict_DACvsADC_Graphs[oh][vfat].SetPointError(dict_DACvsADC_Graphs[oh][vfat].GetN()-1,calibrated_ADC_error,event.dacValX_Err)
-            dict_RawADCvsDAC_Graphs[oh][vfat].SetPointError(dict_RawADCvsDAC_Graphs[oh][vfat].GetN()-1,event.dacValX_Err,0)
+            dict_DACvsADC_Graphs[dacName][oh][vfat].SetPoint(dict_DACvsADC_Graphs[dacName][oh][vfat].GetN(),calibrated_ADC_value,event.dacValX)
+            dict_DACvsADC_Graphs[dacName][oh][vfat].SetPointError(dict_DACvsADC_Graphs[dacName][oh][vfat].GetN()-1,calibrated_ADC_error,event.dacValX_Err)
+            dict_RawADCvsDAC_Graphs[dacName][oh][vfat].SetPoint(dict_RawADCvsDAC_Graphs[dacName][oh][vfat].GetN(),event.dacValX,event.dacValY)
+            dict_RawADCvsDAC_Graphs[dacName][oh][vfat].SetPointError(dict_RawADCvsDAC_Graphs[dacName][oh][vfat].GetN()-1,event.dacValX_Err,0)
         else:
-            dict_DACvsADC_Graphs[oh][vfat].SetPoint(dict_DACvsADC_Graphs[oh][vfat].GetN(),calibrated_ADC_value,event.dacValX)
-            dict_RawADCvsDAC_Graphs[oh][vfat].SetPoint(dict_RawADCvsDAC_Graphs[oh][vfat].GetN(),event.dacValX,event.dacValY)
-            dict_DACvsADC_Graphs[oh][vfat].SetPointError(dict_DACvsADC_Graphs[oh][vfat].GetN()-1,calibrated_ADC_error,0)
-            dict_RawADCvsDAC_Graphs[oh][vfat].SetPointError(dict_RawADCvsDAC_Graphs[oh][vfat].GetN()-1,0,0)
+            dict_DACvsADC_Graphs[dacName][oh][vfat].SetPoint(dict_DACvsADC_Graphs[dacName][oh][vfat].GetN(),calibrated_ADC_value,event.dacValX)
+            dict_DACvsADC_Graphs[dacName][oh][vfat].SetPointError(dict_DACvsADC_Graphs[dacName][oh][vfat].GetN()-1,calibrated_ADC_error,0)
+            dict_RawADCvsDAC_Graphs[dacName][oh][vfat].SetPoint(dict_RawADCvsDAC_Graphs[dacName][oh][vfat].GetN(),event.dacValX,event.dacValY)
+            dict_RawADCvsDAC_Graphs[dacName][oh][vfat].SetPointError(dict_RawADCvsDAC_Graphs[dacName][oh][vfat].GetN()-1,0,0)
 
-    # Fit the TGraphErrors objects    
-    for oh in ohArray:
-        for vfat in range(0,24):
-            if vfat not in dict_nonzeroVFATs[oh]:
-                #so that the output plots for these VFATs are completely empty
-                dict_DACvsADC_Funcs[oh][vfat].SetLineColor(0)
-                continue
-            #the fits fail when the errors on dacValY (the x-axis variable) are used 
-            dict_DACvsADC_Graphs[oh][vfat].Fit(dict_DACvsADC_Funcs[oh][vfat],"QEX0")
+    # Fit the TGraphErrors objects
+    for idx in len(dacNameArray):
+        dacName = dacNameArray[idx]
+        for oh in ohArray:
+            for vfat in range(0,24):
+                if vfat not in dict_nonzeroVFATs[oh]:
+                    #so that the output plots for these VFATs are completely empty
+                    dict_DACvsADC_Funcs[dacName][oh][vfat].SetLineColor(0)
+                    continue
+                #the fits fail when the errors on dacValY (the x-axis variable) are used
+                dict_DACvsADC_Graphs[dacName][oh][vfat].Fit(dict_DACvsADC_Funcs[dacName][oh][vfat],"QEX0")
+
+    # Create Determine max DAC size
+    dict_maxByDacName = {}
+    from gempython.tools.amc_user_functions_xhal import maxVfat3DACSize
+    for dacSelect,dacInfo in maxVfat3DACSize.iteritems():
+        dict_maxByDacName[dacInfo[1]]=dacInfo[0]
 
     # Determine DAC values to achieve recommended bias voltage and current settings
-    graph_dacVals = {}
-    dict_dacVals = nesteddict()
-    for oh in ohArray:
-        graph_dacVals[oh] = r.TGraph()
-        graph_dacVals[oh].SetMinimum(0)
-        graph_dacVals[oh].GetXaxis().SetTitle("VFATN")
-        graph_dacVals[oh].GetYaxis().SetTitle("nominal DAC value")
-        for vfat in range(0,24):
-            if vfat not in dict_nonzeroVFATs[oh]:
-                continue
+    graph_dacVals = ndict()
+    dict_dacVals = ndict()
+    for idx in len(dacNameArray):
+        dacName = dacNameArray[idx]
+        maxDacValue = dict_maxByDacName[dacName]
 
-            maxDacValue = 255
-            
-            for dacSelect in maxVfat3DACSize.keys():
+        for oh in ohArray:
+            graph_dacVals[dacName][oh] = r.TGraph()
+            graph_dacVals[dacName][oh].SetMinimum(0)
+            graph_dacVals[dacName][oh].GetXaxis().SetTitle("VFATN")
+            graph_dacVals[dacName][oh].GetYaxis().SetTitle("nominal {} value".format(dacName))
 
-                #the registers CFG_THR_ARM_DAC and CFG_THR_ZCC_DAC could correspond to voltages or currents
-                #we will use voltages until a way of distinguishing the two cases is implemented 
-                if dacSelect == 14 or dacSelect == 15:
+            for vfat in range(0,24):
+                if vfat not in dict_nonzeroVFATs[oh]:
                     continue
+
+                #evaluate the fitted function at the nominal current or voltage value and convert to an integer
+                fittedDacValue = int(dict_DACvsADC_Funcs[dacName][oh][vfat].Eval(nominal))
+                finalDacValue = max(0,min(maxDacValue,fittedDacValue))
                 
-                if maxVfat3DACSize[dacSelect][1] == nameX:
-                    maxDacValue = int(maxVfat3DACSize[dacSelect][0])
-                    break
+                if fittedDacValue != finalDacValue:
+                    print('Warning: The fitted DAC value, %i, is outside of the range that the register can hold: [0,%i]. It will be replaced by %i.'%(fittedDacValue,maxDacValue,finalDacValue))
                     
-            #evaluate the fitted function at the nominal current or voltage value and convert to an integer
-            fittedDacValue = int(dict_DACvsADC_Funcs[oh][vfat].Eval(nominal))
-            finalDacValue = max(0,min(maxDacValue,fittedDacValue))
-            
-            if fittedDacValue != finalDacValue:
-                print('Warning: The fitted DAC value, %i, is outside of the range that the register can hold: [0,%i]. It will be replaced by %i.'%(fittedDacValue,maxDacValue,finalDacValue))
-                
-            dict_dacVals[oh][vfat] = finalDacValue
-            graph_dacVals[oh].SetPoint(graph_dacVals[oh].GetN(),vfat,dict_dacVals[oh][vfat])
+                dict_dacVals[dacName][oh][vfat] = finalDacValue
+                graph_dacVals[dacName][oh].SetPoint(graph_dacVals[dacName][oh].GetN(),vfat,dict_dacVals[dacName][oh][vfat])
              
     # Write out the dacVal results to a root file, a text file, and the terminal
-    outputTxtFiles_dacVals = {}    
-
-    for oh in ohArray:
-        if scandate == 'noscandate':
-            outputTxtFiles_dacVals[oh] = open(elogPath+"/"+chamber_config[oh]+"/NominalDACValues.txt",'w')
-        else:    
-            outputTxtFiles_dacVals[oh] = open(dataPath+"/"+chamber_config[oh]+"/dacScans/"+scandate+"/NominalDACValues.txt",'w')
+    outputTxtFiles_dacVals = ndict()
+    for idx in len(dacNameArray):
+        dacName = dacNameArray[idx]
+        for oh in ohArray:
+            if scandate == 'noscandate':
+                outputTxtFiles_dacVals[dacName][oh] = open("{0}/{1}/NominalValues-{2}.txt".format(elogPath,chamber_config[oh],dacName),'w')
+            else:
+                outputTxtFiles_dacVals[dacName][oh] = open("{0}/{1}/dacScans/{2}/NominalValues-{3}.txt".format(dataPath,chamber_config[oh],scandate,dacName),'w')
 
     print( "| OH | vfatN | dacVal |")
     print( "| :-: | :---: | :----: |")        
     
     for oh in ohArray:
-        outputFiles[oh].cd()
-        outputFiles[oh].mkdir("Summary")
-        outputFiles[oh].cd("Summary")
-        graph_dacVals[oh].Write("nominalDacValVsVFATX")
+        # Per VFAT Poosition
         for vfat in range(0,24):
-            if vfat not in dict_nonzeroVFATs[oh]:
-                continue            
-            
-            outputFiles[oh].cd()
-            outputFiles[oh].mkdir("VFAT"+str(vfat))
-            outputFiles[oh].cd("VFAT"+str(vfat))
-            dict_DACvsADC_Graphs[oh][vfat].Write("DACvsADC")
-            dict_RawADCvsDAC_Graphs[oh][vfat].Write("RawADCvsDAC")
-            outputFiles[oh].cd("../")
-            outputTxtFiles_dacVals[oh].write(str(vfat)+"\t"+str(dict_dacVals[oh][vfat])+"\n")
-            print("| {0} | {1}  | {2} | ".format(
-                oh,
-                vfat,
-                dict_dacVals[oh][vfat]
-            ))
+            thisVFATDir = outputFiles[oh].mkdir("VFAT{0}".format(vfat))
 
-    # Make plots        
-    for oh in ohArray:
-        canv_Summary = make3x8Canvas('canv_Summary',dict_DACvsADC_Graphs[oh],'APE1',dict_DACvsADC_Funcs[oh],'')
-        if scandate == 'noscandate':
-            canv_Summary.SaveAs(elogPath+"/"+chamber_config[oh]+"/Summary.png")
-        else:
-            canv_Summary.SaveAs(dataPath+"/"+chamber_config[oh]+"/dacScans/"+scandate+"/Summary.png")
+            for idx in len(dacNameArray):
+                dacName = dacNameArray[idx]
+
+                thisDACDir = thisVFATDir.mkdir(dacName)
+                thisDACDir.cd()
+
+                dict_DACvsADC_Graphs[dacName][oh][vfat].Write("g_VFAT{0}_DACvsADC_{1}".format(vfat,dacName))
+                dict_DACvsADC_Funcs[dacName][oh][vfat].Write("func_VFAT{0}_DACvsADC_{1}".format(vfat,dacName))
+                dict_RawADCvsDAC_Graphs[dacName][oh][vfat].Write("g_VFAT{0}_RawADCvsDAC_{1}".format(vfat,dacName))
+
+                if vfat in dict_nonzeroVFATs[oh]:
+                    outputTxtFiles_dacVals[oh].write("{0}\t{1}\n".format(vfat,dict_dacVals[dacName][oh][vfat]))
+
+        # Summary Case
+        dirSummary = outputFiles[oh].mkdir("Summary")
+        dirSummary.cd()
+        for idx in len(dacNameArray):
+            dacName = dacNameArray[idx]
+
+            # Store summary graph
+            graph_dacVals[dacName][oh].Write("g_NominalvsVFATPos_{0}".format(dacName))
+
+            # Store summary grid canvas and print images
+            canv_Summary = make3x8Canvas("canv_Summary_{0}".format(dacName),dict_DACvsADC_Graphs[dacName][oh],'APE1',dict_DACvsADC_Funcs[dacName][oh],'')
+            if scandate == 'noscandate':
+                canv_Summary.SaveAs("{0}/{1}/Summary_{1}_DACScan_{2}.png".format(elogPath,chamber_config[oh],dacName)
+            else:
+                canv_Summary.SaveAs("{0}/{1}/dacScans/{2}/Summary{1}_DACScan_{2}.png".format(dataPath,chamber_config[oh],scandate,dacName))
+
+    # Print Summary?
+    if args.printSum:
+        print("| ohN | vfatN | dacName | Value |")
+        print("| :-: | :---: | :-----: | :---: |")
+        for oh in ohArray:
+            for idx in len(dacNameArray):
+                dacName = dacNameArray[idx]
+            
+                for vfat in range(0,24):
+                    if vfat not in dict_nonzeroVFATs[oh]:
+                        continue
+
+                    print("| {0} | {1} | {2} | {3} |".format(
+                        oh,
+                        vfat,
+                        dacName,
+                        dict_dacVals[dacName][oh][vfat])
+                    )
+
+    print("\nAnalysis completed. Goodbye")

--- a/utils/anaInfo.py
+++ b/utils/anaInfo.py
@@ -15,6 +15,7 @@ import string
 #: Nominal current and voltage values from Tables 9 and 10 of the VFAT3 manual
 #: The registers CFG_THR_ARM_DAC CFG_THR_ZCC_DAC may correspond to either a voltage or a current. Below I have used the voltage. Be careful if you have taken a current scan with these registers (dacSelect options 14 or 15).
 nominalDacValues = {
+        "CFG_CAL_DAC":(0,"uA"), # there is no nominal value
         "CFG_BIAS_PRE_I_BIT":(150,"uA"),
         "CFG_BIAS_PRE_I_BLCC":(25,"nA"),
         "CFG_BIAS_PRE_I_BSF":(26,"uA"),
@@ -34,6 +35,7 @@ nominalDacValues = {
 
 #: From Tables 12 and 13 from the VFAT3 manual
 nominalDacScalingFactors = {
+        "CFG_CAL_DAC":10,
         "CFG_BIAS_PRE_I_BIT":0.2,
         "CFG_BIAS_PRE_I_BLCC":100,
         "CFG_BIAS_PRE_I_BSF":0.25,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Rewrite of `anaDACScans.py` to handle multiple DAC scans in input file.  Calling syntax remains the same.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
It's really annoying to have to analyze ~10-15 different scandates and look through output information in multiple different locations.

Now input files containing multiple DAC scans can be analyzed simultaneously and output in a single location. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran updated analysis:

```bash
% anaDACScan.py --calFileList=tmpCalFileADC.txt dacScanTest.root                                                                                
Analyzing: 'dacScanTest.root'
Loading info from input TTree
Initializing TObjects
Looping over stored events in dacScanTree
fitting DAC vs. ADC distributions
Determining nominal values for bias voltage and/or current settings
Warning: when fitting DAC CFG_BIAS_SD_I_BDIFF the fitted value, 319, is outside range the register can hold: [0,255]. It will be replaced by 255.
Warning: when fitting DAC CFG_BIAS_SD_I_BDIFF the fitted value, 301, is outside range the register can hold: [0,255]. It will be replaced by 255.
Warning: when fitting DAC CFG_BIAS_SD_I_BDIFF the fitted value, 349, is outside range the register can hold: [0,255]. It will be replaced by 255.
Warning: when fitting DAC CFG_BIAS_SD_I_BDIFF the fitted value, 341, is outside range the register can hold: [0,255]. It will be replaced by 255.
Warning: when fitting DAC CFG_BIAS_SD_I_BDIFF the fitted value, 315, is outside range the register can hold: [0,255]. It will be replaced by 255.
Warning: when fitting DAC CFG_BIAS_SD_I_BDIFF the fitted value, 340, is outside range the register can hold: [0,255]. It will be replaced by 255.
Writing output data
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_ADC_VREF.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_CFD_DAC_1.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_CFD_DAC_2.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_PRE_I_BIT.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_PRE_I_BLCC.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_PRE_I_BSF.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_PRE_VREF.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_SD_I_BDIFF.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_SD_I_BFCAS.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_SD_I_BSF.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_SH_I_BDIFF.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_SH_I_BFCAS.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_CAL_DAC.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_HYST.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_THR_ARM_DAC.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_THR_ZCC_DAC.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_ADC_VREF.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_CFD_DAC_1.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_CFD_DAC_2.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_PRE_I_BIT.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_PRE_I_BLCC.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_PRE_I_BSF.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_PRE_VREF.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_SD_I_BDIFF.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_SD_I_BFCAS.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_SD_I_BSF.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_SH_I_BDIFF.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_SH_I_BFCAS.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_CAL_DAC.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_HYST.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_THR_ARM_DAC.png has been created
Info in <TCanvas::Print>: png file /data/gemelog/GE11-X-S-BARI-0010/Summary_GE11-X-S-BARI-0010_DACScan_CFG_THR_ZCC_DAC.png has been created

Analysis completed. Goodbye
```

Output data area now contains summary canvas's and text files:

```bash
% ll
total 3.4M
-rw-r--r--. 1 gemuser zh  85K Nov 15 22:53 Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_CFD_DAC_1.png
-rw-r--r--. 1 gemuser zh  77K Nov 15 22:53 Summary_GE11-X-S-BARI-0010_DACScan_CFG_ADC_VREF.png
-rw-r--r--. 1 gemuser zh 123K Nov 15 22:53 Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_PRE_I_BLCC.png
-rw-r--r--. 1 gemuser zh  84K Nov 15 22:53 Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_PRE_I_BIT.png
-rw-r--r--. 1 gemuser zh  85K Nov 15 22:53 Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_CFD_DAC_2.png
-rw-r--r--. 1 gemuser zh  89K Nov 15 22:53 Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_SD_I_BFCAS.png
-rw-r--r--. 1 gemuser zh  88K Nov 15 22:53 Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_SD_I_BDIFF.png
-rw-r--r--. 1 gemuser zh  83K Nov 15 22:53 Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_PRE_VREF.png
-rw-r--r--. 1 gemuser zh  80K Nov 15 22:53 Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_PRE_I_BSF.png
-rw-r--r--. 1 gemuser zh  90K Nov 15 22:53 Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_SH_I_BFCAS.png
-rw-r--r--. 1 gemuser zh  88K Nov 15 22:53 Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_SH_I_BDIFF.png
-rw-r--r--. 1 gemuser zh  81K Nov 15 22:53 Summary_GE11-X-S-BARI-0010_DACScan_CFG_BIAS_SD_I_BSF.png
-rw-r--r--. 1 gemuser zh  90K Nov 15 22:53 Summary_GE11-X-S-BARI-0010_DACScan_CFG_HYST.png
-rw-r--r--. 1 gemuser zh 145K Nov 15 22:53 Summary_GE11-X-S-BARI-0010_DACScan_CFG_CAL_DAC.png
-rw-r--r--. 1 gemuser zh 117K Nov 15 22:53 Summary_GE11-X-S-BARI-0010_DACScan_CFG_THR_ZCC_DAC.png
-rw-r--r--. 1 gemuser zh 117K Nov 15 22:53 Summary_GE11-X-S-BARI-0010_DACScan_CFG_THR_ARM_DAC.png
-rw-r--r--. 1 gemuser zh 1.9M Nov 15 22:53 DACFitData.root
-rw-r--r--. 1 gemuser zh  107 Nov 15 22:53 NominalValues-CFG_THR_ZCC_DAC.txt
-rw-r--r--. 1 gemuser zh  128 Nov 15 22:53 NominalValues-CFG_THR_ARM_DAC.txt
-rw-r--r--. 1 gemuser zh  105 Nov 15 22:53 NominalValues-CFG_HYST.txt
-rw-r--r--. 1 gemuser zh  113 Nov 15 22:53 NominalValues-CFG_CAL_DAC.txt
-rw-r--r--. 1 gemuser zh  151 Nov 15 22:53 NominalValues-CFG_BIAS_SH_I_BFCAS.txt
-rw-r--r--. 1 gemuser zh  151 Nov 15 22:53 NominalValues-CFG_BIAS_SH_I_BDIFF.txt
-rw-r--r--. 1 gemuser zh  128 Nov 15 22:53 NominalValues-CFG_BIAS_SD_I_BSF.txt
-rw-r--r--. 1 gemuser zh  151 Nov 15 22:53 NominalValues-CFG_BIAS_SD_I_BFCAS.txt
-rw-r--r--. 1 gemuser zh  151 Nov 15 22:53 NominalValues-CFG_BIAS_SD_I_BDIFF.txt
-rw-r--r--. 1 gemuser zh  128 Nov 15 22:53 NominalValues-CFG_BIAS_PRE_VREF.txt
-rw-r--r--. 1 gemuser zh  128 Nov 15 22:53 NominalValues-CFG_BIAS_PRE_I_BSF.txt
-rw-r--r--. 1 gemuser zh  128 Nov 15 22:53 NominalValues-CFG_BIAS_PRE_I_BLCC.txt
-rw-r--r--. 1 gemuser zh  151 Nov 15 22:53 NominalValues-CFG_BIAS_PRE_I_BIT.txt
-rw-r--r--. 1 gemuser zh  128 Nov 15 22:53 NominalValues-CFG_BIAS_CFD_DAC_2.txt
-rw-r--r--. 1 gemuser zh  128 Nov 15 22:53 NominalValues-CFG_BIAS_CFD_DAC_1.txt
-rw-r--r--. 1 gemuser zh  105 Nov 15 22:53 NominalValues-CFG_ADC_VREF.txt   
```

### Screenshots (if appropriate):
Output `TFile` now contains all TObjects subdivided by VFAT position and DAC name:

<img width="348" alt="screen shot 2018-11-15 at 23 02 40" src="https://user-images.githubusercontent.com/6432141/48584675-a7ec9c80-e92a-11e8-823a-3218da691568.png">

Each TObject now shows DAC Name:

<img width="605" alt="screen shot 2018-11-15 at 23 02 50" src="https://user-images.githubusercontent.com/6432141/48584683-b1760480-e92a-11e8-91b3-0f5d50d85fa3.png">
<img width="588" alt="screen shot 2018-11-15 at 23 04 09" src="https://user-images.githubusercontent.com/6432141/48584708-c94d8880-e92a-11e8-9abf-cdafd25ff951.png">

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
