### PR TITLE
[Bug Fix]: in DAC scan analysis, link should be compared with a single number

### DIFF
--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -55,7 +55,10 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
     dict_nonzeroVFATs = {}
     for entry in crateMap:
         ohKey = (entry['shelf'],entry['slot'],entry['link'])
-        dict_nonzeroVFATs[ohKey] = np.unique(vfatArray[np.logical_and(vfatArray['dacValY'] > 0,vfatArray['link'] == ohKey)]['vfatN'])
+        arrayMask = np.logical_and(vfatArray['dacValY'] > 0, vfatArray['link'] == entry['link'])
+        arrayMask = np.logical_and(arrayMask, vfatArray['slot'] == entry['slot'])
+        arrayMask = np.logical_and(arrayMask, vfatArray['shelf'] == entry['shelf'])
+        dict_nonzeroVFATs[ohKey] = np.unique(vfatArray[arrayMask]['vfatN'])
 
     from gempython.utils.wrappers import envCheck
     envCheck("DATA_PATH")


### PR DESCRIPTION
The `link` branch should be compared with a single number instead of a triplet.

## Description
`ohKey` is a triplet while `vfatArray['link']` is a single integer, so a comparison of them will always be false. In this pull request, `ohKey` is replaced by `entry['link']` in the comparison.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This is causing the DAC scan analysis to produce empty results.

## How Has This Been Tested?
Yes, it has been tested on the coffin setup.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
