### PR TITLE
[feature] Finding inflection point

### DIFF
--- a/pkg/setup.py
+++ b/pkg/setup.py
@@ -89,8 +89,7 @@ setup(name             = '__packagename__',
       zip_safe         = False,
       setup_requires   = [
           'setuptools>=25.0',
-          'sphinx>=1.0'
-          # 'sphinx>=1.0,<=1.4'
+          'sphinx>=1.0,<=1.4'
       ],
       install_requires = getreqs(),
       license          = 'GNU General Public License v3 (GPLv3)',

--- a/pkg/setup.py
+++ b/pkg/setup.py
@@ -89,7 +89,8 @@ setup(name             = '__packagename__',
       zip_safe         = False,
       setup_requires   = [
           'setuptools>=25.0',
-          'sphinx>=1.0,<=1.4'
+          'sphinx>=1.0'
+          # 'sphinx>=1.0,<=1.4'
       ],
       install_requires = getreqs(),
       license          = 'GNU General Public License v3 (GPLv3)',

--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -456,6 +456,9 @@ def findInflectionPts(graph):
     import numpy as np
     from itertools import groupby
 
+    # Allow for yellow and red warning colors
+    from gempython.utils.gemlogger import printYellow, printRed
+
     # make TH1F into TGraph
     if type(graph) == root.TH1F :
         graph = root.TGraph(graph)
@@ -477,6 +480,7 @@ def findInflectionPts(graph):
     # Sum the split arrays and find the most negative sum
     negSum = []
     bigNegSum = 0
+    bigIdx = 0
     for iNegArr in range(0, len(negGrad) ) :
         tmpNegSum = sum(negGrad[iNegArr] )
         negSum.append(tmpNegSum)
@@ -486,15 +490,24 @@ def findInflectionPts(graph):
 
     # Get the inflection point
     # We are defining the inflection point as the point where the most negative gradient sum begins
-    inflxGrad = negGrad[bigIdx][0]
-    try: 
-        inflxIdx = np.where(grad == inflxGrad) #return the index at the specified value
-    except ValueError:
-        print("Warning: the inflection point gradient (inflxGrad) value {:f} was not found in the gradient list".format(inflxGrad))
     try:
+        inflxGrad = negGrad[bigIdx][0]
+        inflxIdx = np.where(grad == inflxGrad) #return the index at the specified value
         inflxPnt = (x[inflxIdx], y[inflxIdx] )
+    # Error handling for problematic VFATs
+    except IndexError:
+        if bigIdx == 0:
+            printYellow("Warning: No values with negative slope, so no inflection point! Assigning 0")
+            inflxPnt = (0.0, 0.0)
+        else:
+            printYellow("Warning: There is no negative gradient value at the index (bigIdx) value {:f}, Assigning 0".format(bigIdx) )
+            inflxPnt = (0.0, 0.0)
+    except ValueError:
+        printYellow("Warning: the inflection point gradient (inflxGrad) value {:f} was not found in the gradient list. Assigning 0".format(inflxGrad) )
+        inflxPnt = (0.0, 0.0)
     except NameError:
-        print("Error: No Inflection Point was not found")
+        printYellow("Warning: The inflection point was not found (unqualified name). Assigning 0")
+        inflxPnt = (0.0, 0.0)
 
     return inflxPnt
 

--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -442,10 +442,7 @@ def filePathExists(searchPath, subPath=None, debug=False):
             print "Found %s"%s(testPath)
         return True
 
-#========================================================================================
 # Find Inflection Point /////////////////////////////////////////////////////////////////
-#----------------------------------------------------------------------------------------
-# Author(s): Brendan Regnery, Brian Dorney, Jared Sturdy ////////////////////////////////
 #----------------------------------------------------------------------------------------
 
 def findInflectionPts(graph):
@@ -473,7 +470,7 @@ def findInflectionPts(graph):
     # Documentation here: https://docs.scipy.org/doc/numpy/reference/generated/numpy.gradient.html
     grad = np.gradient(y, x)
 
-    # Split the array when the slope changes sign
+    # Split the array when the slope changes sign and store the partitions of gradients
     posGrad = [list(g) for k, g in groupby(grad, lambda x: x > 0) if k]
     negGrad = [list(g) for k, g in groupby(grad, lambda x: x < 0) if k]
    
@@ -490,10 +487,16 @@ def findInflectionPts(graph):
     # Get the inflection point
     # We are defining the inflection point as the point where the most negative gradient sum begins
     inflxGrad = negGrad[bigIdx][0]
-    for iGrad in range(0, len(grad) ) :
-        if grad[iGrad] == inflxGrad :
-            inflxIdx = iGrad
-    return [x[inflxIdx], y[inflxIdx] ]
+    try: 
+        inflxIdx = np.where(grad == inflxGrad) #return the index at the specified value
+    except ValueError:
+        print("Warning: the inflection point gradient (inflxGrad) value {:f} was not found in the gradient list".format(inflxGrad))
+    try:
+        inflxPnt = (x[inflxIdx], y[inflxIdx] )
+    except NameError:
+        print("Error: No Inflection Point was not found")
+
+    return inflxPnt
 
 def first_index_gt(data_list, value):
     """
@@ -1622,304 +1625,3 @@ def saveSummaryByiEta(dictSummary, name='Summary', trimPt=None, drawOpt="colz"):
 
     return
 
-def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outfilename='SBitRatePlots.root', scandate='noscandate'):
-    """
-    Analyzes a scan taken with sbitRateScanAllLinks(...) from gempython.vfatqc.utils.scanUtils
-    
-    Returns a tuple (boolean,dictionary) where the dictionary returned is:
-
-        dict_dacValsBelowCutOff[dacName][ohKey][vfat] = value
-
-    Where ohKey is a tuple of (shelf,slot,link) providing the mapping for uTCA shelf -> slot -> link mapping.
-    Here dacName are the values stored in the "nameX" TBranch of the input TTree.
-    And value is the value of dacName for which the SBIT rate is below the cutOffRate.
-
-    The boolean returned states whether the channelOR (false) or perchannel (true) analysis was performed
-
-    Additional input parameters are:
-
-        chamber_config  - chamber_config dictionary
-        debug           - Prints additional debugging information
-        rateTree        - instance of gemSbitRateTreeStructure
-        cutOffRate      - Theshold rate (in Hz) described above
-        outfilename     - Name of output TFile to be created
-        scandate        - Either a string 'noscandate' or an a datetime object formated as YYYY.MM.DD.hh.mm, e.g
-                          returned from "datetime.datetime.now().strftime("%Y.%m.%d.%H.%M")"
-    """
-
-    # Check $ENV
-    from gempython.utils.wrappers import envCheck
-    envCheck("DATA_PATH")
-    envCheck("ELOG_PATH")
-
-    import os
-    dataPath = os.getenv("DATA_PATH")
-    elogPath = os.getenv("ELOG_PATH") 
-
-    # Map TPad to correct vfat
-    from ..mapping.chamberInfo import chamber_vfatPos2PadIdx
-
-    # Allow for yellow warning color
-    from gempython.utils.gemlogger import printYellow
-
-    # Set default histogram behavior
-    import ROOT as r
-    r.TH1.SetDefaultSumw2(False)
-    r.gROOT.SetBatch(True)
-    r.gStyle.SetOptStat(1111111)
-
-    print("Loading info from input TTree")
-
-    # Get the data
-    import root_numpy as rp
-    import numpy as np
-    list_bNames = ['dacValX','link','nameX','rate','shelf','slot','vfatCH','vfatN']
-
-    vfatArray = rp.tree2array(tree=rateTree,branches=list_bNames)
-    dacNameArray = np.unique(vfatArray['nameX'])
-
-    # channelOR or perchannel?
-    vfatChannels = np.unique(vfatArray['vfatCH'])
-    if len(vfatChannels) == 1:
-        perchannel = False
-    else:
-        perchannel = True
-        pass
-
-    # make the crateMap
-    list_bNames.remove('dacValX')
-    list_bNames.remove('nameX')
-    list_bNames.remove('rate')
-    list_bNames.remove('vfatCH')
-    list_bNames.remove('vfatN')
-    crateMap = np.unique(rp.tree2array(tree=rateTree,branches=list_bNames))
-
-    # get nonzero VFATs
-    dict_nonzeroVFATs = {}
-    for entry in crateMap:
-        ohKey = (entry['shelf'],entry['slot'],entry['link'])
-        arrayMask = np.logical_and(vfatArray['rate'] > 0, vfatArray['link'] == entry['link'])
-        arrayMask = np.logical_and(arrayMask, vfatArray['slot'] == entry['slot'])
-        arrayMask = np.logical_and(arrayMask, vfatArray['shelf'] == entry['shelf'])
-        dict_nonzeroVFATs[ohKey] = np.unique(vfatArray[arrayMask]['vfatN'])
-
-    if debug:
-        printYellow("crateMap:\n{0}".format(crateMap))
-        printYellow("dacNameArray:\n{0}".format(dacNameArray))
-
-    # make output directories
-    from gempython.utils.wrappers import runCommand
-    for entry in crateMap:
-        ohKey = (entry['shelf'],entry['slot'],entry['link'])
-        if scandate == 'noscandate':
-            runCommand(["mkdir", "-p", "{0}/{1}".format(elogPath,chamber_config[ohKey])])
-            runCommand(["chmod", "g+rw", "{0}/{1}".format(elogPath,chamber_config[ohKey])])
-        else:
-            if perchannel:
-                strDirName = getDirByAnaType("sbitRatech", chamber_config[ohKey])
-            else:
-                strDirName = getDirByAnaType("sbitRateor", chamber_config[ohKey])
-                pass
-            runCommand(["mkdir", "-p", "{0}/{1}".format(strDirName,scandate)])
-            runCommand(["chmod", "g+rw", "{0}/{1}".format(strDirName,scandate)])
-            runCommand(["unlink", "{0}/current".format(strDirName)])
-            runCommand(["ln","-s","{0}/{1}".format(strDirName,scandate),"{0}/current".format(strDirName)])
-            pass
-        pass
-
-    # make nested dictionaries
-    from gempython.utils.nesteddict import nesteddict as ndict
-    dict_Rate1DVsDACNameX = ndict() #[dacName][ohKey][vfat] = TGraphErrors
-    dict_vfatCHVsDACNameX_Rate2D = ndict() #[dacName][ohKey][vfat] = TGraph2D
-    
-    # initialize a TGraphErrors and a TF1 for each vfat
-    for idx in range(len(dacNameArray)):
-        dacName = np.asscalar(dacNameArray[idx])
-        for entry in crateMap:
-            ohKey = (entry['shelf'],entry['slot'],entry['link'])
-            for vfat in range(0,25): #24th VFAT represents "overall case"
-                # 1D Distributions
-                dict_Rate1DVsDACNameX[dacName][ohKey][vfat] = r.TGraphErrors()
-                dict_Rate1DVsDACNameX[dacName][ohKey][vfat].SetName("g1D_rate_vs_{0}_vfat{1}".format(dacName.replace("_","-"),vfat))
-                dict_Rate1DVsDACNameX[dacName][ohKey][vfat].GetXaxis().SetTitle(dacName)
-                dict_Rate1DVsDACNameX[dacName][ohKey][vfat].GetYaxis().SetRangeUser(1e-1,1e8)
-                dict_Rate1DVsDACNameX[dacName][ohKey][vfat].GetYaxis().SetTitle("SBIT Rate #left(Hz#right)")
-                dict_Rate1DVsDACNameX[dacName][ohKey][vfat].SetMarkerStyle(23)
-                dict_Rate1DVsDACNameX[dacName][ohKey][vfat].SetMarkerSize(0.8)
-                dict_Rate1DVsDACNameX[dacName][ohKey][vfat].SetLineWidth(2)
-
-                # 2D Distributions
-                dict_vfatCHVsDACNameX_Rate2D[dacName][ohKey][vfat] = r.TGraph2D()
-                dict_vfatCHVsDACNameX_Rate2D[dacName][ohKey][vfat].SetName("g2D_vfatCH_vs_{0}_rate_vfat{1}".format(dacName.replace("_","-"),vfat))
-                dict_vfatCHVsDACNameX_Rate2D[dacName][ohKey][vfat].GetXaxis().SetTitle(dacName)
-                dict_vfatCHVsDACNameX_Rate2D[dacName][ohKey][vfat].GetYaxis().SetTitle("VFAT Channel")
-                dict_vfatCHVsDACNameX_Rate2D[dacName][ohKey][vfat].GetZaxis().SetTitle("SBIT Rate #left(Hz#right)")
-                pass
-            pass
-        pass
-
-    # create output TFiles
-    outputFiles = {}         
-    for entry in crateMap:
-        ohKey = (entry['shelf'],entry['slot'],entry['link'])
-        if scandate == 'noscandate':
-            outputFiles[ohKey] = r.TFile(elogPath+"/"+chamber_config[ohKey]+"/"+outfilename,'recreate')
-        else:    
-            if perchannel:
-                strDirName = getDirByAnaType("sbitRatech", chamber_config[ohKey])
-            else:
-                strDirName = getDirByAnaType("sbitRateor", chamber_config[ohKey])
-                pass
-            outputFiles[ohKey] = r.TFile(strDirName+scandate+"/"+outfilename,'recreate')
-            pass
-        pass
-
-    # Loop over events the tree and fill plots
-    print("Looping over stored events in rateTree")
-    from math import sqrt 
-    for event in rateTree:
-        ohKey = (event.shelf,event.slot,event.link)
-        vfat = event.vfatN
-
-        if vfat not in dict_nonzeroVFATs[ohKey]:
-            continue
-
-        #Get the DAC Name in question
-        dacName = str(event.nameX.data())
-
-        try:
-            if event.vfatCH == 128:
-                dict_Rate1DVsDACNameX[dacName][ohKey][vfat].SetPoint(
-                        dict_Rate1DVsDACNameX[dacName][ohKey][vfat].GetN(),
-                        event.dacValX,
-                        event.rate)
-                dict_Rate1DVsDACNameX[dacName][ohKey][vfat].SetPointError(
-                        dict_Rate1DVsDACNameX[dacName][ohKey][vfat].GetN()-1,
-                        0,
-                        sqrt(event.rate))
-            else:
-                dict_vfatCHVsDACNameX_Rate2D[dacName][ohKey][vfat].SetPoint(
-                        dict_vfatCHVsDACNameX_Rate2D[dacName][ohKey][vfat].GetN(),
-                        event.dacValX,
-                        event.vfatCH,
-                        event.rate)
-        except AttributeError:
-            print("Point Number: ", counter)
-            print("event.vfatCH = ", event.vfatCH)
-            print("dacName = ", dacName)
-            print("ohKey = ", ohKey)
-            print("vfat = ", vfat)
-            print("dict_Rate1DVsDACNameX[dacName].keys() = ", dict_Rate1DVsDACNameX.keys() )
-            print("dict_Rate1DVsDACNameX[dacName][ohKey].keys() = ", dict_Rate1DVsDACNameX[dacName][ohKey].keys() )
-            print("dict_Rate1DVsDACNameX[dacName][ohKey][vfat] = ", dict_Rate1DVsDACNameX[dacName][ohKey][vfat] )
-            print("dict_Rate1DVsDACNameX = ", dict_Rate1DVsDACNameX)
-            exit()
-
-            pass
-        pass
-
-    print("Determine when SBIT rate falls below {0} Hz and writing output data".format(cutOffRate))
-    #from array import array
-    dict_dacValsBelowCutOff = ndict()
-    
-    # make a named dictionary to store inflection pts
-    dict_dacInflectPts = ndict()
-
-    for entry in crateMap:
-        ohKey = (entry['shelf'],entry['slot'],entry['link'])
-        # Per VFAT Poosition
-        for vfat in range(0,24):
-            thisVFATDir = outputFiles[ohKey].mkdir("VFAT{0}".format(vfat))
-
-            for idx in range(len(dacNameArray)):
-                dacName = np.asscalar(dacNameArray[idx])
-
-                thisDACDir = thisVFATDir.mkdir(dacName)
-                thisDACDir.cd()
-
-                #========================================================================
-                # Get Inflection Points /////////////////////////////////////////////////
-                #========================================================================
-
-                # perchannel case is not supported provide warning
-		if perchannel == True :
-                    printYellow("WARNING: perchannel case is not supported for knee finding!   Skipping knee finding" )
-
-                # channelor case
-                if perchannel == False :
-	            dict_dacInflectPts[dacName][ohKey][vfat] = findInflectionPts(dict_Rate1DVsDACNameX[dacName][ohKey][vfat])
-
-
-                dict_dacValsBelowCutOff[dacName][ohKey][vfat] = 255 #default to max
-                for point in range(0,dict_Rate1DVsDACNameX[dacName][ohKey][vfat].GetN()):
-                    dacValX = r.Double()
-                    rateVal = r.Double()
-                    dict_Rate1DVsDACNameX[dacName][ohKey][vfat].GetPoint(point,dacValX,rateVal)
-                    if rateVal <= cutOffRate:
-                        dict_dacValsBelowCutOff[dacName][ohKey][vfat] = int(dacValX)
-                        break
-                    pass
-
-                if perchannel:
-                    dict_vfatCHVsDACNameX_Rate2D[dacName][ohKey][vfat].Write()
-                else:
-                    dict_Rate1DVsDACNameX[dacName][ohKey][vfat].Write()
-                    pass
-                pass
-            pass
-
-        #==========================================================================================
-        # Make Graphs /////////////////////////////////////////////////////////////////////////////
-        #==========================================================================================
-           
-        for idx in range(len(dacNameArray)):
-            dacName = np.asscalar(dacNameArray[idx])
-            if perchannel:
-                canv_Summary2D = make3x8Canvas("canv_Summary_Rate2D_vs_{0}".format(dacName),dict_vfatCHVsDACNameX_Rate2D[dacName][ohKey],"TRI1")
-                for vfat in range(1,25):
-                    canv_Summary2D.cd(vfat).SetLogz()
-            else:
-                canv_Summary1D = make3x8Canvas("canv_Summary_Rate1D_vs_{0}".format(dacName),dict_Rate1DVsDACNameX[dacName][ohKey],"APE1" )
-                # make 24 TLines
-                kneeLine= []
-                for vfat in range(0,24):
-                    canv_Summary1D.cd(vfat + 1).SetLogy()
-
-                    # make TH1F into TGraph
-                    graph = dict_Rate1DVsDACNameX[dacName][ohKey][vfat] 
-                    if type(graph) == r.TH1F :
-                        graph = r.TGraph(graph)
-
-                    # get maximum y value
-                    y = graph.GetY()
-                    y = np.array(y)
-                    ymax = np.amax(y)
-
-                    # Draw a line on the graphs
-                    kneeLine.append(r.TLine(dict_dacInflectPts[dacName][ohKey][vfat][0], 10.0, dict_dacInflectPts[dacName][ohKey][vfat][0], ymax) )
-                    kneeLine[vfat].SetLineColor(2)
-                    kneeLine[vfat].SetVertical()
-                    canv_Summary1D.cd(chamber_vfatPos2PadIdx[vfat] )
-                    kneeLine[vfat].Draw()
-                canv_Summary1D.Update()
-
-            # Save the graphs
-            if scandate == 'noscandate':
-                if perchannel:
-                    canv_Summary2D.SaveAs("{0}/{1}/{2}_{1}.png".format(elogPath,chamber_config[ohKey],canv_Summary2D.GetName()))
-                else:
-                    canv_Summary1D.SaveAs("{0}/{1}/{2}_{1}.png".format(elogPath,chamber_config[ohKey],canv_Summary1D.GetName()))
-            else:
-                if perchannel:
-                    strDirName = getDirByAnaType("sbitRatech", chamber_config[ohKey])
-                    canv_Summary2D.SaveAs("{0}/{1}/{2}.png".format(strDirName,scandate,canv_Summary2D.GetName()))
-                else:
-                    strDirName = getDirByAnaType("sbitRateor", chamber_config[ohKey])
-                    canv_Summary1D.SaveAs("{0}/{1}/{2}.png".format(strDirName,scandate,canv_Summary1D.GetName()))
-                    pass
-                pass
-            pass
-        outputFiles[ohKey].Close()
-        pass
-
-    return (perchannel, dict_dacValsBelowCutOff)

--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -476,7 +476,6 @@ def findInflectionPts(graph):
     # Split the array when the slope changes sign
     posGrad = [list(g) for k, g in groupby(grad, lambda x: x > 0) if k]
     negGrad = [list(g) for k, g in groupby(grad, lambda x: x < 0) if k]
-    #print "Gradient: ", grad
    
     # Sum the split arrays and find the most negative sum
     negSum = []
@@ -491,11 +490,9 @@ def findInflectionPts(graph):
     # Get the inflection point
     # We are defining the inflection point as the point where the most negative gradient sum begins
     inflxGrad = negGrad[bigIdx][0]
-    print "Inflection Gradient: ", inflxGrad
     for iGrad in range(0, len(grad) ) :
         if grad[iGrad] == inflxGrad :
             inflxIdx = iGrad
-    print "Inflection Point: ", x[inflxIdx], y[inflxIdx]
     return [x[inflxIdx], y[inflxIdx] ]
 
 def first_index_gt(data_list, value):
@@ -1662,6 +1659,9 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
     # Map TPad to correct vfat
     from ..mapping.chamberInfo import chamber_vfatPos2PadIdx
 
+    # Allow for yellow warning color
+    from gempython.utils.gemlogger import printYellow
+
     # Set default histogram behavior
     import ROOT as r
     r.TH1.SetDefaultSumw2(False)
@@ -1843,18 +1843,11 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
                 # Get Inflection Points /////////////////////////////////////////////////
                 #========================================================================
 
-	        # perchannel case working with 2D distributions
+                # perchannel case is not supported provide warning
 		if perchannel == True :
-		    # make 2D histogram from dict_vfatCHVsDACNameX_Rate2D[dacName][ohKey][vfat] with TGraph2D::GetHistogram() method
-                    tmpHist2D = dict_vfatCHVsDACNameX_Rate2D[dacName][ohKey][vfat].GetHistogram()
+                    printYellow("WARNING: perchannel case is not supported for knee finding!   Skipping knee finding" )
 
-		    # Make a temporary 1D histogram to add all the projections too
-                    tmpHist1D = r.TH1F()
-			# Then for channel bins in this tmp 2D histogram loop over them
-				# Make a projection using TH2D::ProjectionX or Y depending on which axis is vfatCH
-				# Add this projection to 1 tmp1D histogram using TH1F::Add()
-
-                # channel or case
+                # channelor case
                 if perchannel == False :
 	            dict_dacInflectPts[dacName][ohKey][vfat] = findInflectionPts(dict_Rate1DVsDACNameX[dacName][ohKey][vfat])
 

--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -1825,8 +1825,6 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
     # make a named dictionary to store inflection pts
     dict_dacInflectPts = ndict()
 
-    print("Enter Crate Loop")
-
     for entry in crateMap:
         ohKey = (entry['shelf'],entry['slot'],entry['link'])
         # Per VFAT Poosition

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -34,11 +34,11 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     extChanMapping - Name of externally supplied file that specifies the ROBstr:PanPin:vfatCH mapping
     isVFAT2 - True (False) if data is coming from VFAT2(3)
     PanPin - If true output plots are made vs. PanPin
-    pervfat - If true only 1D plots are made 
+    pervfat - If true only 1D plots are made
     zscore - selection criterion to use in median absolute deviation outlier identifion algorithm
-    
-    Returns a TTree storing the analysis results if the calling process is the main process; if the 
-    calling process is a child process nothing is returned.  
+
+    Returns a TTree storing the analysis results if the calling process is the main process; if the
+    calling process is a child process nothing is returned.
 
     Other arguments are:
 
@@ -76,7 +76,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
         outputDir = getElogPath()
         pass
 
-    # Redirect sys.stdout and sys.stderr if necessary 
+    # Redirect sys.stdout and sys.stderr if necessary
     from gempython.gemplotting.utils.multiprocUtils import redirectStdOutAndErr
     redirectStdOutAndErr("anaUltraLatency",outputDir)
 
@@ -103,7 +103,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     else:
         dacName = "CFG_THR_ARM_DAC"
         pass
-    
+
     from gempython.gemplotting.utils.anaInfo import mappingNames
     if ((not args.channels) and (not args.PanPin)):
         stripChanOrPinName = ("ROBstr","Strip")
@@ -178,7 +178,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
         stripPinOrChan = dict_vfatChanLUT[event.vfatN][stripChanOrPinType][event.vfatCH]
         dict_h2D_thrDAC[event.vfatN].Fill(stripPinOrChan,event.vth1,event.Nhits)
         pass
-    
+
     # Make output TTree
     from array import array
     thrAnaTree = r.TTree('thrAnaTree','Tree Holding Analyzed Threshold Data')
@@ -198,7 +198,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     thrAnaTree.Branch( 'vfatN', vfatN, 'vfatN/I' )
     vthr = array( 'i', [ 0 ] )
     thrAnaTree.Branch( 'vthr', vthr, 'vthr/I' )
-    
+
     #Determine Hot Channels
     print 'Determining hot channels'
 
@@ -433,12 +433,12 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     # Do we return analyzed TTree?
     from multiprocessing import current_process
     if (current_process().name == 'MainProcess'):
-        return 
+        return
         return thrAnaTree
     else:
         # multiprocessing cannot handle the thrAnaTree object to be passed back
-        # raises a MaybeEncodingError exception; this is because multiprocessing 
-        # encodes data in 32 bit words.  Seems like TTree objects are encoded with 
+        # raises a MaybeEncodingError exception; this is because multiprocessing
+        # encodes data in 32 bit words.  Seems like TTree objects are encoded with
         # 64 bit words; see: https://bugs.python.org/issue17560
         return
 
@@ -446,7 +446,7 @@ def calibrateThrDACStar(inputs):
     """
     Wrapper to be used with multiprocessing.Pool methods
     See: https://stackoverflow.com/questions/5442910/python-multiprocessing-pool-map-for-multiple-arguments
-    
+
     When moving to python 3.X we should use the Pool::starmap function and not this wrapper:
     see: https://stackoverflow.com/a/5442981
     """
@@ -571,7 +571,7 @@ def calibrateThrDAC(args):
         binMin = min(listOfThrValues)-stepSize*0.5
         binMax = max(listOfThrValues)+stepSize*0.5
         nBins = len(listOfThrValues)
-    
+
     # Make containers
     # In each case where vfat position is used as a key, the value of -1 is the sum over the entire detector
     from gempython.utils.nesteddict import nesteddict as ndict
@@ -613,7 +613,7 @@ def calibrateThrDAC(args):
         list_bNames = ['vfatN','vfatID']
         array_vfatData = rp.tree2array(tree=scanFile.scurveFitTree, branches=list_bNames)
         array_vfatData = np.unique(array_vfatData)
-        
+
         import os
         # Get scurve data for this arm dac value (used for boxplots)
         list_bNames = ['noise', 'threshold', 'vfatN', 'vthr', 'ped_eff']
@@ -674,7 +674,7 @@ def calibrateThrDAC(args):
                 dict_ScurveMeanVsThrDac[vfat].SetTitle(suffix)
                 dict_ScurveMeanVsThrDac[vfat].SetName("gScurveMean_vs_{0}_{1}".format(thrDacName,suffix))
                 dict_ScurveMeanVsThrDac[vfat].SetMarkerStyle(23)
-                
+
                 if len(uniqueDeltas) == 1:
                     #placeholder
                     dict_ScurveMeanVsThrDac_BoxPlot[vfat] = r.TH2F("h_ScurveMean_vs_{0}_{1}".format(thrDacName,suffix),suffix,nBins,binMin,binMax,1002,-0.1,100.1)
@@ -690,7 +690,7 @@ def calibrateThrDAC(args):
                 dict_ScurveSigmaVsThrDac[vfat].SetTitle(suffix)
                 dict_ScurveSigmaVsThrDac[vfat].SetName("gScurveSigma_vs_{0}_{1}".format(thrDacName,suffix))
                 dict_ScurveSigmaVsThrDac[vfat].SetMarkerStyle(23)
-                
+
                 if len(uniqueDeltas) == 1:
                     dict_ScurveSigmaVsThrDac_BoxPlot[vfat] = r.TH2F("h_ScurveSigma_vs_{0}_{1}".format(thrDacName,suffix),suffix,nBins,binMin,binMax,504,-0.1,25.1)
                 else:
@@ -936,8 +936,8 @@ def calibrateThrDAC(args):
             dict_ScurveMeanVsThrDac[vfat].GetPoint(i,thrDacVal,scurveMean)
             thrDacIndexPairs.append([thrDacVal,i])
 
-        thrDacIndexPairs.sort()    
-        
+        thrDacIndexPairs.sort()
+
         #remove THR DAC values where there appear to be pedestal effects
         tgraph_scurveSigmaHighThrDacVal=r.TGraphErrors(5)
         scurveSigmaMeanHighThrDacVal = 0
@@ -949,7 +949,7 @@ def calibrateThrDAC(args):
             tgraph_scurveSigmaHighThrDacVal.SetPoint(i-(len(thrDacIndexPairs)-5),thrDacVal,scurveSigma)
             tgraph_scurveSigmaHighThrDacVal.SetPointError(i-(len(thrDacIndexPairs)-5),0,scurveSigmaError)
 
-        tgraph_scurveSigmaHighThrDacVal.Fit("pol0","Q")    
+        tgraph_scurveSigmaHighThrDacVal.Fit("pol0","Q")
         sigmaHighThrDacPlusError = tgraph_scurveSigmaHighThrDacVal.GetFunction("pol0").GetParameter(0)+tgraph_scurveSigmaHighThrDacVal.GetFunction("pol0").GetParError(0)
         sigmaHighThrDacChiSquaredOverNdof = tgraph_scurveSigmaHighThrDacVal.GetFunction("pol0").GetChisquare()/4.0
 
@@ -988,7 +988,7 @@ def calibrateThrDAC(args):
         tgraph_scurveMeanVsThrDacForFit.GetPoint(0,thrDacVal,scurveMean)
         if thrDacVal < perVfatFitRange[1]:
             perVfatFitRange[1] = float(thrDacVal)
-        
+
         # Mean vs CFG_THR_*_DAC
         dict_canvScurveMeanVsThrDac[vfat] = r.TCanvas("canvScurveMeanVsThrDac_{0}".format(suffix),"Scurve Mean vs. THR DAC - {0}".format(suffix),700,700)
         dict_canvScurveMeanVsThrDac[vfat].cd()
@@ -997,8 +997,8 @@ def calibrateThrDAC(args):
         dict_ScurveMeanVsThrDac[vfat].GetYaxis().SetTitle("Scurve Mean #left(fC#right)")
         dict_ScurveMeanVsThrDac[vfat].Draw("APE1")
         dict_funcScurveMeanVsThrDac[vfat] = r.TF1("func_{0}".format((dict_ScurveMeanVsThrDac[vfat].GetName()).strip('g')),"[0]*x^4+[1]*x^3+[2]*x^2+[3]*x+[4]",min(perVfatFitRange),max(perVfatFitRange))
-        #require the first derivative to be positive at the lower boundary of the fit range 
-        dict_funcScurveMeanVsThrDac[vfat].SetParLimits(3,0,1000000) 
+        #require the first derivative to be positive at the lower boundary of the fit range
+        dict_funcScurveMeanVsThrDac[vfat].SetParLimits(3,0,1000000)
         tgraph_scurveMeanVsThrDacForFit.Fit(dict_funcScurveMeanVsThrDac[vfat],"QR")
         dict_ScurveMeanVsThrDac[vfat].Write()
         dict_funcScurveMeanVsThrDac[vfat].Write()
@@ -1140,7 +1140,7 @@ def calibrateThrDAC(args):
 def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outfilename='SBitRatePlots.root', scandate='noscandate'):
     """
     Analyzes a scan taken with sbitRateScanAllLinks(...) from gempython.vfatqc.utils.scanUtils
-    
+
     Returns a tuple (boolean,dictionary) where the dictionary returned is:
 
         dict_dacValsBelowCutOff[dacName][ohKey][vfat] = value
@@ -1166,6 +1166,15 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
     from gempython.gemplotting.utils.anautilities import getDataPath, getElogPath
     dataPath = getDataPath()
     elogPath = getElogPath()
+
+    # Map TPad to correct vfat
+    from ..mapping.chamberInfo import chamber_vfatPos2PadIdx
+
+    from gempython.gemplotting.utils.anautilities import findInflectionPts
+    from gempython.gemplotting.utils.anautilities import make3x8Canvas
+
+    # Allow for yellow warning color
+    from gempython.utils.gemlogger import printYellow
 
     # Set default histogram behavior
     import ROOT as r
@@ -1209,7 +1218,6 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
         dict_nonzeroVFATs[ohKey] = np.unique(vfatArray[arrayMask]['vfatN'])
 
     if debug:
-        from gempython.utils.gemlogger import printYellow
         printYellow("crateMap:\n{0}".format(crateMap))
         printYellow("dacNameArray:\n{0}".format(dacNameArray))
 
@@ -1239,7 +1247,7 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
     from gempython.utils.nesteddict import nesteddict as ndict
     dict_Rate1DVsDACNameX = ndict() #[dacName][ohKey][vfat] = TGraphErrors
     dict_vfatCHVsDACNameX_Rate2D = ndict() #[dacName][ohKey][vfat] = TGraph2D
-    
+
     # initialize a TGraphErrors and a TF1 for each vfat
     for idx in range(len(dacNameArray)):
         dacName = np.asscalar(dacNameArray[idx])
@@ -1267,12 +1275,12 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
         pass
 
     # create output TFiles
-    outputFiles = {}         
+    outputFiles = {}
     for entry in crateMap:
         ohKey = (entry['shelf'],entry['slot'],entry['link'])
         if scandate == 'noscandate':
             outputFiles[ohKey] = r.TFile(elogPath+"/"+chamber_config[ohKey]+"/"+outfilename,'recreate')
-        else:    
+        else:
             if perchannel:
                 strDirName = getDirByAnaType("sbitRatech", chamber_config[ohKey])
             else:
@@ -1284,7 +1292,7 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
 
     # Loop over events the tree and fill plots
     print("Looping over stored events in rateTree")
-    from math import sqrt 
+    from math import sqrt
     for event in rateTree:
         ohKey = (event.shelf,event.slot,event.link)
         vfat = event.vfatN
@@ -1295,7 +1303,6 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
         #Get the DAC Name in question
         dacName = str(event.nameX.data())
 
-        import os, sys, traceback
         try:
             if event.vfatCH == 128:
                 dict_Rate1DVsDACNameX[dacName][ohKey][vfat].SetPoint(
@@ -1331,7 +1338,10 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
     print("Determine when SBIT rate falls below {0} Hz and writing output data".format(cutOffRate))
     #from array import array
     dict_dacValsBelowCutOff = ndict()
-    from gempython.gemplotting.utils.anautilities import make3x8Canvas
+
+    # make a named dictionary to store inflection pts
+    dict_dacInflectPts = ndict()
+
     for entry in crateMap:
         ohKey = (entry['shelf'],entry['slot'],entry['link'])
         # Per VFAT Poosition
@@ -1343,6 +1353,18 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
 
                 thisDACDir = thisVFATDir.mkdir(dacName)
                 thisDACDir.cd()
+
+                # Get Inflection Points /////////////////////////////////////////////////
+                #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+                # perchannel case is not supported provide warning
+		if perchannel == True :
+                    printYellow("WARNING: perchannel case is not supported for knee finding!   Skipping knee finding" )
+
+                # channelor case
+                if perchannel == False :
+	            dict_dacInflectPts[dacName][ohKey][vfat] = findInflectionPts(dict_Rate1DVsDACNameX[dacName][ohKey][vfat])
+
 
                 dict_dacValsBelowCutOff[dacName][ohKey][vfat] = 255 #default to max
                 for point in range(0,dict_Rate1DVsDACNameX[dacName][ohKey][vfat].GetN()):
@@ -1361,6 +1383,10 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
                     pass
                 pass
             pass
+
+        # Make Graphs /////////////////////////////////////////////////////////////////////////////
+        #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
         for idx in range(len(dacNameArray)):
             dacName = np.asscalar(dacNameArray[idx])
             if perchannel:
@@ -1368,12 +1394,31 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
                 for vfat in range(1,25):
                     canv_Summary2D.cd(vfat).SetLogz()
             else:
-                canv_Summary1D = make3x8Canvas("canv_Summary_Rate1D_vs_{0}".format(dacName),dict_Rate1DVsDACNameX[dacName][ohKey],"APE1")
-                for vfat in range(1,25):
-                    canv_Summary1D.cd(vfat).SetLogy()
-                    dict_Rate1DVsDACNameX[dacName][ohKey][vfat].GetYaxis().SetRangeUser(1e-1,1e8)
-                    canv_Summary1D.cd(vfat).Update()
+                canv_Summary1D = make3x8Canvas("canv_Summary_Rate1D_vs_{0}".format(dacName),dict_Rate1DVsDACNameX[dacName][ohKey],"APE1" )
+                # make 24 TLines
+                kneeLine= []
+                for vfat in range(0,24):
+                    canv_Summary1D.cd(vfat + 1).SetLogy()
 
+                    # make TH1F into TGraph
+                    graph = dict_Rate1DVsDACNameX[dacName][ohKey][vfat]
+                    if type(graph) == r.TH1F :
+                        graph = r.TGraph(graph)
+
+                    # get maximum y value
+                    y = graph.GetY()
+                    y = np.array(y)
+                    ymax = np.amax(y)
+
+                    # Draw a line on the graphs
+                    kneeLine.append(r.TLine(dict_dacInflectPts[dacName][ohKey][vfat][0], 10.0, dict_dacInflectPts[dacName][ohKey][vfat][0], ymax) )
+                    kneeLine[vfat].SetLineColor(2)
+                    kneeLine[vfat].SetVertical()
+                    canv_Summary1D.cd(chamber_vfatPos2PadIdx[vfat] )
+                    kneeLine[vfat].Draw()
+                canv_Summary1D.Update()
+
+            # Save the graphs
             if scandate == 'noscandate':
                 if perchannel:
                     canv_Summary2D.SaveAs("{0}/{1}/{2}_{1}.png".format(elogPath,chamber_config[ohKey],canv_Summary2D.GetName()))

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -433,7 +433,6 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     # Do we return analyzed TTree?
     from multiprocessing import current_process
     if (current_process().name == 'MainProcess'):
-        return
         return thrAnaTree
     else:
         # multiprocessing cannot handle the thrAnaTree object to be passed back

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -1169,6 +1169,7 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
 
     # Map TPad to correct vfat
     from ..mapping.chamberInfo import chamber_vfatPos2PadIdx
+    from tabulate import tabulate
 
     from gempython.gemplotting.utils.anautilities import findInflectionPts
     from gempython.gemplotting.utils.anautilities import make3x8Canvas
@@ -1341,6 +1342,7 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
 
     # make a named dictionary to store inflection pts
     dict_dacInflectPts = ndict()
+    inflectTable = []
 
     for entry in crateMap:
         ohKey = (entry['shelf'],entry['slot'],entry['link'])
@@ -1364,7 +1366,7 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
                 # channelor case
                 if perchannel == False :
 	            dict_dacInflectPts[dacName][ohKey][vfat] = findInflectionPts(dict_Rate1DVsDACNameX[dacName][ohKey][vfat])
-
+                    inflectTable.append([ohKey, vfat, dict_dacInflectPts[dacName][ohKey][vfat][0][0] ])
 
                 dict_dacValsBelowCutOff[dacName][ohKey][vfat] = 255 #default to max
                 for point in range(0,dict_Rate1DVsDACNameX[dacName][ohKey][vfat].GetN()):
@@ -1383,6 +1385,11 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
                     pass
                 pass
             pass
+
+        # print points in a table
+        print(tabulate(inflectTable, headers = ['Geo Addr', 'VFAT Number', 'ARM DAC Inflection Pt'], tablefmt='orgtbl') )
+        inflectTableFile = file("{0}/{1}/inflectionPointTable.txt".format(elogPath,chamber_config[ohKey],scandate), "w")
+        inflectTableFile.write(tabulate(inflectTable, headers = ['Geo Addr', 'VFAT Number', 'ARM DAC Inflection Pt'], tablefmt='orgtbl') )
 
         # Make Graphs /////////////////////////////////////////////////////////////////////////////
         #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -1387,9 +1387,10 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
             pass
 
         # print points in a table
-        print(tabulate(inflectTable, headers = ['Geo Addr', 'VFAT Number', 'ARM DAC Inflection Pt'], tablefmt='orgtbl') )
-        inflectTableFile = file("{0}/{1}/inflectionPointTable.txt".format(elogPath,chamber_config[ohKey],scandate), "w")
-        inflectTableFile.write(tabulate(inflectTable, headers = ['Geo Addr', 'VFAT Number', 'ARM DAC Inflection Pt'], tablefmt='orgtbl') )
+        if perchannel == False:
+            print(tabulate(inflectTable, headers = ['Geo Addr', 'VFAT Number', 'ARM DAC Inflection Pt'], tablefmt='orgtbl') )
+            inflectTableFile = file("{0}/{1}/inflectionPointTable.txt".format(elogPath,chamber_config[ohKey],scandate), "w")
+            inflectTableFile.write(tabulate(inflectTable, headers = ['Geo Addr', 'VFAT Number', 'ARM DAC Inflection Pt'], tablefmt='orgtbl') )
 
         # Make Graphs /////////////////////////////////////////////////////////////////////////////
         #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -1244,6 +1244,7 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
             pass
         pass
 
+
     # make nested dictionaries
     from gempython.utils.nesteddict import nesteddict as ndict
     dict_Rate1DVsDACNameX = ndict() #[dacName][ohKey][vfat] = TGraphErrors
@@ -1342,10 +1343,11 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
 
     # make a named dictionary to store inflection pts
     dict_dacInflectPts = ndict()
-    inflectTable = []
 
     for entry in crateMap:
         ohKey = (entry['shelf'],entry['slot'],entry['link'])
+        # clear the inflection point table for each new link
+        inflectTable = []
         # Per VFAT Poosition
         for vfat in range(0,24):
             thisVFATDir = outputFiles[ohKey].mkdir("VFAT{0}".format(vfat))
@@ -1386,11 +1388,15 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
                 pass
             pass
 
-        # print points in a table
+        # put inflection points in a table for each different ohKey 
         if perchannel == False:
             print(tabulate(inflectTable, headers = ['Geo Addr', 'VFAT Number', 'ARM DAC Inflection Pt'], tablefmt='orgtbl') )
-            inflectTableFile = file("{0}/{1}/inflectionPointTable.txt".format(elogPath,chamber_config[ohKey],scandate), "w")
-            inflectTableFile.write(tabulate(inflectTable, headers = ['Geo Addr', 'VFAT Number', 'ARM DAC Inflection Pt'], tablefmt='orgtbl') )
+            if scandate == 'noscandate':
+                inflectTableFile = file("{0}/{1}/inflectionPointTable.txt".format(elogPath,chamber_config[ohKey]), "w")
+                inflectTableFile.write(tabulate(inflectTable, headers = ['Geo Addr', 'VFAT Number', 'ARM DAC Inflection Pt'], tablefmt='orgtbl') )
+            else: 
+                inflectTableFile = file("{0}/{1}/inflectionPointTable.txt".format(strDirName,scandate ), "w")
+                inflectTableFile.write(tabulate(inflectTable, headers = ['Geo Addr', 'VFAT Number', 'ARM DAC Inflection Pt'], tablefmt='orgtbl') )
 
         # Make Graphs /////////////////////////////////////////////////////////////////////////////
         #++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
This new feature finds the inflection point (knee) in the SBit rate scan and marks this point with a vertical line on the SBit rate scan graph. But this functionality is only available for the channelor case.

## Description
I created a new function, findInflectionPoint, and altered the sbitRateAnalysis function in `utils/anautilities.py`. The new function uses `numpy.gradient` along with some loops to find the inflection point. The altered sbitRateAnalysis draws a line in the sbit graph at the inflection point location. These changes are for the channelor case only.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
We wanted to find the inflection point.

## How Has This Been Tested?
I used a python virtual environment on my account on gem904daq01. The code was tested using sbit rate data for the channelor case.

### Screenshots (if appropriate):

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
