### PR TITLE
Bug Fix: Resolved a type mismatch error

### DIFF
--- a/macros/calibrateThrDac.py
+++ b/macros/calibrateThrDac.py
@@ -126,7 +126,7 @@ if __name__ == '__main__':
             mapVFATPos2VFATSN = np.loadtxt(
                         fname = args.listOfVFATs,
                         dtype={'names':('vfatN', 'serialNum'),
-                                'formats':('i4', 'i4')},
+                                'formats':('u4', 'u4')},
                         skiprows=1,
                     )
         except Exception as e:
@@ -135,7 +135,7 @@ if __name__ == '__main__':
             exit(os.EX_NOINPUT)
             pass
     else:
-        mapVFATPos2VFATSN = np.zeros(24,dtype={'names':('vfatN', 'serialNum'),'formats':('i4', 'i4')})
+        mapVFATPos2VFATSN = np.zeros(24,dtype={'names':('vfatN', 'serialNum'),'formats':('u4', 'u4')})
 
     # Get list of THR DAC values
     listOfThrValues = []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed `mapVFATPos2VFATSN` from `int32` to `uint32` data type.  This resolves a type mismatch in older versions of `numpy` and is also more correct.  The `vfatID` is treated as an unsigned 32 bit integer due to the possibility of bit flips in the chipID register. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
Resolves type issue shown [here](https://mattermost.web.cern.ch/cms-gem-daq/pl/8sy34q8cn78zbm4fp6gcuqxdge).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran analysis without having the problem in older version of `numpy`.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
