### PR TITLE
add itertrim to getdirbyana

### DIFF
--- a/utils/anaInfo.py
+++ b/utils/anaInfo.py
@@ -80,7 +80,8 @@ ana_config = {
         "thresholdvftrk":"anaUltraThreshold.py",
         "thresholdvftrig":"anaUltraThreshold.py",
         "trim":"anaUltraScurve.py",
-        "trimV3":"anaUltraScurve.py"
+        "trimV3":"anaUltraScurve.py",
+        "iterTrim":"anaUltraScurve.py"
         }
 
 #: key values match ana_config (mostly...)

--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -688,6 +688,8 @@ def getDirByAnaType(anaType, cName, ztrim=4):
         dirPath = "%s/%s/%s/z%f/"%(dataPath,cName,anaType,ztrim)
     elif anaType == "trimV3":
         dirPath = "%s/%s/trim/"%(dataPath,cName)
+    elif anaType == "iterTrim":
+        dirPath = "%s/%s/itertrim/"%(dataPath,cName)
 
     return dirPath
 


### PR DESCRIPTION
vfatqc-python-scripts depends on gem-plotting-tools, and so these are the changes in gem-plotting tools which are needed to add iterative trimming to run_scans.py in vfatqc-python-scripts

## Description
Add `iterTrim` to list of analysis types in two places.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
In order for https://github.com/cms-gem-daq-project/vfatqc-python-scripts/pull/275 to work, we need to have `iterTrim` as one of the scan types known to getdirbyana.

## How Has This Been Tested?
Yes, it was tested on the coffin. 

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
