### PR TITLE
in anaUltraScurve.py, TF1 associated with TTree branch should be copied into

### DIFF
--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -580,7 +580,8 @@ if __name__ == '__main__':
                 # Set TObjects linked to TBranches
                 holder_curve = fitter.scanHistos[vfat][chan]
                 holder_curve.Copy(scurve_h)
-                scurve_fit = fitter.getFunc(vfat,chan).Clone('scurveFit_vfat%i_chan%i'%(vfat,chan))
+                holder_fit = fitter.getFunc(vfat,chan).Clone('scurveFit_vfat%i_chan%i'%(vfat,chan))
+                holder_fit.Copy(scurve_fit)
                 
                 # Filling the arrays for plotting later
                 if options.drawbad:


### PR DESCRIPTION
Bug was causing scurve fit branch to be corrupted in output tree.

## Description
Currently, we are correctly handling the `scurve_h` branch but not the `scurve_fit` branch:

https://github.com/cms-gem-daq-project/gem-plotting-tools/blob/aacb46da4c6ebe952996ec8695584cd9bc926e9c/anaUltraScurve.py#L581-L583

This pull request uses the same logic involving a holder to handle the `scurve_fit` branch as the `scurve_h` branch.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
Currently, the `scurve_fit` branch stored in the output tree does not contain the scurve fit, and it will induce a crash if it is read from. 

A similar issue was reported https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/63, although it is not clear to me if that is actually address by this pull request.

## How Has This Been Tested?
Yes, the bugfix was tested on GE11-X-S-PAK-0005 data taken by the QC8 team.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
