### PR TITLE
[Bug Fix] Corrected bug in nominalDacScalingFactors

### DIFF
--- a/utils/anaInfo.py
+++ b/utils/anaInfo.py
@@ -40,7 +40,7 @@ nominalDacValues = {
 
 #: From Tables 12 and 13 from the VFAT3 manual
 nominalDacScalingFactors = {
-        "CFG_CAL_DAC":10,
+        "CFG_CAL_DAC":10, # Valid only for currentPulse; if voltageStep this is 1
         "CFG_BIAS_PRE_I_BIT":0.2,
         "CFG_BIAS_PRE_I_BLCC":100,
         "CFG_BIAS_PRE_I_BSF":0.25,
@@ -51,7 +51,7 @@ nominalDacScalingFactors = {
         "CFG_BIAS_SD_I_BSF":0.25,
         "CFG_BIAS_CFD_DAC_1":1,
         "CFG_BIAS_CFD_DAC_2":1,
-        "CFG_HYST":1,
+        "CFG_HYST":5,
         "CFG_THR_ARM_DAC":1,
         "CFG_THR_ZCC_DAC":4,
         "CFG_BIAS_PRE_VREF":1,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

In QC7 we noticed that for some VFATs the DAC scan for CFG_HYST would always fail to find a valid value; after some discussion in person with VFAT3 designers we determined that the value for the scaling factor needs to be updated.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
So inside *some* DACs there is a factor that is inside the DAC itself that will change the input current/voltage; this current/voltage that the DAC actually uses is not accessible by either ADC when making a DAC scan but it is related to the actual current used by the fixed factor.

VFAT3 designers admitted this isn't very well described in the manual; but we went through and cross-checked each of the scaling factors.

It was found that only `CFG_HYST` was in error and it should be noted that for `CFG_CAL_DAC` the value we have in the `nominalDacScalingFactors` dictionary is only valid for the `voltageStep` injection mode and is *not* valid for the currentPulse mode.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Change was trivial

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
