### PR TITLE
Apply scurve quality masks in ARM DAC calibration

### DIFF
--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -8,8 +8,8 @@ anaUltraScurve
 if __name__ == '__main__':
     # Define the parser
     import argparse
-    from gempython.gemplotting.utils.anaoptions import parent_parser
-    parser = argparse.ArgumentParser(description="Options to give to anaUltraScurve.py", parents=[parent_parser])
+    from gempython.gemplotting.utils.anaoptions import parent_parser, parser_scurveChanMasks
+    parser = argparse.ArgumentParser(description="Options to give to anaUltraScurve.py", parents=[parent_parser,parser_scurveChanMasks])
     
     # Positional arguments
     parser.add_argument("GEBtype",type=str,help="Specify GEB type, options are 'long,short,m1,...,m8', if analyzing data from an ME0 detector write 'null'")
@@ -23,18 +23,6 @@ if __name__ == '__main__':
     parser.add_argument("--isVFAT2", action="store_true", help="Provide this argument if input data was acquired from vfat2")
     parser.add_argument("-v", "--vfatList", type=str, default=None, help="Comma separated list of VFAT positions to consider for analysis.  If not provided default will be all positions")
     parser.add_argument("-z", "--zscore", type=float, default=3.5, help="Z-Score for Outlier Identification in MAD Algo")
-
-    chanMaskGroup = parser.add_argument_group(
-            title="Options for channel mask decisions", 
-            description="Parameters which specify how Dead, Noisy, and High Pedestal Channels are charaterized")
-    chanMaskGroup.add_argument("--maxEffPedPercent", type=float, default=0.02,
-                      help="Percentage, Threshold for setting the HighEffPed mask reason, if channel (effPed > maxEffPedPercent * nevts) then HighEffPed is set")
-    chanMaskGroup.add_argument("--highNoiseCut", type=float, default=1.5,
-            help="Threshold for setting the HighNoise maskReason, if channel (scurve_sigma > highNoiseCut) then HighNoise is set")
-    chanMaskGroup.add_argument("--deadChanCutLow", type=float, default=None,
-                      help="If channel (deadChanCutLow < scurve_sigma < deadChanCutHigh) then DeadChannel is set")
-    chanMaskGroup.add_argument("--deadChanCutHigh", type=float, default=None,
-                      help="If channel (deadChanCutHigh < scurve_sigma < deadChanCutHigh) then DeadChannel is set")
 
     from gempython.gemplotting.utils.scurveAlgos import anaUltraScurve 
     parser.set_defaults(func=anaUltraScurve, outfilename="SCurveFitData.root")

--- a/ana_scans.py
+++ b/ana_scans.py
@@ -833,15 +833,6 @@ if __name__ == '__main__':
     cpuUsagee.add_argument("--light", action="store_true", help="Analysis uses only 25%% of available cores")
     cpuUsagee.add_argument("--medium", action="store_true", help="Analysis uses only 50%% of available cores")
     cpuUsagee.add_argument("--heavy", action="store_true", help="Analysis uses only 75%% of available cores")
-    
-    # create the parent parser for channel masks for scurve analysis
-    parser_scurveChanMasks = argparse.ArgumentParser(add_help = False)
-
-    chanMaskGroup = parser_scurveChanMasks.add_argument_group(title="Options for channel mask decisions", description="Parameters which specify how Dead, Noisy, and High Pedestal Channels are charaterized")
-    chanMaskGroup.add_argument("--maxEffPedPercent", type=float, default=0.02, help="Percentage, threshold for setting the HighEffPed mask reason, if channel (effPed > maxEffPedPercent * nevts) then HighEffPed is set")
-    chanMaskGroup.add_argument("--highNoiseCut", type=float, default=1.5, help="Threshold in fC for setting the HighNoise maskReason, if channel (scurve_sigma > highNoiseCut) then HighNoise is set")
-    chanMaskGroup.add_argument("--deadChanCutLow", type=float, default=0,help="If channel (deadChanCutLow < scurve_sigma < deadChanCutHigh) then DeadChannel is set")
-    chanMaskGroup.add_argument("--deadChanCutHigh", type=float, default=0, help="If channel (deadChanCutHigh < scurve_sigma < deadChanCutHigh) then DeadChannel is set")
 
     # create the parent parser for making output plots w.r.t ASIC channel or panasonic connector pin
     parser_stripChanOrPinType = argparse.ArgumentParser(add_help = False)
@@ -853,6 +844,8 @@ if __name__ == '__main__':
     parser_zscore = argparse.ArgumentParser(add_help = False)
     parser_zscore.add_argument("-z","--zscore", type=float, default=10,help="Z-Score for Outlier Identification in MAD Algo, used to set HotChannel bit")
 
+    from gempython.gemplotting.utils.anaoptions import parser_scurveChanMasks
+    
     # List of parent parsers specifically scurce analysis
     listOfParentParsers4Scurves = [parser_fileAndConfig, parser_parallelAna, parser_scurveChanMasks, parser_stripChanOrPinType, parser_zscore]
 

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -302,11 +302,11 @@ class ScanDataFitter(DeadChannelFinder):
                     if self.isVFAT3:
                         fitTF1.SetParLimits(0, self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat], self.calDAC2Q_m[vfat]*(1)+self.calDAC2Q_b[vfat])
                         fitTF1.SetParLimits(1, 0.0, self.calDAC2Q_m[vfat]*(128)+self.calDAC2Q_b[vfat])
-                        fitTF1.SetParLimits(2, -0.01, self.Nev[vfat][ch])
+                        fitTF1.SetParLimits(2, -0.01, self.calDAC2Q_m[vfat]*(1)+self.calDAC2Q_b[vfat])
                     else:
                         fitTF1.SetParLimits(0, -0.01, self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat])
                         fitTF1.SetParLimits(1, 0.0,  self.calDAC2Q_m[vfat]*(128)+self.calDAC2Q_b[vfat])
-                        fitTF1.SetParLimits(2, -0.01, self.Nev[vfat][ch])
+                        fitTF1.SetParLimits(2, -0.01, self.calDAC2Q_m[vfat]*(256)+self.calDAC2Q_b[vfat])
                         pass
 
                     fitTF1.SetParLimits(3, 0.75*init_guess_p3, 1.25*init_guess_p3)

--- a/macros/calibrateThrDac.py
+++ b/macros/calibrateThrDac.py
@@ -85,9 +85,7 @@ if __name__ == '__main__':
     import argparse
     from gempython.gemplotting.utils.anaoptions import parser_scurveChanMasks
     parser = argparse.ArgumentParser(description='Arguments to supply to calibrateThrDac.py',parents=[parser_scurveChanMasks])
-    parser.add_argument("filename", type=str, dest="inputFile",
-            help="Tab delimited file specifying the input list of scandates, in three column format, specifying chamberName, scandate, and either CFG_THR_ARM_DAC or CFG_THR_ZCC_DAC value")
-
+    parser.add_argument("inputFile", type=str, help="Tab delimited file specifying the input list of scandates, in three column format, specifying chamberName, scandate, and either CFG_THR_ARM_DAC or CFG_THR_ZCC_DAC value")
     parser.add_argument("-d","--debug", action="store_true", help="Prints additional debugging information")
     parser.add_argument("--fitRange", type=str, default="0,255", 
             help="Two comma separated integers which specify the range of 'CFG_THR_*_DAC' to use in fitting when deriving the calibration curve")
