### PR TITLE
New Feature: dacAnalysis raises ValueError if one or more DACs Out of Range

### DIFF
--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -81,9 +81,10 @@ if __name__ == '__main__':
         scandate = 'noscandate'
 
     from gempython.gemplotting.utils.anautilities import dacAnalysis
+    from gempython.gemplotting.utils.exceptions import VFATDACBiasCannotBeReached
     try:
         dacAnalysis(args, dacScanFile.dacScanTree, chamber_config, scandate=scandate)
-    except ValueError as err:
+    except VFATDACBiasCannotBeReached as err:
         from gempython.utils.gemlogger import printRed
         printRed(err.message)
         printRed("VFATs above may *NOT* be properly biased")

--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -81,7 +81,12 @@ if __name__ == '__main__':
         scandate = 'noscandate'
 
     from gempython.gemplotting.utils.anautilities import dacAnalysis
-    dacAnalysis(args, dacScanFile.dacScanTree, chamber_config, scandate=scandate)
+    try:
+        dacAnalysis(args, dacScanFile.dacScanTree, chamber_config, scandate=scandate)
+    except ValueError as err:
+        from gempython.utils.gemlogger import printRed
+        printRed(err.message)
+        printRed("VFATs above may *NOT* be properly biased")
     dacScanFile.Close()
 
     print("\nAnalysis completed. Goodbye")

--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -395,7 +395,8 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
         for ohKey,vfatDACtuple in dictOfDACsWithBadBias.iteritems():
             err_msg = "{0}\n\t{1}\t{2}".format(err_msg,ohKey,vfatDACtuple)
             pass
-        raise ValueError(err_msg)
+        from gempython.gemplotting.utils.exceptions import VFATDACBiasCannotBeReached
+        raise VFATDACBiasCannotBeReached(err_msg)
 
     return dict_dacVals
 

--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -43,9 +43,13 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
 
     import root_numpy as rp
     import numpy as np
-    list_bNames = ['dacValY','link','nameX','shelf','slot','vfatN']
+    list_bNames = ['dacValY','link','nameX','shelf','slot','vfatID','vfatN']
     vfatArray = rp.tree2array(tree=dacScanTree,branches=list_bNames)
     dacNameArray = np.unique(vfatArray['nameX'])
+
+    # Get VFATID's
+    vfatIDArray = getSubArray(vfatArray, ['vfatID','vfatN'])
+    vfatIDArray = np.sort(vfatIDArray,order='vfatN')['vfatID'] # index now gauranteed to match vfatN
     
     # make the crateMap
     list_bNames.remove('dacValY')
@@ -92,14 +96,14 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
     from gempython.utils.gemlogger import colormsg
     import logging
     if adcName not in ['ADC0', 'ADC1']:
-        raise Exception(colormsg("Error: unexpected value of adcName: '%s'"%adcName,logging.ERROR), os.EX_DATAERR)
+        raise ValueError(colormsg("Error: unexpected value of adcName: '%s'"%adcName,logging.ERROR), os.EX_DATAERR)
 
     from gempython.gemplotting.utils.anaInfo import nominalDacValues, nominalDacScalingFactors
     nominal = {}
     for idx in range(len(dacNameArray)):
         dacName = np.asscalar(dacNameArray[idx])
         if dacName not in nominalDacValues.keys():
-            raise Exception(colormsg("Error: unexpected DAC Name: '{}'".format(dacName),logging.ERROR), os.EX_DATAERR)
+            raise ValueError(colormsg("Error: unexpected DAC Name: '{}'".format(dacName),logging.ERROR), os.EX_DATAERR)
         else:
             nominal[dacName] = nominalDacValues[dacName][0]
 
@@ -121,7 +125,8 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
             elif nominalDacValues[dacName][1] == 'nA':
                 nominal[dacName] *= pow(10.0,-3)
             else:
-                raise Exception(colormsg("Error: unexpected units: '%s'"%nominalDacValues[dacName][1],logging.ERROR), os.EX_DATAERR)
+                # Maybe a TypeError is more appropriate...?
+                raise ValueError(colormsg("Error: unexpected units: '%s'"%nominalDacValues[dacName][1],logging.ERROR), os.EX_DATAERR)
 
     #the nominal reference current is 10 uA and it has a scaling factor of 0.5   
     nominal_iref = 10*0.5
