### PR TITLE
[Bug Fix] printYellow takes one argument

### DIFF
--- a/mapping/chamberInfo.py
+++ b/mapping/chamberInfo.py
@@ -14,7 +14,7 @@ from gempython.utils.gemlogger import printYellow
 try:
     from system_specific_constants import chamber_config
 except ImportError as e:
-    printYellow(e,"Using gempython_gemplotting package default for chamber_config dictionary")
+    printYellow("Using gempython_gemplotting package default for chamber_config dictionary")
     #: Available chambers
     """
     Keys should be a tuple of (shelf,slot,link)
@@ -36,7 +36,7 @@ except ImportError as e:
 try:
     from system_specific_constants import GEBtype
 except ImportError as e:
-    printYellow(e,"Using gempython_gemplotting package default for GEBtype dictionary")
+    printYellow("Using gempython_gemplotting package default for GEBtype dictionary")
     """
     Keys should be a tuple of (shelf,slot,link)
     """
@@ -78,7 +78,7 @@ for ieta, vfatRow in chamber_iEta2VFATPos.iteritems():
 try:
     from system_specific_constants import chamber_vfatDACSettings
 except ImportError as e:
-    printYellow(e,"Using gempython_gemplotting package default for chamber_vfatDACSettings dictionary")
+    printYellow("Using gempython_gemplotting package default for chamber_vfatDACSettings dictionary")
     """
     Keys should be a tuple of (shelf,slot,link)
     """


### PR DESCRIPTION
`printYellow` was provided two arguments instead of one.

## Description
`printYellow` is defined here

https://github.com/cms-gem-daq-project/cmsgemos/blob/generic-amc-RPC-v3-short-term/gempython/utils/gemlogger.py

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
It caused a crash.

## How Has This Been Tested?
Yes.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
