### PR TITLE
Bug Fix: in anaDACScan.py, fix handling of calFiles

### DIFF
--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -173,7 +173,10 @@ if __name__ == '__main__':
         if oh not in calInfo.keys():
             calAdcCalFile = "{0}/{1}/calFile_{2}_{1}.txt".format(dataPath,chamber_config[oh],adcName)
             calAdcCalFileExists = os.path.isfile(calAdcCalFile)
-            if not calAdcCalFileExists:
+            if calAdcCalFileExists:
+                tuple_calInfo = parseCalFile(calAdcCalFile)
+                calInfo[oh] = {'slope' : tuple_calInfo[0], 'intercept' : tuple_calInfo[1]}
+            else:    
                 print("Skipping OH{0}, detector {1}, missing {2} calibration file:\n\t{3}".format(
                     oh,
                     chamber_config[oh],


### PR DESCRIPTION
anaDACScan.py did not work when calFiles were not explicitly passed but provided in $DATA_PATH/[chamber name]/.

## Description
Currently, when a calFile is found in $DATA_PATH/[chamber name]/, the OH is kept in the list of OHs to calibrate, but the calFile is not parsed, causing the KeyError reported by @bdorney in https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/171. This pull request parses these calFiles and stores the calibration information.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This pull request address https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/171

## How Has This Been Tested?
Yes, it has been tested in a virtual environment:

Command executed:
```
anaDACScan.py /data/bigdisk/GEM-Data-Taking/GE11_QC8/dacScanV3/2018.11.30.21.55/dacScanV3.root
```

Tail of output:
```
Loading info from input TTree
Info in <TCanvas::Print>: png file /data/bigdisk/GEM-Data-Taking/GE11_QC8//GE11-X-S-INDIA-0002/dacScans/2018.11.30.21.55/SummaryGE11-X-S-INDIA-0002_DACScan_2018.11.30.21.55.png has been created
Initializing TObjects
Looping over stored events in dacScanTree
fitting DAC vs. ADC distributions
Determining nominal values for bias voltage and/or current settings
Warning: when fitting DAC CFG_BIAS_PRE_I_BIT the fitted value, 274, is outside range the register can hold: [0,255]. It will be replaced by 255.
Writing output data

Analysis completed. Goodbye
```

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