@@ -104,8 +102,8 @@ if __name__ == '__main__':
     envCheck('ELOG_PATH')
 
     # Determine outputDir
-    if "/" in args.filename:
-        outputDir = args.filename[0:args.filename.rfind("/")+1]
+    if "/" in args.inputFile:
+        outputDir = args.inputFile[0:args.inputFile.rfind("/")+1]
     else:
         from gempython.gemplotting.utils.anautilities import getElogPath
         outputDir = getElogPath()

--- a/macros/calibrateThrDac.py
+++ b/macros/calibrateThrDac.py
@@ -112,7 +112,6 @@ if __name__ == '__main__':
     from gempython.gemplotting.utils.threshAlgos import calibrateThrDAC
     from gempython.utils.gemlogger import printGreen, printRed
     from gempython.utils.wrappers import runCommand
-    from gempython.gemplotting.utils.namespace import Namespace
     import os, sys, traceback
     try:
         args.outputDir = outputDir

--- a/macros/calibrateThrDac.py
+++ b/macros/calibrateThrDac.py
@@ -93,7 +93,7 @@ if __name__ == '__main__':
             help="Two comma separated integers which specify the range of 'CFG_THR_*_DAC' to use in fitting when deriving the calibration curve")
     parser.add_argument("--listOfVFATs", type=str, default=None,
             help="If provided the VFATID will be taken from this file rather than scurveTree.  Tab delimited file, first line is a column header, subsequent lines specify respectively VFAT position and VFAT serial number.  Lines beginning with the '#' character will be skipped")
-    parser.add_argument("--numOfGoodChannelsMin", type=int, default=10, help="Minimum number of channels that must be good (unmasked) for an armDacVal point to be use in the calibration procedure.")
+    parser.add_argument("--numOfGoodChansMin", type=int, default=10, help="Minimum number of channels that must be good (unmasked) for an armDacVal point to be use in the calibration procedure.")
     parser.add_argument("--noLeg", action="store_true", help="Do not draw a TLegend on the output plots")
     parser.add_argument("--savePlots", action="store_true", help="Make *.png file for all plots that will be saved in the output TFile")
     args = parser.parse_args()

--- a/macros/calibrateThrDac.py
+++ b/macros/calibrateThrDac.py
@@ -93,6 +93,7 @@ if __name__ == '__main__':
             help="Two comma separated integers which specify the range of 'CFG_THR_*_DAC' to use in fitting when deriving the calibration curve")
     parser.add_argument("--listOfVFATs", type=str, default=None,
             help="If provided the VFATID will be taken from this file rather than scurveTree.  Tab delimited file, first line is a column header, subsequent lines specify respectively VFAT position and VFAT serial number.  Lines beginning with the '#' character will be skipped")
+    parser.add_argument("--numOfGoodChannelsMin", type=int, default=10, help="Minimum number of channels that must be good (unmasked) for an armDacVal point to be use in the calibration procedure.")
     parser.add_argument("--noLeg", action="store_true", help="Do not draw a TLegend on the output plots")
     parser.add_argument("--savePlots", action="store_true", help="Make *.png file for all plots that will be saved in the output TFile")
     args = parser.parse_args()

--- a/macros/calibrateThrDac.py
+++ b/macros/calibrateThrDac.py
@@ -85,7 +85,7 @@ if __name__ == '__main__':
     import argparse
     from gempython.gemplotting.utils.anaoptions import parser_scurveChanMasks
     parser = argparse.ArgumentParser(description='Arguments to supply to calibrateThrDac.py',parents=[parser_scurveChanMasks])
