### PR TITLE
Updating default highNoiseCut value in anaUltraScurve.py from 1.0 to 3.0 fC

### DIFF
--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -172,7 +172,7 @@ if __name__ == '__main__':
     chanMaskGroup.add_option("--maxEffPedPercent", type="float", dest="maxEffPedPercent", default=0.05,
                       help="Percentage, Threshold for setting the HighEffPed mask reason, if channel (effPed > maxEffPedPercent * nevts) then HighEffPed is set",
                       metavar="maxEffPedPercent")
-    chanMaskGroup.add_option("--highNoiseCut", type="float", dest="highNoiseCut", default=1.0,
+    chanMaskGroup.add_option("--highNoiseCut", type="float", dest="highNoiseCut", default=3.0,
                       help="Threshold for setting the HighNoise maskReason, if channel (scurve_sigma > highNoiseCut) then HighNoise is set",
                       metavar="highNoiseCut")
     chanMaskGroup.add_option("--deadChanCutLow", type="float", dest="deadChanCutLow", default=None,


### PR DESCRIPTION
## Description
Updating the default value of `--highNoiseCut` in `anaUltraScurve.py` from 1.0 to 3.0 fC.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
Since we noticed that the default cut on the noise value was to low for our needs in the cosmic stand and we got entire VFATs with masked channels, after a thorough study of the noise, we decided to change the default value. From the original value of 1.0 fC, we have changed it now to 3.0 fC. It can be clearly seen by the attached plots that it is more than reasonable and that it permits us to mask less than 1% of the strips because of noise.

## How Has This Been Tested?
The change have been tested re-analysing a trim run with the new cut value.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->

Plot 1: Integral of number of strips that have noise above the value 'x' for all the scurves analysed:
/data/bigdisk/GEM-Data-Taking/GE11_QC8/GE11-X-S-INDIA-0004/scurve/2019.05.17.15.43/SCurveData/SCurveFitData.root
/data/bigdisk/GEM-Data-Taking/GE11_QC8/GE11-X-S-INDIA-0009/scurve/2019.05.17.15.43/SCurveData/SCurveFitData.root
/data/bigdisk/GEM-Data-Taking/GE11_QC8/GE11-X-S-INDIA-0015/scurve/2019.05.16.17.28/SCurveData/SCurveFitData.root

![ERFnoise1Dall](https://user-images.githubusercontent.com/26896876/58162400-6692cc00-7c82-11e9-9bca-f33686c4e8be.png)

Plot 2: same as plot 1, but Y axis normalised to the total value of strips (to get the percentage)

![ERFnoise1DallNorm](https://user-images.githubusercontent.com/26896876/58162360-567aec80-7c82-11e9-8d8f-34b00ee2e388.png)
