### PR TITLE
in calibrateThrDac.py, remove points with low scurveMeanError and restrict fit range

### DIFF
--- a/macros/calibrateThrDac.py
+++ b/macros/calibrateThrDac.py
@@ -494,7 +494,8 @@ if __name__ == '__main__':
             dict_ScurveMeanVsThrDac[vfat].GetPoint(thrDacIndexPairs[i][1],thrDacVal,scurveMean)
             scurveSigmaError = dict_ScurveSigmaVsThrDac[vfat].GetErrorY(thrDacIndexPairs[i][1])
             scurveMeanError = dict_ScurveMeanVsThrDac[vfat].GetErrorY(thrDacIndexPairs[i][1])
-            if scurveMean < 0.1 or scurveMeanError/scurveMean < 0.001:
+            from gempython.gemplotting.utils.anaInfo import scurveMeanMin, scurveMeanFracErrMin
+            if scurveMean < scurveMeanMin or scurveMeanError/scurveMean < scurveMeanFracErrMin:
                 continue
             if not setLastUnremovedScurveMean:
                 lastUnremovedScurveMean = scurveMean

--- a/macros/calibrateThrDac.py
+++ b/macros/calibrateThrDac.py
@@ -494,7 +494,7 @@ if __name__ == '__main__':
             dict_ScurveMeanVsThrDac[vfat].GetPoint(thrDacIndexPairs[i][1],thrDacVal,scurveMean)
             scurveSigmaError = dict_ScurveSigmaVsThrDac[vfat].GetErrorY(thrDacIndexPairs[i][1])
             scurveMeanError = dict_ScurveMeanVsThrDac[vfat].GetErrorY(thrDacIndexPairs[i][1])
-            if scurveMean < 0.1:
+            if scurveMean < 0.1 or scurveMeanError/scurveMean < 0.001:
                 continue
             if not setLastUnremovedScurveMean:
                 lastUnremovedScurveMean = scurveMean
@@ -505,6 +505,18 @@ if __name__ == '__main__':
             tgraph_scurveMeanVsThrDacForFit.SetPoint(tgraph_scurveMeanVsThrDacForFit.GetN(),thrDacVal,scurveMean)
             tgraph_scurveMeanVsThrDacForFit.SetPointError(tgraph_scurveMeanVsThrDacForFit.GetN()-1,0,scurveMeanError)
 
+        #update the fit range
+        #this will not affect the fit, it is just for the output plots
+        thrDacVal = r.Double()
+        scurveMean = r.Double()
+        tgraph_scurveMeanVsThrDacForFit.GetPoint(tgraph_scurveMeanVsThrDacForFit.GetN()-1,thrDacVal,scurveMean)
+        perVfatFitRange = list(fitRange)
+        if thrDacVal > perVfatFitRange[0]:
+            perVfatFitRange[0] = float(thrDacVal)
+        tgraph_scurveMeanVsThrDacForFit.GetPoint(0,thrDacVal,scurveMean)
+        if thrDacVal < perVfatFitRange[1]:
+            perVfatFitRange[1] = float(thrDacVal)
+        
         # Mean vs CFG_THR_*_DAC
         dict_canvScurveMeanVsThrDac[vfat] = r.TCanvas("canvScurveMeanVsThrDac_{0}".format(suffix),"Scurve Mean vs. THR DAC - {0}".format(suffix),700,700)
         dict_canvScurveMeanVsThrDac[vfat].cd()
@@ -512,7 +524,7 @@ if __name__ == '__main__':
         dict_ScurveMeanVsThrDac[vfat].GetXaxis().SetTitle(thrDacName)
         dict_ScurveMeanVsThrDac[vfat].GetYaxis().SetTitle("Scurve Mean #left(fC#right)")
         dict_ScurveMeanVsThrDac[vfat].Draw("APE1")
-        dict_funcScurveMeanVsThrDac[vfat] = r.TF1("func_{0}".format((dict_ScurveMeanVsThrDac[vfat].GetName()).strip('g')),"[0]*x^4+[1]*x^3+[2]*x^2+[3]*x+[4]",min(fitRange),max(fitRange))
+        dict_funcScurveMeanVsThrDac[vfat] = r.TF1("func_{0}".format((dict_ScurveMeanVsThrDac[vfat].GetName()).strip('g')),"[0]*x^4+[1]*x^3+[2]*x^2+[3]*x+[4]",min(perVfatFitRange),max(perVfatFitRange))
         #require the first derivative to be positive at the lower boundary of the fit range 
         dict_funcScurveMeanVsThrDac[vfat].SetParLimits(3,0,1000000) 
         tgraph_scurveMeanVsThrDacForFit.Fit(dict_funcScurveMeanVsThrDac[vfat],"QR")

--- a/utils/anaInfo.py
+++ b/utils/anaInfo.py
@@ -12,6 +12,11 @@ Documentation
 
 import string
 
+#: CFG_THR_ARM_DAC calibration parameters
+#: The CFG_THR_ARM_DAC calibration routine involves performing a fit of scurveMean vs CFG_THR_ARM_DAC in which some points with bad quality, defined by the parameters below, are removed
+scurveMeanMin = 0.1 #: points are removed if they satisfy scurveMean < scurveMeanMin
+scurveMeanFracErrMin = 0.001 #: points are removed if they satisfy scurveMeanError/scurveMean < scurveFracErrMin
+
 #: Nominal current and voltage values from Tables 9 and 10 of the VFAT3 manual
 #: The registers CFG_THR_ARM_DAC CFG_THR_ZCC_DAC may correspond to either a voltage or a current. Below I have used the voltage. Be careful if you have taken a current scan with these registers (dacSelect options 14 or 15).
 nominalDacValues = {


### PR DESCRIPTION
Add protection against failed Gaussian fits to the scurveMean distribution and restrict the fit range automatically.

## Description
The scurve mean and the error on the scurve mean are determined by a Gaussian fit to a histogram (actually a TGraph) of the scurveMean. The Gaussian fit can fail in a way that produces a reasonable scurveMean but an scurveMeanError that is unreasonably small. This can cause the scurveMean vs THR_DAC fit to fail. So, this pull request removes points in which the scurveMeanError is less than 0.1% of the scurveMean error.

The new fit range restriction will not affect the fit, but will affect how the fitted function is plotted. The fit range is determined on a per vfat basis based on which points are included in the fit.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This address https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/208 including the comment https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/208#issuecomment-495305202.

## How Has This Been Tested?
Yes. As stated in the issue, among the 33 list of scandates files that I tested, there are 7 points that are removed by this algorithm. The scurveMean distributions shown there all indicate that it is reasonable to remove them. And the problematic scurveMean vs thrDac fit is improved in the case that motivated the issue (notice VFAT18):

Before:

![58165543-45cd7500-7c88-11e9-8013-2ce581058492](https://user-images.githubusercontent.com/3329216/58424340-7f8ee900-8097-11e9-9670-d16408f4305f.png)

With the new point removal algorithm:

![canvScurveMeanVsThrDac_Summary 11](https://user-images.githubusercontent.com/3329216/58130203-c904b180-7c1b-11e9-8b37-d6860a0c0158.png)

With the new point removal algorithm and the new restriction on the fit range:

![canvScurveMeanVsThrDac_Summary](https://user-images.githubusercontent.com/3329216/58424260-5706ef00-8097-11e9-8d74-eddd2e880fcf.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->