### PR TITLE
[Bugfix] forgot to import os in armDac calibration parsing function

### DIFF
--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -1136,6 +1136,7 @@ def parseArmDacCalFile(filename):
         calTree.ReadFile(filename)
     except IOError:
         printRed("file {0} is not readable or does not exist, please cross-check".format(filename))
+        import os
         exit(os.EX_IOERR)
     array_CalData = rp.tree2array(tree=calTree, branches=list_bNames)
     


### PR DESCRIPTION
`import os` statement was missing

## Description
One line change.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
Would crash if it ever reaches this line, although it seems PyROOT is not actually throwing IOErrors in the current version. Instead it prints:

```
Error in <TTree::ReadFile>: Cannot open file: ~/test.txt
```

## How Has This Been Tested?
Change is trivial.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
