### PR TITLE
resolve argument mismatch when ana_scans calls calibrateThrDac

### DIFF
--- a/macros/calibrateThrDac.py
+++ b/macros/calibrateThrDac.py
@@ -112,10 +112,23 @@ if __name__ == '__main__':
     from gempython.gemplotting.utils.threshAlgos import calibrateThrDAC
     from gempython.utils.gemlogger import printGreen, printRed
     from gempython.utils.wrappers import runCommand
+    from gempython.gemplotting.utils.namespace import Namespace
     import os, sys, traceback
-    args.outputDir = outputDir
+    ns = Namespace(
+        inputFile=args.inputFile,
+        fitRange=args.fitRange,
+        listOfVFATs=args.listOfVFATs,
+        maxEffPedPercent=args.maxEffPedPercent,
+        highNoiseCut=args.highNoiseCut,
+        deadChanCutLow=args.deadChanCutLow,
+        deadChanCutHigh=args.deadChanCutHigh,
+        noLeg=args.noLeg,
+        outputDir=outputDir,
+        savePlots=args.savePlots,
+        debug=args.debug
+    )
     try:
-        retCode = calibrateThrDAC(args)
+        retCode = calibrateThrDAC(ns)
     except IOError as err:
         printRed("IOError: {0}".format(err.message))
         printRed("Analysis failed with error code {0}".format(retCode))

--- a/utils/namespace.py
+++ b/utils/namespace.py
@@ -1,0 +1,3 @@
+class Namespace:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -501,7 +501,7 @@ def calibrateThrDAC(args):
         args.maxEffPedPercent=maxEffPedPercentDefault
 
     if not hasattr(args,"highNoiseCut"):
-        args.highNoiseCut=HighNoiseCutDefault
+        args.highNoiseCut=highNoiseCutDefault
 
     if not hasattr(args,"deadChanCutLow"):
         args.deadChanCutLow=deadChanCutLowDefault


### PR DESCRIPTION
Adds a namespace module and uses this namespace module to pass arguments to calibrateThrDac in ana_scans.py

## Description
Also, the namespace is used in calibrateThrDac.py and a bug in threshAlgos.py is fixed (`highNoiseCutDefault` --> `HighNoiseCutDefault`).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
Resolves https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/246

## How Has This Been Tested?
Yes, I have used `ana_scans.py` to run over two detectors in parallel and also checked that `calibrateThrDac.py` still works.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
