### PR TITLE
anaDACScan.py update: handle the case when the OH number is not in the chamber dictionary

### DIFF
--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -118,8 +118,8 @@ if __name__ == '__main__':
     from gempython.utils.wrappers import runCommand
     for oh in ohArray:
         if scandate == 'noscandate':
-            runCommand(["mkdir", "-p", "{0}/{1}".format(elogPath,cName)])
-            runCommand(["chmod", "g+rw", "{0}/{1}".format(elogPath,cName)])
+            runCommand(["mkdir", "-p", "{0}/{1}".format(elogPath,dict_chamberNames[oh])])
+            runCommand(["chmod", "g+rw", "{0}/{1}".format(elogPath,dict_chamberNames[oh])])
         else:
             runCommand(["mkdir", "-p", "{0}/{1}/dacScans/{2}".format(dataPath,dict_chamberNames[oh],scandate)])
             runCommand(["chmod", "g+rw", "{0}/{1}/dacScans/{2}".format(dataPath,dict_chamberNames[oh],scandate)])

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -104,15 +104,17 @@ if __name__ == '__main__':
 
     dict_chamberNames = {}
     unknownChamberName = "unknown"
+    from gempython.utils.gemlogger import colormsg
+    import logging
     for oh in ohArray:
         if oh in chamber_config.keys():
             chamberName = chamber_config[oh]
         else:
-            chamberName = unknownChamberName
-            errorMsg = "Warning: OH{0} not found in chamber name dictionary. The chamber name associated with this OH will be set to '{1}'".format(
+            errorMsg = "Warning: OH{0} not found in chamber name dictionary. The chamber name associated with this OH will be set to '{1}'.".format(
                 oh,
-                chamberName)
+                unknownChamberName)
             print(colormsg(errorMsg,logging.ERROR))
+            chamberName = unknownChamberName
         dict_chamberNames[oh] = chamberName    
     
     from gempython.utils.wrappers import runCommand
@@ -130,8 +132,6 @@ if __name__ == '__main__':
         adcName = str(event.nameY.data())
         break # all entries will be the same
 
-    from gempython.utils.gemlogger import colormsg
-    import logging
     if adcName not in ['ADC0', 'ADC1']:
         print(colormsg("Error: unexpected value of adcName: '%s'"%adcName,logging.ERROR))
         exit(os.EX_DATAERR)

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -189,15 +189,18 @@ if __name__ == '__main__':
             if dict_chamberNames[oh] != unknownChamberName:
                 calAdcCalFile = "{0}/{1}/calFile_{2}_{1}.txt".format(dataPath,dict_chamberNames[oh],adcName)
                 calAdcCalFileExists = os.path.isfile(calAdcCalFile)
-            if calAdcCalFileExists:
-                tuple_calInfo = parseCalFile(calAdcCalFile)
-                calInfo[oh] = {'slope' : tuple_calInfo[0], 'intercept' : tuple_calInfo[1]}
-            else:    
-                print("Skipping OH{0}, detector {1}, missing {2} calibration file:\n\t{3}".format(
-                    oh,
-                    dict_chamberNames[oh],
-                    adcName,
-                    calAdcCalFile))
+                if calAdcCalFileExists:
+                    tuple_calInfo = parseCalFile(calAdcCalFile)
+                    calInfo[oh] = {'slope' : tuple_calInfo[0], 'intercept' : tuple_calInfo[1]}
+                else:    
+                    print("Skipping OH{0}, detector {1}, missing {2} calibration file:\n\t{3}".format(
+                        oh,
+                        dict_chamberNames[oh],
+                        adcName,
+                        calAdcCalFile))
+                    ohArray = np.delete(ohArray,(oh))
+            else:
+                print("Skipping OH%i, no calibration file"%oh)
                 ohArray = np.delete(ohArray,(oh))
 
     if len(ohArray) == 0:


### PR DESCRIPTION
Handles the case when an OH in the input tree is not in the chamber dictionary.

## Description
This pull request introduces a `dict_chamberNames` and sets the chamber name to `unknown` for OH numbers that are not in the `chamber_config` dictionary.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This pull request resolves https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/173

## How Has This Been Tested?
I have tested the script (in a venv) for 3 cases:

1) OH in chamber config

```
Initializing TObjects
Looping over stored events in dacScanTree
fitting DAC vs. ADC distributions
Determining nominal values for bias voltage and/or current settings
Warning: when fitting DAC CFG_BIAS_PRE_I_BIT the fitted value, 274, is outside range the register can hold: [0,255]. It will be replaced by 255.
Writing output data
Info in <TCanvas::Print>: png file /data/bigdisk/GEM-Data-Taking/GE11_QC8//GE11-X-S-INDIA-0002/dacScans/2018.11.30.21.55/SummaryGE11-X-S-INDIA-0002_DACScan_2018.11.30.21.55.png has been created

Analysis completed. Goodbye
```

2) OH not in chamber config and no calFile is passed 

```
Warning: OH0 not found in chamber name dictionary. The chamber name associated with this OH will be set to 'unknown'.
Skipping OH0, no calibration file
No OHs with a calFile, exiting.
```

3) OH not in chamber config and calFile is passed

```
Warning: OH0 not found in chamber name dictionary. The chamber name associated with this OH will be set to 'unknown'.
Initializing TObjects
Looping over stored events in dacScanTree
fitting DAC vs. ADC distributions
Determining nominal values for bias voltage and/or current settings
Warning: when fitting DAC CFG_BIAS_PRE_I_BIT the fitted value, 274, is outside range the register can hold: [0,255]. It will be replaced by 255.
Writing output data
Info in <TCanvas::Print>: png file /data/bigdisk/GEM-Data-Taking/GE11_QC8//unknown/dacScans/2018.11.30.21.55/Summaryunknown_DACScan_2018.11.30.21.55.png has been created

Analysis completed. Goodbye
```

### Screenshots (if appropriate):

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