@@ -160,7 +165,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
                 crateMap = np.delete(crateMap,(idx))
 
     if len(crateMap) == 0:
-        raise Exception(colormsg('No OHs with a calFile, exiting.',logging.ERROR),os.EX_DATAERR)
+        raise RuntimeError(colormsg('No OHs with a calFile, exiting.',logging.ERROR),os.EX_DATAERR)
            
     # Initialize nested dictionaries
     from gempython.utils.nesteddict import nesteddict as ndict
@@ -270,6 +275,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
     # Determine DAC values to achieve recommended bias voltage and current settings
     graph_dacVals = ndict()
     dict_dacVals = ndict()
+    dictOfDACsWithBadBias = {} # [ohKey] = (vfatN,vfatID,dacName)
     for idx in range(len(dacNameArray)):
         dacName = np.asscalar(dacNameArray[idx])
         maxDacValue = dict_maxByDacName[dacName]
@@ -290,6 +296,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
                 finalDacValue = max(0,min(maxDacValue,fittedDacValue))
                 
                 if fittedDacValue != finalDacValue:
+                    dictOfDACsWithBadBias[ohKey] = (vfat,vfatIDArray[vfat],dacName)
                     errorMsg = "Warning: when fitting VFAT{5} of chamber {6} (Shelf{7},Slot{8},OH{4}) DAC {0} the fitted value, {1}, is outside range the register can hold: [0,{2}]. It will be replaced by {3}.".format(
                             dacName,
                             fittedDacValue,
@@ -378,6 +385,14 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
                 pass
             pass
         pass
+
+    # Raise a ValueError if a DAC is found to be out of range
+    if len(dictOfDACsWithBadBias):
+        err_msg = "The following (vfatN,DAC Names) where found to be out of range"
+        for ohKey,vfatDACtuple in dictOfDACsWithBadBias.iteritems():
+            err_msg = "{0}\n\t{1}\t{2}".format(err_msg,ohKey,vfatDACtuple)
+            pass
+        raise ValueError(err_msg)
 
     return dict_dacVals
 
@@ -851,6 +866,19 @@ def getStringNoSpecials(inputStr):
     inputStr = inputStr.replace('#','')
 
     return inputStr
+
+def getSubArray(structArray, fields):
+    """
+    Taken from: https://stackoverflow.com/a/21819324
+
+    Returns a view of a structured numpy array
+
+    structArray - structured numpy array
+    fields - list of column names in the structure array
+    """
+
+    dtype2 = np.dtype({name:structArray.dtype.fields[name] for name in fields})
+    return np.ndarray(structArray.shape, dtype2, structArray, 0, structArray.strides)
 
 def initVFATArray(array_dtype, nstrips=128):
     import numpy as np

--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -25,6 +25,9 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
 
     Where ohKey is a tuple of (shelf,slot,link) providing the mapping for uTCA shelf -> slot -> link mapping
 
+    Will raise a ValueError if one or more DAC's are found to need a DAC value that places the DAC out of its
+    range to hit the correct bias voltage/current required.
+
     Here dacName are the values stored in the "nameX" TBranch of the input TTree.
 
         dacScanTree - Instance of gemDacCalTreeStructure.  Note the "nameY" TBranch must be either "ADC0" or "ADC1"

--- a/utils/exceptions.py
+++ b/utils/exceptions.py
@@ -1,0 +1,6 @@
+class VFATDACBiasCannotBeReached(ValueError):
+    def __init__(self, message, errors):
+        super(VFATDACBiasCannotBeReached, self).__init__(message)
+
+        self.errors = errors
+        return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Following discussion in GEM Electronics meeting today it was suggested by VFAT3 team that we should reject VFATs found to have one or more DAC's that would need a DAC value out of the DAC range to achieve the proper bias voltage/current.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

The `dacAnalysis` function will now run to completion; but just before returning it will throw a `ValueError` if one or more DAC's are found to need a DAC value to achieve the correct bias voltage/current that would place the DAC out of it's range. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
We need to be able to reject VFATs that have this DAC behavior; this provides an exception that can be caught by the `testConnectivity.py` routine to stop the procedure and warn the user.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested but don't know of a setup where this occurs at present.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