-    parser.add_argument("filename", type=str, 
+    parser.add_argument("filename", type=str, dest="inputFile",
             help="Tab delimited file specifying the input list of scandates, in three column format, specifying chamberName, scandate, and either CFG_THR_ARM_DAC or CFG_THR_ZCC_DAC value")
 
     parser.add_argument("-d","--debug", action="store_true", help="Prints additional debugging information")
@@ -116,23 +116,9 @@ if __name__ == '__main__':
     from gempython.gemplotting.utils.namespace import Namespace
     import os, sys, traceback
     try:
-
-        args = Namespace(
-            inputFile=args.filename,
-            fitRange=args.fitRange,
-            listOfVFATs=args.listOfVFATs,
-            maxEffPedPercent=args.maxEffPedPercent,
-            highNoiseCut=args.highNoiseCut,
-            deadChanCutLow=args.deadChanCutLow,
-            deadChanCutHigh=args.deadChanCutHigh,
-            noLeg=args.noLeg,
-            outputDir=outputDir,
-            savePlots=args.savePlots,
-            debug=args.debug
-        )
+        args.outputDir = outputDir
 
         retCode = calibrateThrDAC(args)
-
     except IOError as err:
         printRed("IOError: {0}".format(err.message))
         printRed("Analysis failed with error code {0}".format(retCode))

--- a/macros/calibrateThrDac.py
+++ b/macros/calibrateThrDac.py
@@ -83,7 +83,8 @@ Internals
 if __name__ == '__main__':
     # create the parser
     import argparse
-    parser = argparse.ArgumentParser(description='Arguments to supply to calibrateThrDac.py')
+    from gempython.gemplotting.utils.anaoptions import parser_scurveChanMasks
+    parser = argparse.ArgumentParser(description='Arguments to supply to calibrateThrDac.py',parents=[parser_scurveChanMasks])
     parser.add_argument("filename", type=str, 
             help="Tab delimited file specifying the input list of scandates, in three column format, specifying chamberName, scandate, and either CFG_THR_ARM_DAC or CFG_THR_ZCC_DAC value")
 
@@ -112,16 +113,26 @@ if __name__ == '__main__':
     from gempython.gemplotting.utils.threshAlgos import calibrateThrDAC
     from gempython.utils.gemlogger import printGreen, printRed
     from gempython.utils.wrappers import runCommand
+    from gempython.gemplotting.utils.namespace import Namespace
     import os, sys, traceback
     try:
-        retCode = calibrateThrDAC(
-                inputFile=args.filename,
-                fitRange=args.fitRange,
-                listOfVFATs=args.listOfVFATs,
-                noLeg=args.noLeg,
-                outputDir=outputDir,
-                savePlots=args.savePlots,
-                debug=args.debug)
+
+        args = Namespace(
+            inputFile=args.filename,
+            fitRange=args.fitRange,
+            listOfVFATs=args.listOfVFATs,
+            maxEffPedPercent=args.maxEffPedPercent,
+            highNoiseCut=args.highNoiseCut,
+            deadChanCutLow=args.deadChanCutLow,
+            deadChanCutHigh=args.deadChanCutHigh,
+            noLeg=args.noLeg,
+            outputDir=outputDir,
+            savePlots=args.savePlots,
+            debug=args.debug
+        )
+
+        retCode = calibrateThrDAC(args)
+
     except IOError as err:
         printRed("IOError: {0}".format(err.message))
         printRed("Analysis failed with error code {0}".format(retCode))

--- a/macros/calibrateThrDac.py
+++ b/macros/calibrateThrDac.py
@@ -113,9 +113,8 @@ if __name__ == '__main__':
     from gempython.utils.gemlogger import printGreen, printRed
     from gempython.utils.wrappers import runCommand
     import os, sys, traceback
+    args.outputDir = outputDir
     try:
-        args.outputDir = outputDir
-
         retCode = calibrateThrDAC(args)
     except IOError as err:
         printRed("IOError: {0}".format(err.message))

--- a/utils/anaInfo.py
+++ b/utils/anaInfo.py
@@ -16,6 +16,7 @@ import string
 #: The CFG_THR_ARM_DAC calibration routine involves performing a fit of scurveMean vs CFG_THR_ARM_DAC in which some points with bad quality, defined by the parameters below, are removed
 scurveMeanMin = 0.1 #: points are removed if they satisfy scurveMean < scurveMeanMin
 scurveMeanFracErrMin = 0.001 #: points are removed if they satisfy scurveMeanError/scurveMean < scurveFracErrMin
+numOfGoodChannelsMin = 10 #: minimum number of good channels scurveMean points are required to have
 
 #: The default values for the cuts that determine the scurve fit quality masks
 maxEffPedPercentDefault=0.02

--- a/utils/anaInfo.py
+++ b/utils/anaInfo.py
@@ -17,6 +17,12 @@ import string
 scurveMeanMin = 0.1 #: points are removed if they satisfy scurveMean < scurveMeanMin
 scurveMeanFracErrMin = 0.001 #: points are removed if they satisfy scurveMeanError/scurveMean < scurveFracErrMin
 
+#: The default values for the cuts that determine the scurve fit quality masks
+maxEffPedPercentDefault=0.02
+highNoiseCutDefault=1.5
+deadChanCutLowDefault=0
+deadChanCutHighDefault=0
+
 #: Nominal current and voltage values from Tables 9 and 10 of the VFAT3 manual
 #: The registers CFG_THR_ARM_DAC CFG_THR_ZCC_DAC may correspond to either a voltage or a current. Below I have used the voltage. Be careful if you have taken a current scan with these registers (dacSelect options 14 or 15).
 nominalDacValues = {

--- a/utils/anaInfo.py
+++ b/utils/anaInfo.py
@@ -16,7 +16,7 @@ import string
 #: The CFG_THR_ARM_DAC calibration routine involves performing a fit of scurveMean vs CFG_THR_ARM_DAC in which some points with bad quality, defined by the parameters below, are removed
 scurveMeanMin = 0.1 #: points are removed if they satisfy scurveMean < scurveMeanMin
 scurveMeanFracErrMin = 0.001 #: points are removed if they satisfy scurveMeanError/scurveMean < scurveFracErrMin
-numOfGoodChannelsMin = 10 #: minimum number of good channels scurveMean points are required to have
+numOfGoodChansMinDefault = 10 #: default value of: minimum number of good channels scurveMean points are required to have
 
 #: The default values for the cuts that determine the scurve fit quality masks
 maxEffPedPercentDefault=0.02

--- a/utils/anaoptions.py
+++ b/utils/anaoptions.py
@@ -23,3 +23,13 @@ parent_parser.add_argument("-o", "--outfilename", type=str, help="Specify Output
 stripChanOrPinType = parent_parser.add_mutually_exclusive_group(required=False)
 stripChanOrPinType.add_argument("-c","--channels", action="store_true", help="Make plots vs channels instead of strips")
 stripChanOrPinType.add_argument("-p","--panasonic", action="store_true", dest="PanPin",help="Make plots vs Panasonic pins instead of strips")
+
+parser_scurveChanMasks = argparse.ArgumentParser(add_help = False)	
+
+from anaInfo import maxEffPedPercentDefault,highNoiseCutDefault,deadChanCutLowDefault,deadChanCutHighDefault
+
+chanMaskGroup = parser_scurveChanMasks.add_argument_group(title="Options for channel mask decisions", description="Parameters which specify how Dead, Noisy, and High Pedestal Channels are charaterized")
+chanMaskGroup.add_argument("--maxEffPedPercent", type=float, default=maxEffPedPercentDefault, help="Percentage, threshold for setting the HighEffPed mask reason, if channel (effPed > maxEffPedPercent * nevts) then HighEffPed is set")
+chanMaskGroup.add_argument("--highNoiseCut", type=float, default=highNoiseCutDefault, help="Threshold in fC for setting the HighNoise maskReason, if channel (scurve_sigma > highNoiseCut) then HighNoise is set")
+chanMaskGroup.add_argument("--deadChanCutLow", type=float, default=deadChanCutLowDefault,help="If channel (deadChanCutLow < scurve_sigma < deadChanCutHigh) then DeadChannel is set")
+chanMaskGroup.add_argument("--deadChanCutHigh", type=float, default=deadChanCutHighDefault, help="If channel (deadChanCutHigh < scurve_sigma < deadChanCutHigh) then DeadChannel is set")

--- a/utils/namespace.py
+++ b/utils/namespace.py
@@ -1,0 +1,3 @@
+class Namespace:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)

--- a/utils/namespace.py
+++ b/utils/namespace.py
@@ -1,3 +1,0 @@
-class Namespace:
-    def __init__(self, **kwargs):
-        self.__dict__.update(kwargs)

--- a/utils/scurveAlgos.py
+++ b/utils/scurveAlgos.py
@@ -564,7 +564,8 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
                 Nhigh[0] = int(scanFitResults[4][vfat][chan])
                 noise[0] = scanFitResults[1][vfat][chan]
                 panPin[0] = dict_vfatChanLUT[vfat]["PanPin"][chan]
-                ped_eff[0] = effectivePedestals[vfat][chan]
+                if chan in fitter.Nev[vfat].keys():
+                    ped_eff[0] = effectivePedestals[vfat][chan]/fitter.Nev[vfat][chan]
                 pedestal[0] = scanFitResults[2][vfat][chan]
                 ROBstr[0] = dict_vfatChanLUT[vfat]["Strip"][chan]
                 threshold[0] = scanFitResults[0][vfat][chan]

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -706,7 +706,6 @@ def calibrateThrDAC(args):
                 
             #fill histograms with the scurve means and the scurve sigmas that pass the quality cuts
             #leave TH1Fs and TGraphs empty for ARM DAC points with too few unmasked channels
-            from gempython.gemplotting.utils.anaInfo import args.numOfGoodChansMin
             if len(scurveFitDataThisVfat) >= args.numOfGoodChansMin:
                 for idy in range(0,len(scurveFitDataThisVfat)):
                     scurveMean = scurveFitDataThisVfat[idy]['threshold']

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -452,7 +452,7 @@ def calibrateThrDACStar(inputs):
     """
     return calibrateThrDAC(*inputs)
 
-from anaInfo import maxEffPedPercentDefault, highNoiseCutDefault, deadChanCutLowDefault, deadChanCutHighDefault
+from anaInfo import maxEffPedPercentDefault, highNoiseCutDefault, deadChanCutLowDefault, deadChanCutHighDefault, numOfGoodChannelsMinDefault 
 
 def calibrateThrDAC(args):
     """
@@ -487,6 +487,9 @@ def calibrateThrDAC(args):
     if not hasattr(args,"listofVFATs"):
         args.listOfVFATs = None
 
+    if not hasattr(args,"numOfGoodChannelsMin"):
+        args.numOfGoodChannelsMin=numOfGoodChannelsMinDefault 
+        
     if not hasattr(args,"maxEffPedPercent"):
         args.maxEffPedPercent=maxEffPedPercentDefault
 
@@ -695,8 +698,8 @@ def calibrateThrDAC(args):
                 
             #fill histograms with the scurve means and the scurve sigmas that pass the quality cuts
             #leave TH1Fs and TGraphs empty for ARM DAC points with too few unmasked channels
-            from gempython.gemplotting.utils.anaInfo import numOfGoodChannelsMin
-            if len(scurveFitDataThisVfat) >= numOfGoodChannelsMin:
+            from gempython.gemplotting.utils.anaInfo import args.numOfGoodChannelsMin
+            if len(scurveFitDataThisVfat) >= args.numOfGoodChannelsMin:
                 for idy in range(0,len(scurveFitDataThisVfat)):
                     scurveMean = scurveFitDataThisVfat[idy]['threshold']
                     scurveSigma = scurveFitDataThisVfat[idy]['noise']

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -619,11 +619,12 @@ def calibrateThrDAC(args):
         list_bNames = ['noise', 'threshold', 'vfatN', 'vthr', 'ped_eff']
         scurveFitData = rp.tree2array(tree=scanFile.scurveFitTree, branches=list_bNames)
 
-        #remove channels that are masked and those for which the noise or the threshold equal the initial value
-        #also, following what is done in the scurve analysis script, we remove scurve fits in which either of these parameters are 0
+        #remove channels that fail quality cuts
         scurveFitMask1 = np.logical_or(scurveFitData['noise'] < args.deadChanCutLow,scurveFitData['noise'] > args.deadChanCutHigh)
         scurveFitMask2 = scurveFitData['noise'] < args.highNoiseCut
         scurveFitMask3 = scurveFitData['ped_eff'] < args.maxEffPedPercent
+        #following what is done in the scurve analysis script, 
+        #we also remove scurve fits in which the noise or the threshold are equal to their initial values
         scurveFitMask4 = np.logical_and(scurveFitData['noise'] != 0,scurveFitData['threshold'] != 0)
 
         for vfat in range(-1,24):

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -452,26 +452,34 @@ def calibrateThrDACStar(inputs):
     """
     return calibrateThrDAC(*inputs)
 
-from anaInfo import maxEffPedPercentDefault, highNoiseCutDefault, deadChanCutLowDefault, deadChanCutHighDefault, numOfGoodChannelsMinDefault 
+from anaInfo import maxEffPedPercentDefault, highNoiseCutDefault, deadChanCutLowDefault, deadChanCutHighDefault, numOfGoodChansMinDefault 
 
 def calibrateThrDAC(args):
     """
     Calibrates CFG_THR_X_DAC, for X = {ARM,ZCC}, in terms of charge units from a series of scurve measurements.
 
     Returns either 0 or an error code, see: https://docs.python.org/2/library/os.html#process-management
-    
-        inputFile     - Filename of a file in the "Three Column Format," see parseListOfScanDatesFile from
-                        gempython.gemplotting.utils.anautilities, where each entry after the column header
-                        is an analyzed scurve file taken at a different CFG_THR_X_DAC for a (shelf,slot,link).
-        fitRange      - Two comma separated integers which specify the range of 'CFG_THR_*_DAC' to use in 
-                        fitting when deriving the calibration curve.
-        listOfVFATs   - If provided vfatID will be taken from this file rather than scurveFitTree in input
-                        analyzed scurve files defined in inputFile.  This is a tab delimited file, first line
-                        is a column header, subsequent lines specifying respectively VFAT position and chipID.
-                        Lines beginning with the "#" character will be skipped.
-        noLeg         - Do not draw a TLegend on the output plots.
-        outputDir     - String specifying location of output files, if None then $ELOG_PATH will be used
-        savePlots     - Make a '*.png' file for all plots that will be saved in the output TFile
+
+    The single argument "args" is intended to be a namespace which has attributes among those listed below.  
+
+        inputFile         - Filename of a file in the "Three Column Format," see parseListOfScanDatesFile from
+                                 gempython.gemplotting.utils.anautilities, where each entry after the column header
+                                 is an analyzed scurve file taken at a different CFG_THR_X_DAC for a (shelf,slot,link).
+        fitRange          - Two comma separated integers which specify the range of 'CFG_THR_*_DAC' to use in 
+                                 fitting when deriving the calibration curve.
+        listOfVFATs       - If provided vfatID will be taken from this file rather than scurveFitTree in input
+                                 analyzed scurve files defined in inputFile.  This is a tab delimited file, first line
+                                 is a column header, subsequent lines specifying respectively VFAT position and chipID.
+                                 Lines beginning with the "#" character will be skipped.
+        noLeg             - Do not draw a TLegend on the output plots.
+        outputDir         - String specifying location of output files, if None then $ELOG_PATH will be used
+        savePlots         - Make a '*.png' file for all plots that will be saved in the output TFile
+        numOfGoodChansMin - If the number of good channels associated with an armDacVal point is less than numOfGoodChansMin, 
+                                then that armDacVal point is not used. This is criterion is applied separately for each VFAT.
+        maxEffPedPercent  - If channel effPed > maxEffPedPercent, then the channel is marked as bad. 
+        highNoiseCut      - If scurve_sigma > highNoiseCut, then the channel is marked as bad.
+        deadChanCutLow    - If deadChanCutLow < scurve_sigma < deadChanCutHigh, then the channel is marked as bad.
+        deadChanHighLow   - If deadChanCutLow < scurve_sigma < deadChanCutHigh, then the channel is marked as bad.
     """
 
     if not hasattr(args,"inputFile"):
@@ -487,8 +495,8 @@ def calibrateThrDAC(args):
     if not hasattr(args,"listofVFATs"):
         args.listOfVFATs = None
 
-    if not hasattr(args,"numOfGoodChannelsMin"):
-        args.numOfGoodChannelsMin=numOfGoodChannelsMinDefault 
+    if not hasattr(args,"numOfGoodChansMin"):
+        args.numOfGoodChansMin=numOfGoodChansMinDefault 
         
     if not hasattr(args,"maxEffPedPercent"):
         args.maxEffPedPercent=maxEffPedPercentDefault
@@ -698,8 +706,8 @@ def calibrateThrDAC(args):
                 
             #fill histograms with the scurve means and the scurve sigmas that pass the quality cuts
             #leave TH1Fs and TGraphs empty for ARM DAC points with too few unmasked channels
-            from gempython.gemplotting.utils.anaInfo import args.numOfGoodChannelsMin
-            if len(scurveFitDataThisVfat) >= args.numOfGoodChannelsMin:
+            from gempython.gemplotting.utils.anaInfo import args.numOfGoodChansMin
+            if len(scurveFitDataThisVfat) >= args.numOfGoodChansMin:
                 for idy in range(0,len(scurveFitDataThisVfat)):
                     scurveMean = scurveFitDataThisVfat[idy]['threshold']
                     scurveSigma = scurveFitDataThisVfat[idy]['noise']

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -477,9 +477,11 @@ def calibrateThrDAC(args):
     if not hasattr(args,"inputFile"):
         print("No inputFile provided to calibrateThrDac")
         sys.exit(1)
-        
+
     if not hasattr(args,"fitRange"):
-        args.fitRange = "0,255"
+        args.fitRange = [0, 255]
+    else:
+        args.fitRange = [int(item) for item in args.fitRange.split(",")]        
 
     if not hasattr(args,"listofVFATs"):
         args.listOfVFATs = None
@@ -858,7 +860,6 @@ def calibrateThrDAC(args):
     if args.debug:
         print("| vfatN | coef4 | coef3 | coef2 | coef1 | coef0 | noise | noise_err |")
         print("| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :-------: |")
-    args.fitRange = [int(item) for item in args.fitRange.split(",")]
     for vfat in range(-1,24):
         if vfat == -1:
             suffix = "All"

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -484,8 +484,8 @@ def calibrateThrDAC(args):
 
     if not hasattr(args,"inputFile"):
         print("No inputFile provided to calibrateThrDac")
-        import sys, os
-        sys.exit(os.EX_NOINPUT)
+        import os
+        exit(os.EX_NOINPUT)
 
     if not hasattr(args,"fitRange"):
         args.fitRange = [0, 255]

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -476,7 +476,8 @@ def calibrateThrDAC(args):
 
     if not hasattr(args,"inputFile"):
         print("No inputFile provided to calibrateThrDac")
-        sys.exit(1)
+        import sys, os
+        sys.exit(os.EX_NOINPUT)
 
     if not hasattr(args,"fitRange"):
         args.fitRange = [0, 255]

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -1077,8 +1077,11 @@ def calibrateThrDAC(args):
         for infoTuple in listChamberAndScanDate:
             if vfat not in dict_nBadChannels or infoTuple[2] not in dict_nBadChannels[vfat]:
                 continue
-            print '| %i | %i | %i | %i | %i | %i |'%(
-                vfat,
+            vfatnOrAll = str(vfat)
+            if vfatnOrAll == "-1":
+                vfatnOrAll = "All"
+            print '| %s | %i | %i | %i | %i | %i |'%(
+                vfatnOrAll,
                 infoTuple[2],
                 dict_nBadChannels[vfat][infoTuple[2]]["DeadChannel"],
                 dict_nBadChannels[vfat][infoTuple[2]]["HighNoise"],

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -452,7 +452,9 @@ def calibrateThrDACStar(inputs):
     """
     return calibrateThrDAC(*inputs)
 
-def calibrateThrDAC(inputFile,fitRange="0,255",listOfVFATs=None,noLeg=False,outputDir=None,savePlots=False,debug=False):
+from anaInfo import maxEffPedPercentDefault, highNoiseCutDefault, deadChanCutLowDefault, deadChanCutHighDefault
+
+def calibrateThrDAC(args):
     """
     Calibrates CFG_THR_X_DAC, for X = {ARM,ZCC}, in terms of charge units from a series of scurve measurements.
 
@@ -472,22 +474,52 @@ def calibrateThrDAC(inputFile,fitRange="0,255",listOfVFATs=None,noLeg=False,outp
         savePlots     - Make a '*.png' file for all plots that will be saved in the output TFile
     """
 
+    if not hasattr(args,"inputFile"):
+        print("No inputFile provided to calibrateThrDac")
+        sys.exit(1)
+        
+    if not hasattr(args,"fitRange"):
+        args.fitRange = "0,255"
+
+    if not hasattr(args,"listofVFATs"):
+        args.listOfVFATs = None
+
+    if not hasattr(args,"maxEffPedPercent"):
+        args.maxEffPedPercent=maxEffPedPercentDefault
+
+    if not hasattr(args,"highNoiseCut"):
+        args.highNoiseCut=HighNoiseCutDefault
+
+    if not hasattr(args,"deadChanCutLow"):
+        args.deadChanCutLow=deadChanCutLowDefault
+
+    if not hasattr(args,"deadChanCutHigh"):
+        args.deadChanCutHigh=deadChanCutHighDefault
+
+    if not hasattr(args,"noLeg"):
+        args.noLeg=False
+
+    if not hasattr(args,"outputDir"):
+        from gempython.gemplotting.utils.anautilities import getElogPath
+        args.outputDir = getElogPath()
+
+    if not hasattr(args,"savePlots"):
+        args.savePlots=False
+
+    if not hasattr(args,"debug"):
+        args.debug=False                        
+    
     # Suppress all pop-ups from ROOT
     import ROOT as r
     r.gROOT.SetBatch(True)
 
-    # Detemrine outputDir
-    from gempython.gemplotting.utils.anautilities import getElogPath
-    if outputDir is None:
-        outputDir = getElogPath()
-
     # Redirect sys.stdout and sys.stderr if necessary 
     from gempython.gemplotting.utils.multiprocUtils import redirectStdOutAndErr
-    redirectStdOutAndErr("anaUltraThreshold",outputDir)
+    redirectStdOutAndErr("anaUltraThreshold",args.outputDir)
 
     # Get info from input file
     from gempython.gemplotting.utils.anautilities import getCyclicColor, getDirByAnaType, filePathExists, make3x8Canvas, parseListOfScanDatesFile
-    parsedTuple = parseListOfScanDatesFile(inputFile)
+    parsedTuple = parseListOfScanDatesFile(args.inputFile)
     listChamberAndScanDate = parsedTuple[0]
     thrDacName = parsedTuple[1]
     chamberName = listChamberAndScanDate[0][0]
@@ -495,16 +527,16 @@ def calibrateThrDAC(inputFile,fitRange="0,255",listOfVFATs=None,noLeg=False,outp
     # Do we load an optional vfat serial number table? (e.g. chips did not have serial number in efuse burned in)
     import numpy as np
     import root_numpy as rp
-    if listOfVFATs is not None:
+    if args.listOfVFATs is not None:
         try:
             mapVFATPos2VFATSN = np.loadtxt(
-                        fname = listOfVFATs,
+                        fname = args.listOfVFATs,
                         dtype={'names':('vfatN', 'serialNum'),
                                 'formats':('u4', 'u4')},
                         skiprows=1,
                     )
         except IOError as err:
-            print('{0} does not seem to exist, is not readable, or does not have the right format'.format(listOfVFATs))
+            print('{0} does not seem to exist, is not readable, or does not have the right format'.format(args.listOfVFATs))
             print(type(err))
             return os.EX_NOINPUT
     else:
@@ -568,8 +600,17 @@ def calibrateThrDAC(inputFile,fitRange="0,255",listOfVFATs=None,noLeg=False,outp
         
         import os
         # Get scurve data for this arm dac value (used for boxplots)
-        list_bNames = ['noise', 'threshold', 'vfatN', 'vthr']
+        list_bNames = ['noise', 'threshold', 'vfatN', 'vthr', 'ped_eff']
         scurveFitData = rp.tree2array(tree=scanFile.scurveFitTree, branches=list_bNames)
+
+        #remove channels that are masked and those for which the noise or the threshold equal the initial value 
+        scurveFitMask = np.logical_or(scurveFitData['noise'] < args.deadChanCutLow,scurveFitData['noise'] > args.deadChanCutHigh)
+        scurveFitMask = np.logical_and(scurveFitMask,scurveFitData['noise'] < args.highNoiseCut)
+        scurveFitMask = np.logical_and(scurveFitMask,scurveFitData['ped_eff'] < args.maxEffPedPercent)
+        scurveFitData = scurveFitData[scurveFitMask]
+        #following what is done in the scurve analysis script, we remove scurve fits in which either of these parameters are 0
+        scurveFitData = scurveFitData[scurveFitData['noise'] != 0]
+        scurveFitData = scurveFitData[scurveFitData['threshold'] != 0]
 
         ###################
         # Get and fit individual distributions
@@ -580,7 +621,7 @@ def calibrateThrDAC(inputFile,fitRange="0,255",listOfVFATs=None,noLeg=False,outp
                 loadPath = suffix
                 directory = "Summary"
             else:
-                if listOfVFATs is not None:
+                if args.listOfVFATs is not None:
                     vfatID = mapVFATPos2VFATSN[mapVFATPos2VFATSN['vfatN'] == vfat]
                 else:
                     if len(array_vfatData[array_vfatData['vfatN'] == vfat]) > 0:
@@ -626,10 +667,42 @@ def calibrateThrDAC(inputFile,fitRange="0,255",listOfVFATs=None,noLeg=False,outp
                 dict_ScurveSigmaVsThrDac_BoxPlot[vfat].SetXTitle(thrDacName)
                 dict_ScurveSigmaVsThrDac_BoxPlot[vfat].SetYTitle("Scurve Sigma #left(fC#right)")
 
+            if vfat > -1:    
+                scurveFitDataThisVfat = scurveFitData[scurveFitData["vfatN"] == vfat]
+            else:
+                scurveFitDataThisVfat = scurveFitData
+
+            #define histograms which will hold the per-VFAT scurve mean and scurve sigma distributions
+            #when there is no data, we create a dummy histogram which will not be filled with anything
+            if len(scurveFitDataThisVfat) != 0:
+                thisVFAT_ThreshMean = np.mean(scurveFitDataThisVfat["threshold"])
+                thisVFAT_ThreshStd = np.std(scurveFitDataThisVfat["threshold"])
+                thisVFAT_ENCMean = np.mean(scurveFitDataThisVfat["noise"])
+                thisVFAT_ENCStd = np.std(scurveFitDataThisVfat["noise"])
+            else:    
+                thisVFAT_ThreshMean = 0 #dummy value
+                thisVFAT_ThreshStd = 1 #dummy value
+                thisVFAT_ENCMean = 0 #dummy value
+                thisVFAT_ENCStd = 1 #dummy value
+                
+            histThresh = r.TH1F("scurveMean_vfat%i"%vfat,"VFAT %i;S-Curve Mean #left(fC#right);N"%vfat, 
+                                40, thisVFAT_ThreshMean - 5. * thisVFAT_ThreshStd, thisVFAT_ThreshMean + 5. * thisVFAT_ThreshStd )
+            histENC = r.TH1F("scurveSigma_vfat%i"%vfat,"VFAT %i;S-Curve Sigma #left(fC#right);N"%vfat,
+                                 40, thisVFAT_ENCMean - 5. * thisVFAT_ENCStd, thisVFAT_ENCMean + 5. * thisVFAT_ENCStd )
+                
+            #fill histograms with the scurve means and the scurve sigmas that pass the quality cuts    
+            for idy in range(0,len(scurveFitDataThisVfat)):
+                scurveMean = scurveFitDataThisVfat[idy]['threshold']
+                scurveSigma = scurveFitDataThisVfat[idy]['noise']
+                histThresh.Fill(scurveMean)
+                histENC.Fill(scurveSigma)
+
             ###################
             ### Scurve Mean ###
             ###################
-            dict_gScurveMean[infoTuple[2]][vfat] = scanFile.Get("{0}/gScurveMeanDist_{1}".format(directory,loadPath))
+            #convert TH1F to TGraph for fitting           
+            dict_gScurveMean[infoTuple[2]][vfat] = r.TGraphErrors(histThresh)
+
             if vfat > -1:
                 dict_gScurveMean[infoTuple[2]][vfat].SetName("gScurveMeanDist_{0}_thrDAC{1}".format(suffix,infoTuple[2]))
             else:
@@ -674,7 +747,9 @@ def calibrateThrDAC(inputFile,fitRange="0,255",listOfVFATs=None,noLeg=False,outp
             ####################
             ### Scurve Sigma ###
             ####################
-            dict_gScurveSigma[infoTuple[2]][vfat] = scanFile.Get("{0}/gScurveSigmaDist_{1}".format(directory,loadPath))
+            #convert TH1F to TGraphErrors for fitting                       
+            dict_gScurveSigma[infoTuple[2]][vfat] = r.TGraphErrors(histENC)
+
             if vfat > -1:
                 dict_gScurveSigma[infoTuple[2]][vfat].SetName("gScurveSigmaDist_{0}_thrDAC{1}".format(suffix,infoTuple[2]))
             else:
@@ -694,6 +769,9 @@ def calibrateThrDAC(inputFile,fitRange="0,255",listOfVFATs=None,noLeg=False,outp
                     np.min(arrayX),
                     np.max(arrayX))
 
+            #prevents the fit from going crazy and returning a mean of 10^300, which causes pyroot to crash later on
+            dict_funcScurveSigma[infoTuple[2]][vfat].SetParLimits(dict_funcScurveSigma[infoTuple[2]][vfat].GetParNumber("Mean"),np.min(arrayX),np.max(arrayX))
+            
             # Set style of TF1
             dict_funcScurveSigma[infoTuple[2]][vfat].SetLineColor(getCyclicColor(idx))
             dict_funcScurveSigma[infoTuple[2]][vfat].SetLineWidth(2)
@@ -745,10 +823,10 @@ def calibrateThrDAC(inputFile,fitRange="0,255",listOfVFATs=None,noLeg=False,outp
     # Make output calibration file
     ###################
     try:
-        calThrDacFile = open("{0}/calFile_{2}_{1}.txt".format(outputDir,chamberName,thrDacName),'w')
+        calThrDacFile = open("{0}/calFile_{2}_{1}.txt".format(args.outputDir,chamberName,thrDacName),'w')
     except IOError as e:
         print("Caught Exception: {0}".format(e))
-        print("Unabled to open file '{0}/calFile_{2}_{1}.txt'".format(outputDir,chamberName,thrDacName))
+        print("Unabled to open file '{0}/calFile_{2}_{1}.txt'".format(args.outputDir,chamberName,thrDacName))
         print("Perhaps the path does not exist or you do not have write permissions?")
         return os.EX_IOERR
     calThrDacFile.write("vfatN/I:coef4/F:coef3/F:coef2/F:coef1/F:coef0/F\n")
@@ -756,7 +834,7 @@ def calibrateThrDAC(inputFile,fitRange="0,255",listOfVFATs=None,noLeg=False,outp
     ###################
     # Make output ROOT file
     ###################
-    outFileName = "{0}/calFile_{2}_{1}.root".format(outputDir,chamberName,thrDacName)
+    outFileName = "{0}/calFile_{2}_{1}.root".format(args.outputDir,chamberName,thrDacName)
     outFile = r.TFile(outFileName,"RECREATE")
 
     # Plot Containers
@@ -770,14 +848,14 @@ def calibrateThrDAC(inputFile,fitRange="0,255",listOfVFATs=None,noLeg=False,outp
     dict_canvScurveSigmaVsThrDac_BoxPlot = {}
 
     dict_funcScurveMeanVsThrDac = {}
-    
+
     ###################
     # Now Make plots & Fit DAC Curves
     ###################
-    if debug:
+    if args.debug:
         print("| vfatN | coef4 | coef3 | coef2 | coef1 | coef0 | noise | noise_err |")
         print("| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :-------: |")
-    fitRange = [int(item) for item in fitRange.split(",")]
+    args.fitRange = [int(item) for item in args.fitRange.split(",")]
     for vfat in range(-1,24):
         if vfat == -1:
             suffix = "All"
@@ -868,7 +946,7 @@ def calibrateThrDAC(inputFile,fitRange="0,255",listOfVFATs=None,noLeg=False,outp
         thrDacVal = r.Double()
         scurveMean = r.Double()
         tgraph_scurveMeanVsThrDacForFit.GetPoint(tgraph_scurveMeanVsThrDacForFit.GetN()-1,thrDacVal,scurveMean)
-        perVfatFitRange = list(fitRange)
+        perVfatFitRange = list(args.fitRange)
         if thrDacVal > perVfatFitRange[0]:
             perVfatFitRange[0] = float(thrDacVal)
         tgraph_scurveMeanVsThrDacForFit.GetPoint(0,thrDacVal,scurveMean)
@@ -902,7 +980,7 @@ def calibrateThrDAC(inputFile,fitRange="0,255",listOfVFATs=None,noLeg=False,outp
         dict_ScurveSigmaVsThrDac[vfat].GetXaxis().SetTitle(thrDacName)
         dict_ScurveSigmaVsThrDac[vfat].GetYaxis().SetTitle("Scurve Sigma #left(fC#right)")
         dict_ScurveSigmaVsThrDac[vfat].Draw("APE1")
-        func_ScurveSigmaVsThrDac = r.TF1("func_{0}".format((dict_ScurveSigmaVsThrDac[vfat].GetName()).strip('g')),"[0]",min(fitRange), max(fitRange) )
+        func_ScurveSigmaVsThrDac = r.TF1("func_{0}".format((dict_ScurveSigmaVsThrDac[vfat].GetName()).strip('g')),"[0]",min(args.fitRange), max(args.fitRange) )
         dict_ScurveSigmaVsThrDac[vfat].Fit(func_ScurveSigmaVsThrDac,"QR")
         dict_ScurveSigmaVsThrDac[vfat].Write()
         func_ScurveSigmaVsThrDac.Write()
@@ -924,7 +1002,7 @@ def calibrateThrDAC(inputFile,fitRange="0,255",listOfVFATs=None,noLeg=False,outp
             )
 
         # Draw Legend?
-        if not noLeg:
+        if not args.noLeg:
             dict_canvScurveMeanByThrDac[vfat].cd()
             legArmDacValues.Draw("same")
 
@@ -941,7 +1019,7 @@ def calibrateThrDAC(inputFile,fitRange="0,255",listOfVFATs=None,noLeg=False,outp
         dict_canvScurveSigmaVsThrDac_BoxPlot[vfat].Write()
 
         # Print info to user
-        if debug:
+        if args.debug:
             vfatOrAll = vfat
             if vfat == -1:
                 vfatOrAll == "All"
@@ -956,14 +1034,14 @@ def calibrateThrDAC(inputFile,fitRange="0,255",listOfVFATs=None,noLeg=False,outp
                 func_ScurveSigmaVsThrDac.GetParError(1))
                 )
 
-    if savePlots:
+    if args.savePlots:
         for vfat in range(-1,24):
-            dict_canvScurveMeanByThrDac[vfat].SaveAs("{0}/{1}.png".format(outputDir,dict_canvScurveMeanByThrDac[vfat].GetName()))
-            dict_canvScurveSigmaByThrDac[vfat].SaveAs("{0}/{1}.png".format(outputDir,dict_canvScurveSigmaByThrDac[vfat].GetName()))
-            dict_canvScurveMeanVsThrDac[vfat].SaveAs("{0}/{1}.png".format(outputDir,dict_canvScurveMeanVsThrDac[vfat].GetName()))
-            dict_canvScurveSigmaVsThrDac[vfat].SaveAs("{0}/{1}.png".format(outputDir,dict_canvScurveSigmaVsThrDac[vfat].GetName()))
-            dict_canvScurveMeanVsThrDac_BoxPlot[vfat].SaveAs("{0}/{1}.png".format(outputDir,dict_canvScurveMeanVsThrDac_BoxPlot[vfat].GetName()))
-            dict_canvScurveSigmaVsThrDac_BoxPlot[vfat].SaveAs("{0}/{1}.png".format(outputDir,dict_canvScurveSigmaVsThrDac_BoxPlot[vfat].GetName()))
+            dict_canvScurveMeanByThrDac[vfat].SaveAs("{0}/{1}.png".format(args.outputDir,dict_canvScurveMeanByThrDac[vfat].GetName()))
+            dict_canvScurveSigmaByThrDac[vfat].SaveAs("{0}/{1}.png".format(args.outputDir,dict_canvScurveSigmaByThrDac[vfat].GetName()))
+            dict_canvScurveMeanVsThrDac[vfat].SaveAs("{0}/{1}.png".format(args.outputDir,dict_canvScurveMeanVsThrDac[vfat].GetName()))
+            dict_canvScurveSigmaVsThrDac[vfat].SaveAs("{0}/{1}.png".format(args.outputDir,dict_canvScurveSigmaVsThrDac[vfat].GetName()))
+            dict_canvScurveMeanVsThrDac_BoxPlot[vfat].SaveAs("{0}/{1}.png".format(args.outputDir,dict_canvScurveMeanVsThrDac_BoxPlot[vfat].GetName()))
+            dict_canvScurveSigmaVsThrDac_BoxPlot[vfat].SaveAs("{0}/{1}.png".format(args.outputDir,dict_canvScurveSigmaVsThrDac_BoxPlot[vfat].GetName()))
     
     # Make summary canvases, always save these
     canvScurveMeanByThrDac_Summary = make3x8Canvas("canvScurveMeanByThrDac_Summary",dict_mGraphScurveMean,"APE1")
@@ -974,7 +1052,7 @@ def calibrateThrDAC(inputFile,fitRange="0,255",listOfVFATs=None,noLeg=False,outp
     canvScurveSigmaVsThrDac_BoxPlot_Summary = make3x8Canvas("canvScurveSigmaVsThrDac_BoxPlot_Summary",dict_ScurveSigmaVsThrDac_BoxPlot,"candle1")
 
     # Draw Legend?
-    if not noLeg:
+    if not args.noLeg:
         canvScurveMeanByThrDac_Summary.cd(1)
         legArmDacValues.Draw("same")
 
@@ -983,25 +1061,25 @@ def calibrateThrDAC(inputFile,fitRange="0,255",listOfVFATs=None,noLeg=False,outp
 
     # Save summary canvases (alwasys)
     print("\nSaving Summary TCanvas Objects")
-    canvScurveMeanByThrDac_Summary.SaveAs("{0}/{1}.png".format(outputDir,canvScurveMeanByThrDac_Summary.GetName()))
-    canvScurveSigmaByThrDac_Summary.SaveAs("{0}/{1}.png".format(outputDir,canvScurveSigmaByThrDac_Summary.GetName()))
-    canvScurveMeanVsThrDac_Summary.SaveAs("{0}/{1}.png".format(outputDir,canvScurveMeanVsThrDac_Summary.GetName()))
-    canvScurveSigmaVsThrDac_Summary.SaveAs("{0}/{1}.png".format(outputDir,canvScurveSigmaVsThrDac_Summary.GetName()))
-    canvScurveMeanVsThrDac_BoxPlot_Summary.SaveAs("{0}/{1}.png".format(outputDir,canvScurveMeanVsThrDac_BoxPlot_Summary.GetName()))
-    canvScurveSigmaVsThrDac_BoxPlot_Summary.SaveAs("{0}/{1}.png".format(outputDir,canvScurveSigmaVsThrDac_BoxPlot_Summary.GetName()))
+    canvScurveMeanByThrDac_Summary.SaveAs("{0}/{1}.png".format(args.outputDir,canvScurveMeanByThrDac_Summary.GetName()))
+    canvScurveSigmaByThrDac_Summary.SaveAs("{0}/{1}.png".format(args.outputDir,canvScurveSigmaByThrDac_Summary.GetName()))
+    canvScurveMeanVsThrDac_Summary.SaveAs("{0}/{1}.png".format(args.outputDir,canvScurveMeanVsThrDac_Summary.GetName()))
+    canvScurveSigmaVsThrDac_Summary.SaveAs("{0}/{1}.png".format(args.outputDir,canvScurveSigmaVsThrDac_Summary.GetName()))
+    canvScurveMeanVsThrDac_BoxPlot_Summary.SaveAs("{0}/{1}.png".format(args.outputDir,canvScurveMeanVsThrDac_BoxPlot_Summary.GetName()))
+    canvScurveSigmaVsThrDac_BoxPlot_Summary.SaveAs("{0}/{1}.png".format(args.outputDir,canvScurveSigmaVsThrDac_BoxPlot_Summary.GetName()))
 
     # Close output files
     outFile.Close()
     calThrDacFile.close()
 
     print("\nYour calibration file is located in:")
-    print("\n\t{0}/calFile_{2}_{1}.txt\n".format(outputDir,chamberName,thrDacName))
+    print("\n\t{0}/calFile_{2}_{1}.txt\n".format(args.outputDir,chamberName,thrDacName))
 
     print("You can find all ROOT objects in:")
-    print("\n\t{0}/calFile_{2}_{1}.root\n".format(outputDir,chamberName,thrDacName))
+    print("\n\t{0}/calFile_{2}_{1}.root\n".format(args.outputDir,chamberName,thrDacName))
 
     print("You can find all plots in:")
-    print("\n\t{0}\n".format(outputDir))
+    print("\n\t{0}\n".format(args.outputDir))
 
     return 0
 

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -690,12 +690,15 @@ def calibrateThrDAC(args):
             histENC = r.TH1F("scurveSigma_vfat%i"%vfat,"VFAT %i;S-Curve Sigma #left(fC#right);N"%vfat,
                                  40, thisVFAT_ENCMean - 5. * thisVFAT_ENCStd, thisVFAT_ENCMean + 5. * thisVFAT_ENCStd )
                 
-            #fill histograms with the scurve means and the scurve sigmas that pass the quality cuts    
-            for idy in range(0,len(scurveFitDataThisVfat)):
-                scurveMean = scurveFitDataThisVfat[idy]['threshold']
-                scurveSigma = scurveFitDataThisVfat[idy]['noise']
-                histThresh.Fill(scurveMean)
-                histENC.Fill(scurveSigma)
+            #fill histograms with the scurve means and the scurve sigmas that pass the quality cuts
+            #leave TH1Fs and TGraphs empty for ARM DAC points with too few unmasked channels
+            from gempython.gemplotting.utils.anaInfo import numOfGoodChannelsMin
+            if len(scurveFitDataThisVfat) >= numOfGoodChannelsMin:
+                for idy in range(0,len(scurveFitDataThisVfat)):
+                    scurveMean = scurveFitDataThisVfat[idy]['threshold']
+                    scurveSigma = scurveFitDataThisVfat[idy]['noise']
+                    histThresh.Fill(scurveMean)
+                    histENC.Fill(scurveSigma)
 
             ###################
             ### Scurve Mean ###


### PR DESCRIPTION
Applies quality cuts to the scurve fits that are used in the ARM DAC calibration with configurable cut values. 

## Description
This pull request makes the following changes:

1. Fixes an obvious mistake with the upper limit of the pedestal parameter in the scurve fit.
2. Adds the number of events to the TTree that is output from the scurve analysis. This is needed to apply the quality cut on the effective pedestal.
3. Moves the default cut values for the 4 mask criteria into `anaInfo.py`. The default values were taken from https://github.com/cms-gem-daq-project/sw_utils/blob/develop/scripts/calibrateArmDac.sh, not from the default values set are currently set in the `argparse` argument construction.
4. Moves the `argparse` block associated with these cut values into `anaoptions.py`.
5. Redesigns the feeding of data into the ARM DAC calibration such that it is based on the TTrees instead of the TGraphErrors that are output from the scurve analysis.
6. Removes the scurve fits for which any of the four quality mask criteria are satisfied.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
Intended to resolve issue https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/235

## How Has This Been Tested?
Yes, I tested both the updated scurve analysis and the ARM DAC calibration on previously collected ARM DAC calibration data from the detector GE11-X-S-CERN-0010. The "canvScurveMeanVsThrDac_Summary" ARM DAC calibration plots are shown below.

With the head of develop:

![canvScurveMeanVsThrDac_Summary](https://user-images.githubusercontent.com/3329216/61065938-f6dcca00-a404-11e9-95ba-2d98460ebd21.png)

With this pull request:

![canvScurveMeanVsThrDac_Summary](https://user-images.githubusercontent.com/3329216/61068249-d8c59880-a409-11e9-89c7-d563af2c19ae.png)

There are slight changes to the plots e.g. VFATs 5, 6, and 10. I would conclude that these changes are improvements, given that Gaussian fits to the scurveMean distribution that previously failed are now succeeding, and some of large error bars are reduced.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
