### PR TITLE
use the detName branch in analyses

### DIFF
--- a/anaSBitThresh.py
+++ b/anaSBitThresh.py
@@ -86,38 +86,12 @@ if __name__ == '__main__':
 
     from gempython.gemplotting.mapping.chamberInfo import chamber_config
     from gempython.gemplotting.utils.threshAlgos import sbitRateAnalysis
-    anaResults = sbitRateAnalysis(
-            chamber_config = chamber_config, 
-            rateTree = sbitThreshFile.rateTree,
-            cutOffRate = args.maxNoiseRate,
-            debug = args.debug,
-            outfilename = args.outfilename,
-            scandate = scandate)
-
-    perchannel = anaResults[0]
-    dict_dacValsBelowCutOff = anaResults[1]
-
-    from gempython.utils.gemlogger import printGreen
-    from gempython.gemplotting.utils.anautilities import getDirByAnaType
-    for ohKey,innerDictByVFATKey in dict_dacValsBelowCutOff["THR_ARM_DAC"].iteritems():
-        if scandate == 'noscandate':
-            vfatConfg = open("{0}/{1}/vfatConfig.txt".format(elogPath,chamber_config[ohKey]),'w')
-            printGreen("Output Data for {0} can be found in:\n\t{1}/{0}\n".format(chamber_config[ohKey],elogPath))
-        else:
-            if perchannel:
-                strDirName = getDirByAnaType("sbitRatech", chamber_config[ohKey])
-            else:
-                strDirName = getDirByAnaType("sbitRateor", chamber_config[ohKey])
-                pass
-            vfatConfg = open("{0}/{1}/vfatConfig.txt".format(strDirName,scandate),'w')
-            printGreen("Output Data for {0} can be found in:\n\t{1}/{2}\n".format(chamber_config[ohKey],strDirName,scandate))
-            pass
-
-        vfatConfg.write("vfatN/I:vt1/I:trimRange/I\n")
-        for vfat,armDACVal in innerDictByVFATKey.iteritems():
-            vfatConfg.write('%i\t%i\t%i\n'%(vfat, armDACVal,0))
-            pass
-        vfatConfg.close()
-        pass
+    sbitRateAnalysis(
+        chamber_config = chamber_config, 
+    rateTree = sbitThreshFile.rateTree,
+        cutOffRate = args.maxNoiseRate,
+        debug = args.debug,
+        outfilename = args.outfilename,
+        scandate = scandate)
 
     print('Analysis Completed Successfully')

--- a/anaSBitThresh.py
+++ b/anaSBitThresh.py
@@ -88,7 +88,7 @@ if __name__ == '__main__':
     from gempython.gemplotting.utils.threshAlgos import sbitRateAnalysis
     sbitRateAnalysis(
         chamber_config = chamber_config, 
-    rateTree = sbitThreshFile.rateTree,
+        rateTree = sbitThreshFile.rateTree,
         cutOffRate = args.maxNoiseRate,
         debug = args.debug,
         outfilename = args.outfilename,

--- a/ana_scans.py
+++ b/ana_scans.py
@@ -114,18 +114,25 @@ def anaSBITThresh(args):
 
         dict_dacValsBelowCutOff = anaResults[1]
 
+        import numpy as np
+        import root_numpy as rp
+        if "detName" in sbitThreshFile.rateTree.GetListOfBranches():
+            detName = rp.tree2array(sbitThreshFile.rateTree, branches = [ 'detName' ] )[0][0][0]
+        else:
+            detName = chamber_config[ohKey]
+        
         for ohKey,innerDictByVFATKey in dict_dacValsBelowCutOff["THR_ARM_DAC"].iteritems():
             if args.scandate == 'noscandate':
-                vfatConfg = open("{0}/{1}/vfatConfig.txt".format(elogPath,chamber_config[ohKey]),'w')
-                printGreen("Output Data for {0} can be found in:\n\t{1}/{0}\n".format(chamber_config[ohKey],elogPath))
+                vfatConfg = open("{0}/{1}/vfatConfig.txt".format(elogPath,detName),'w')
+                printGreen("Output Data for {0} can be found in:\n\t{1}/{0}\n".format(detName,elogPath))
             else:
                 if args.perchannel:
-                    strDirName = getDirByAnaType("sbitRatech", chamber_config[ohKey])
+                    strDirName = getDirByAnaType("sbitRatech", detName)
                 else:
-                    strDirName = getDirByAnaType("sbitRateor", chamber_config[ohKey])
+                    strDirName = getDirByAnaType("sbitRateor", detName)
                     pass
                 vfatConfg = open("{0}/{1}/vfatConfig.txt".format(strDirName,args.scandate),'w')
-                printGreen("Output Data for {0} can be found in:\n\t{1}/{2}\n".format(chamber_config[ohKey],strDirName,args.scandate))
+                printGreen("Output Data for {0} can be found in:\n\t{1}/{2}\n".format(detName,strDirName,args.scandate))
                 pass
 
             vfatConfg.write("vfatN/I:vt1/I:trimRange/I\n")

--- a/ana_scans.py
+++ b/ana_scans.py
@@ -105,43 +105,12 @@ def anaSBITThresh(args):
         if args.scandate is None:
             args.scandate = getScandateFromFilename(fileTuple[0])
 
-        anaResults = sbitRateAnalysis(
-                chamber_config = chamber_config,
-                rateTree = sbitThreshFile.rateTree,
-                cutOffRate = args.maxNoiseRate,
-                debug = args.debug,
-                scandate = args.scandate)
-
-        dict_dacValsBelowCutOff = anaResults[1]
-
-        import numpy as np
-        import root_numpy as rp
-        if "detName" in sbitThreshFile.rateTree.GetListOfBranches():
-            detName = rp.tree2array(sbitThreshFile.rateTree, branches = [ 'detName' ] )[0][0][0]
-        else:
-            detName = chamber_config[ohKey]
-        
-        for ohKey,innerDictByVFATKey in dict_dacValsBelowCutOff["THR_ARM_DAC"].iteritems():
-            if args.scandate == 'noscandate':
-                vfatConfg = open("{0}/{1}/vfatConfig.txt".format(elogPath,detName),'w')
-                printGreen("Output Data for {0} can be found in:\n\t{1}/{0}\n".format(detName,elogPath))
-            else:
-                if args.perchannel:
-                    strDirName = getDirByAnaType("sbitRatech", detName)
-                else:
-                    strDirName = getDirByAnaType("sbitRateor", detName)
-                    pass
-                vfatConfg = open("{0}/{1}/vfatConfig.txt".format(strDirName,args.scandate),'w')
-                printGreen("Output Data for {0} can be found in:\n\t{1}/{2}\n".format(detName,strDirName,args.scandate))
-                pass
-
-            vfatConfg.write("vfatN/I:vt1/I:trimRange/I\n")
-            for vfat,armDACVal in innerDictByVFATKey.iteritems():
-                vfatConfg.write('%i\t%i\t%i\n'%(vfat, armDACVal,0))
-                pass
-            vfatConfg.close()
-            pass
-        pass
+        sbitRateAnalysis(
+            chamber_config = chamber_config,
+            rateTree = sbitThreshFile.rateTree,
+            cutOffRate = args.maxNoiseRate,
+            debug = args.debug,
+            scandate = args.scandate)
 
     printGreen("Analysis Completed Successfully")
     return

--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -436,7 +436,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
                     if vfat not in dict_nonzeroVFATs[ohKey]:
                         continue
 
-                    print("| {1} | {2} | {3} | {4} | {5} | {6} |".format(
+                    print("| {0} | {1} | {2} | {3} | {4} | {5} | {6} |".format(
                         detName,
                         ohKey[0],
                         ohKey[1],

--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -73,7 +73,16 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
 
     import root_numpy as rp
     import numpy as np
-    list_bNames = ['dacValY','link','nameX','shelf','slot','vfatID','vfatN']
+
+    #for backwards compatibility, handle input trees that do not have a detName branch by finding the detName using the chamber_config
+    hasDetNameBranch = False
+    if 'detName' in dacScanTree.GetListOfBranches():
+        hasDetNameBranch = True
+
+    list_bNames = ['dacValY','link','nameX','shelf','slot','vfatID','vfatN','detName']
+    if not hasDetNameBranch:
+        list_bNames.remove('detName')
+    
     vfatArray = rp.tree2array(tree=dacScanTree,branches=list_bNames)
     dacNameArray = np.unique(vfatArray['nameX'])
 
@@ -102,16 +111,19 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
     
     from gempython.utils.wrappers import runCommand
     for entry in crateMap:
-        ohKey = (entry['shelf'],entry['slot'],entry['link'])
-        if scandate == 'noscandate':
-            runCommand(["mkdir", "-p", "{0}/{1}".format(elogPath,chamber_config[ohKey])])
-            runCommand(["chmod", "g+rw", "{0}/{1}".format(elogPath,chamber_config[ohKey])])
+        if hasDetNameBranch:
+            detName = entry['detName'][0]
         else:
-            runCommand(["mkdir", "-p", "{0}/{1}/dacScans/{2}".format(dataPath,chamber_config[ohKey],scandate)])
-            runCommand(["chmod", "g+rw", "{0}/{1}/dacScans/{2}".format(dataPath,chamber_config[ohKey],scandate)])
+            detName = chamber_config[(entry['shelf'],entry['slot'],entry['link'])]
+        if scandate == 'noscandate':
+            runCommand(["mkdir", "-p", "{0}/{1}".format(elogPath,detName)])
+            runCommand(["chmod", "g+rw", "{0}/{1}".format(elogPath,detName)])
+        else:
+            runCommand(["mkdir", "-p", "{0}/{1}/dacScans/{2}".format(dataPath,detName,scandate)])
+            runCommand(["chmod", "g+rw", "{0}/{1}/dacScans/{2}".format(dataPath,detName,scandate)])
             if scandate != "current":
-                runCommand(["unlink", "{0}/{1}/dacScans/current".format(dataPath,chamber_config[ohKey])])
-                runCommand(["ln","-s","{0}/{1}/dacScans/{2}".format(dataPath,chamber_config[ohKey],scandate),"{0}/{1}/dacScans/current".format(dataPath,chamber_config[ohKey])])
+                runCommand(["unlink", "{0}/{1}/dacScans/current".format(dataPath,detName)])
+                runCommand(["ln","-s","{0}/{1}/dacScans/{2}".format(dataPath,detName,scandate),"{0}/{1}/dacScans/current".format(dataPath,detName)])
             pass
             
     # Determine which DAC was scanned and against which ADC
@@ -176,8 +188,12 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
     import os
     for idx,entry in enumerate(crateMap):
         ohKey = (entry['shelf'],entry['slot'],entry['link'])
+        if hasDetNameBranch:
+            detName = entry['detName'][0]
+        else:
+            detName = chamber_config[ohKey]
         if ohKey not in calInfo.keys():
-            calAdcCalFile = "{0}/{1}/calFile_{2}_{1}.txt".format(dataPath,chamber_config[ohKey],adcName)
+            calAdcCalFile = "{0}/{1}/calFile_{2}_{1}.txt".format(dataPath,detName,adcName)
             calAdcCalFileExists = os.path.isfile(calAdcCalFile)
             if calAdcCalFileExists:
                 tuple_calInfo = parseCalFile(calAdcCalFile)
@@ -188,7 +204,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
                     ohKey[0],
                     ohKey[1],
                     ohKey[2],
-                    chamber_config[ohKey],
+                    detName,
                     adcName,
                     calAdcCalFile))
                 crateMap = np.delete(crateMap,(idx))
@@ -229,11 +245,14 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
 
     outputFiles = {}         
     for entry in crateMap:
-        ohKey = (entry['shelf'],entry['slot'],entry['link'])
+        if hasDetNameBranch:
+            detName = entry['detName'][0]
+        else:
+            detName = chamber_config[(entry['shelf'],entry['slot'],entry['link'])]
         if scandate == 'noscandate':
-            outputFiles[ohKey] = r.TFile(elogPath+"/"+chamber_config[ohKey]+"/"+args.outfilename,'recreate')
+            outputFiles[ohKey] = r.TFile(elogPath+"/"+detName+"/"+args.outfilename,'recreate')
         else:    
-            outputFiles[ohKey] = r.TFile(dataPath+"/"+chamber_config[ohKey]+"/dacScans/"+scandate+"/"+args.outfilename,'recreate')
+            outputFiles[ohKey] = r.TFile(dataPath+"/"+detName+"/dacScans/"+scandate+"/"+args.outfilename,'recreate')
 
     print("Looping over stored events in dacScanTree")
 
@@ -311,6 +330,10 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
 
         for entry in crateMap:
             ohKey = (entry['shelf'],entry['slot'],entry['link'])
+            if hasDetNameBranch:
+                detName = entry['detName'][0]
+            else:
+                detName = entry[ohKey]            
             graph_dacVals[dacName][ohKey] = r.TGraph()
             graph_dacVals[dacName][ohKey].SetMinimum(0)
             graph_dacVals[dacName][ohKey].GetXaxis().SetTitle("VFATN")
@@ -333,7 +356,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
                             finalDacValue,
                             ohKey[2],
                             vfat,
-                            chamber_config[ohKey],
+                            detName, 
                             ohKey[0],
                             ohKey[1])
                     print(colormsg(errorMsg,logging.ERROR))
@@ -348,14 +371,21 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
     for idx in range(len(dacNameArray)):
         dacName = np.asscalar(dacNameArray[idx])
         for entry in crateMap:
-            ohKey = (entry['shelf'],entry['slot'],entry['link'])
-            if scandate == 'noscandate':
-                outputTxtFiles_dacVals[dacName][ohKey] = open("{0}/{1}/NominalValues-{2}.txt".format(elogPath,chamber_config[ohKey],dacName),'w')
+            if hasDetNameBranch:
+                detName = entry['detName'][0]
             else:
-                outputTxtFiles_dacVals[dacName][ohKey] = open("{0}/{1}/dacScans/{2}/NominalValues-{3}.txt".format(dataPath,chamber_config[ohKey],scandate,dacName),'w')
+                detName = entry[(entry['shelf'],entry['slot'],entry['link'])]
+            if scandate == 'noscandate':
+                outputTxtFiles_dacVals[dacName][ohKey] = open("{0}/{1}/NominalValues-{2}.txt".format(elogPath,detName,dacName),'w')
+            else:
+                outputTxtFiles_dacVals[dacName][ohKey] = open("{0}/{1}/dacScans/{2}/NominalValues-{3}.txt".format(dataPath,detName,scandate,dacName),'w')
 
     for entry in crateMap:
-        ohKey = (entry['shelf'],entry['slot'],entry['link'])
+        ohKey = (entry['shelf'],entry['slot'],entry['link'])        
+        if hasDetNameBranch:
+            detName = entry['detName'][0]                
+        else:
+            detName = entry[ohKey]
         # Per VFAT Poosition
         for vfat in range(0,24):
             thisVFATDir = outputFiles[ohKey].mkdir("VFAT{0}".format(vfat))
@@ -385,16 +415,20 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
             # Store summary grid canvas and print images
             canv_Summary = make3x8Canvas("canv_Summary_{0}".format(dacName),dict_DACvsADC_Graphs[dacName][ohKey],'APE1',dict_DACvsADC_Funcs[dacName][ohKey],'')
             if scandate == 'noscandate':
-                canv_Summary.SaveAs("{0}/{1}/Summary_{1}_DACScan_{2}.png".format(elogPath,chamber_config[ohKey],dacName))
+                canv_Summary.SaveAs("{0}/{1}/Summary_{1}_DACScan_{2}.png".format(elogPath,detName,dacName))
             else:
-                canv_Summary.SaveAs("{0}/{1}/dacScans/{2}/Summary{1}_DACScan_{3}.png".format(dataPath,chamber_config[ohKey],scandate,dacName))
+                canv_Summary.SaveAs("{0}/{1}/dacScans/{2}/Summary{1}_DACScan_{3}.png".format(dataPath,detName,scandate,dacName))
 
     # Print Summary?
     if args.printSum:
-        print("| shelf | slot | ohN | vfatN | dacName | Value |")
-        print("| :---: | :--: | :-: | :---: | :-----: | :---: |")
+        print("| detName | shelf | slot | ohN | vfatN | dacName | Value |")
+        print("| :-----: | :---: | :--: | :-: | :---: | :-----: | :---: |")
         for entry in crateMap:
             ohKey = (entry['shelf'],entry['slot'],entry['link'])
+            if hasDetNameBranch:
+                detName = entry['detName'][0]
+            else:
+                detName = chamber_config[ohKey]
             for idx in range(len(dacNameArray)):
                 dacName = np.asscalar(dacNameArray[idx])
             
@@ -402,7 +436,8 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
                     if vfat not in dict_nonzeroVFATs[ohKey]:
                         continue
 
-                    print("| {0} | {1} | {2} | {3} | {4} | {5} |".format(
+                    print("| {1} | {2} | {3} | {4} | {5} | {6} |".format(
+                        detName,
                         ohKey[0],
                         ohKey[1],
                         ohKey[2],

--- a/utils/latAlgos.py
+++ b/utils/latAlgos.py
@@ -163,6 +163,10 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
     # Make output TFile and TTree
     from array import array
     dirVFATPlots = outF.mkdir("VFAT_Plots")
+    if 'detName' in listOfBranches:    
+        detName = r.vector('string')()
+        detName.push_back(rp.tree2array(inFile.latTree, branches = [ 'detName' ] )[0][0][0])
+        myT.Branch( 'detName', detName)
     vfatN = array( 'i', [ 0 ] )
     myT.Branch( 'vfatN', vfatN, 'vfatN/I' )
     vfatID = array( 'L', [0] )
@@ -199,7 +203,13 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
     r.gStyle.SetOptStat(0)
     if debug and performFit:
         print("VFAT\tSignalHits\tSignal/Noise")
+
     for vfat in dict_hVFATHitsVsLat:
+        #if we don't have any data for this VFAT, we just need to initialize the TGraphAsymmErrors since it is drawn later
+        if vfat not in dict_chipID:
+            dict_grNHitsVFAT[vfat] = r.TGraphAsymmErrors()
+            continue
+        
         # Store VFAT info
         vfatN[0] = vfat
         vfatID[0] = dict_chipID[vfat]

--- a/utils/scurveAlgos.py
+++ b/utils/scurveAlgos.py
@@ -133,7 +133,7 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
         inFile.Close()
         raise IOError("Input file {0} is a Zombie, check to make sure you have write permissions and file has expected size".format(scurveFilename))
     scurveTree = inFile.scurveTree
-    
+
     # Get ChipID's
     import numpy as np
     import root_numpy as rp
@@ -460,6 +460,10 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
         #scurveFitTree = r.TTree('scurveFitTree','Tree Holding FitData')
 
         from array import array
+        if 'detName' in listOfBranches:
+            detName = r.vector('string')()
+            detName.push_back(rp.tree2array(scurveTree, branches = [ 'detName' ] )[0][0][0])
+            scurveFitTree.Branch( 'detName', detName)
         chi2 = array( 'f', [ 0 ] )
         scurveFitTree.Branch( 'chi2', chi2, 'chi2/F')
         mask = array( 'i', [ 0 ] )

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -134,9 +134,11 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     listOfBranches = thrTree.GetListOfBranches()
     if 'vfatID' in listOfBranches:
         array_chipID = np.unique(rp.tree2array(thrTree, branches = [ 'vfatID','vfatN' ] ))
-        array_chipID = np.sort(array_chipID, order='vfatN')['vfatID']
+        dict_chipID = {}
+        for entry in array_chipID:
+            dict_chipID[entry['vfatN']]=entry['vfatID']
     else:
-        array_chipID = np.zeros(24)
+        dict_chipID = { vfat:0 for vfat in range(24) }
 
     r.TH1.SetDefaultSumw2(False)
     r.gROOT.SetBatch(True)
@@ -146,7 +148,11 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     dict_hMaxThrDAC_NoOutlier = {}
     dict_chanMaxThrDAC = {}
     for vfat in range(0,24):
-        chipID = array_chipID[vfat]
+        if vfat not in dict_chipID:
+            dict_h2D_thrDAC[vfat] = r.TH2D()
+            continue
+        
+        chipID = dict_chipID[vfat]
         dict_h2D_thrDAC[vfat] = r.TH2D(
                 'h_thrDAC_vs_ROBstr_VFAT{0}'.format(vfat),
                 'VFAT{0} chipID {1};{2};{3} [DAC units]'.format(vfat,chipID,stripChanOrPinName[1],dacName),
@@ -169,19 +175,18 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
         if args.isVFAT2:
             dict_trimRange[int(event.vfatN)] = int(event.dict_trimRange)
 
-        if not (array_chipID[event.vfatN] > 0):
-            if 'vfatID' in listOfBranches:
-                array_chipID[event.vfatN] = event.vfatID
-            else:
-                array_chipID[event.vfatN] = 0
-
         stripPinOrChan = dict_vfatChanLUT[event.vfatN][stripChanOrPinType][event.vfatCH]
         dict_h2D_thrDAC[event.vfatN].Fill(stripPinOrChan,event.vth1,event.Nhits)
         pass
 
-    # Make output TTree
+    # Make output TFile and make output TTree
     from array import array
+    outFile = r.TFile("{0}/{1}".format(outputDir,args.outfilename),"RECREATE")
     thrAnaTree = r.TTree('thrAnaTree','Tree Holding Analyzed Threshold Data')
+    if 'detName' in listOfBranches:
+        detName = r.vector('string')()
+        detName.push_back(rp.tree2array(thrTree, branches = [ 'detName' ] )[0][0][0])
+        thrAnaTree.Branch('detName', detName)
     mask = array( 'i', [ 0 ] )
     thrAnaTree.Branch( 'mask', mask, 'mask/I' )
     maskReason = array( 'i', [ 0 ] )
@@ -208,6 +213,9 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     import root_numpy as rp #note need root_numpy-4.7.2 (may need to run 'pip install root_numpy --upgrade')
     hot_channels = {}
     for vfat in range(0,24):
+        if vfat not in dict_chipID:
+            continue
+        
         #For each channel determine the maximum thresholds
         dict_chanMaxThrDAC[vfat] = -1 * np.ones((2,dict_h2D_thrDAC[vfat].GetNbinsX()))
         for chan in range(0,128):
@@ -242,7 +250,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
             if args.isVFAT2:
                 trimRange[0] = dict_trimRange[vfat]
             vfatCH[0] = chan
-            vfatID[0] = array_chipID[vfat]
+            vfatID[0] = dict_chipID[vfat]
             vfatN[0] = vfat
             vthr[0] = int(dict_chanMaxThrDAC[vfat][1][chan])
             thrAnaTree.Fill()
@@ -307,6 +315,8 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     if not args.pervfat:
         print("Subtracting off hot channels")
         for vfat in range(0,24):
+            if vfat not in dict_chipID:
+                continue
             vfatChanArray = hot_channels[ hot_channels['vfatN'] == vfat ]
             for chan in range(0,dict_h2D_thrDAC[vfat].GetNbinsX()):
                 isHotChan = vfatChanArray[ vfatChanArray['vfatCH'] == chan ]['mask']
@@ -325,12 +335,14 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
             pass
         pass
 
-    #Make output TFile and write data to it
-    outFile = r.TFile("{0}/{1}".format(outputDir,args.outfilename),"RECREATE")
     outFile.cd()
     thrAnaTree.Write()
     dict_h2D_thrDACProjPruned = {}
     for vfat in range(0,24):
+        #if we don't have any data for this VFAT, we just need to initialize the TH1D since it is drawn later
+        if vfat not in dict_chipID:
+            dict_h2D_thrDACProjPruned[vfat] = r.TH1D()
+            continue                
         thisDir = outFile.mkdir("VFAT{0}".format(vfat))
         thisDir.cd()
         dict_h2D_thrDAC[vfat].Write()
@@ -350,6 +362,8 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     print('Determining the thrDAC values for each VFAT')
     vt1 = dict((vfat,0) for vfat in range(0,24))
     for vfat in range(0,24):
+        if vfat not in dict_chipID:
+            continue        
         proj = dict_h2D_thrDAC[vfat].ProjectionY()
         proj.Draw()
         for thresh in range(THR_DAC_MAX+1,0,-1):
@@ -366,12 +380,16 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     if args.isVFAT2:
         txt_vfat.write("vfatN/I:vfatID/I:vt1/I:trimRange/I\n")
         for vfat in range(0,24):
-            txt_vfat.write('%i\t%i\t%i\t%i\n'%(vfat,array_chipID[vfat],vt1[vfat],trimRange[vfat]))
+            if vfat not in dict_chipID:
+                continue
+            txt_vfat.write('%i\t%i\t%i\t%i\n'%(vfat,dict_chipID[vfat],vt1[vfat],trimRange[vfat]))
             pass
     else:
         txt_vfat.write("vfatN/I:vfatID/I:vt1/I\n")
         for vfat in range(0,24):
-            txt_vfat.write('%i\t%i\t%i\n'%(vfat,array_chipID[vfat],vt1[vfat]))
+            if vfat not in dict_chipID:
+                continue
+            txt_vfat.write('%i\t%i\t%i\n'%(vfat,dict_chipID[vfat],vt1[vfat]))
             pass
     txt_vfat.close()
 
@@ -383,19 +401,21 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
             if args.debug:
                 print 'vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:mask/I\n'
             for vfat in range (0,24):
+                if vfat not in dict_chipID:
+                    continue                
                 vfatChanArray = hot_channels[ hot_channels['vfatN'] == vfat ]
                 for chan in range (0, 128):
                     isHotChan = vfatChanArray[ vfatChanArray['vfatCH'] == chan ]['mask']
                     if args.debug:
                         print('{0}\t{1}\t{2}\t{3}\t{4}\n'.format(
                             vfat,
-                            array_chipID[vfat],
+                            dict_chipID[vfat],
                             chan,
                             dict_vfatTrimMaskData[vfat][chan]['trimDAC'],
                             int(isHotChan or dict_vfatTrimMaskData[vfat][chan]['mask'])))
                     confF.write('{0}\t{1}\t{2}\t{3}\t{4}\n'.format(
                         vfat,
-                        array_chipID[vfat],
+                        dict_chipID[vfat],
                         chan,
                         dict_vfatTrimMaskData[vfat][chan]['trimDAC'],
                         int(isHotChan or dict_vfatTrimMaskData[vfat][chan]['mask'])))
@@ -404,13 +424,15 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
             if args.debug:
                 print 'vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:mask/I\n'
             for vfat in range (0,24):
+                if vfat not in dict_chipID:
+                    continue
                 vfatChanArray = hot_channels[ hot_channels['vfatN'] == vfat ]
                 for chan in range(0,128):
                     isHotChan = vfatChanArray[ vfatChanArray['vfatCH'] == chan ]['mask']
                     if args.debug:
                         print('%i\t%i\t%i\t%i\t%i\t%i\t%i\n'%(
                             vfat,
-                            array_chipID[vfat],
+                            dict_chipID[vfat],
                             chan,
                             dict_vfatTrimMaskData[vfat][chan]['trimDAC'],
                             dict_vfatTrimMaskData[vfat][chan]['trimPolarity'],
@@ -418,7 +440,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
                             dict_vfatTrimMaskData[vfat][chan]['maskReason']))
                     confF.write('%i\t%i\t%i\t%i\t%i\t%i\t%i\n'%(
                         vfat,
-                        array_chipID[vfat],
+                        dict_chipID[vfat],
                         chan,
                         dict_vfatTrimMaskData[vfat][chan]['trimDAC'],
                         dict_vfatTrimMaskData[vfat][chan]['trimPolarity'],
@@ -1187,8 +1209,16 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
     # Get the data
     import root_numpy as rp
     import numpy as np
-    list_bNames = ['dacValX','link','nameX','rate','shelf','slot','vfatCH','vfatN']
 
+    #for backwards compatibility, handle input trees that do not have a detName branch by finding the detName using the chamber_config
+    hasDetNameBranch = False
+    if 'detName' in rateTree.GetListOfBranches():
+        hasDetNameBranch = True
+
+    list_bNames = ['dacValX','link','nameX','rate','shelf','slot','vfatCH','vfatN','detName']
+    if not hasDetNameBranch:
+        list_bNames.remove('detName')
+        
     vfatArray = rp.tree2array(tree=rateTree,branches=list_bNames)
     dacNameArray = np.unique(vfatArray['nameX'])
 
@@ -1225,15 +1255,18 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
     from gempython.utils.wrappers import runCommand
     from gempython.gemplotting.utils.anautilities import getDirByAnaType
     for entry in crateMap:
-        ohKey = (entry['shelf'],entry['slot'],entry['link'])
+        if hasDetNameBranch:
+            detName = entry['detName'][0]
+        else:
+            detName = chamber_config[(entry['shelf'],entry['slot'],entry['link'])]            
         if scandate == 'noscandate':
-            runCommand(["mkdir", "-p", "{0}/{1}".format(elogPath,chamber_config[ohKey])])
-            runCommand(["chmod", "g+rw", "{0}/{1}".format(elogPath,chamber_config[ohKey])])
+            runCommand(["mkdir", "-p", "{0}/{1}".format(elogPath,detName)])
+            runCommand(["chmod", "g+rw", "{0}/{1}".format(elogPath,detName)])
         else:
             if perchannel:
-                strDirName = getDirByAnaType("sbitRatech", chamber_config[ohKey])
+                strDirName = getDirByAnaType("sbitRatech", detName)
             else:
-                strDirName = getDirByAnaType("sbitRateor", chamber_config[ohKey])
+                strDirName = getDirByAnaType("sbitRateor", detName)
                 pass
             runCommand(["mkdir", "-p", "{0}/{1}".format(strDirName,scandate)])
             runCommand(["chmod", "g+rw", "{0}/{1}".format(strDirName,scandate)])
@@ -1278,14 +1311,17 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
     # create output TFiles
     outputFiles = {}
     for entry in crateMap:
-        ohKey = (entry['shelf'],entry['slot'],entry['link'])
+        if hasDetNameBranch:
+            detName = entry['detName'][0]
+        else:
+            detName = chamber_config[(entry['shelf'],entry['slot'],entry['link'])]                    
         if scandate == 'noscandate':
-            outputFiles[ohKey] = r.TFile(elogPath+"/"+chamber_config[ohKey]+"/"+outfilename,'recreate')
+            outputFiles[ohKey] = r.TFile(elogPath+"/"+detName+"/"+outfilename,'recreate')
         else:
             if perchannel:
-                strDirName = getDirByAnaType("sbitRatech", chamber_config[ohKey])
+                strDirName = getDirByAnaType("sbitRatech", detName)
             else:
-                strDirName = getDirByAnaType("sbitRateor", chamber_config[ohKey])
+                strDirName = getDirByAnaType("sbitRateor", detName)
                 pass
             outputFiles[ohKey] = r.TFile(strDirName+scandate+"/"+outfilename,'recreate')
             pass
@@ -1345,6 +1381,10 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
 
     for entry in crateMap:
         ohKey = (entry['shelf'],entry['slot'],entry['link'])
+        if hasDetNameBranch:
+            detName = entry['detName'][0]
+        else:
+            detName = chamber_config[ohKey]
         # clear the inflection point table for each new link
         inflectTable = []
         # Per VFAT Poosition
@@ -1391,7 +1431,7 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
         if perchannel == False:
             print(tabulate(inflectTable, headers = ['Geo Addr', 'VFAT Number', 'ARM DAC Inflection Pt'], tablefmt='orgtbl') )
             if scandate == 'noscandate':
-                inflectTableFile = file("{0}/{1}/inflectionPointTable.txt".format(elogPath,chamber_config[ohKey]), "w")
+                inflectTableFile = file("{0}/{1}/inflectionPointTable.txt".format(elogPath,detName), "w")
                 inflectTableFile.write(tabulate(inflectTable, headers = ['Geo Addr', 'VFAT Number', 'ARM DAC Inflection Pt'], tablefmt='orgtbl') )
             else: 
                 inflectTableFile = file("{0}/{1}/inflectionPointTable.txt".format(strDirName,scandate ), "w")
@@ -1434,15 +1474,15 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
             # Save the graphs
             if scandate == 'noscandate':
                 if perchannel:
-                    canv_Summary2D.SaveAs("{0}/{1}/{2}_{1}.png".format(elogPath,chamber_config[ohKey],canv_Summary2D.GetName()))
+                    canv_Summary2D.SaveAs("{0}/{1}/{2}_{1}.png".format(elogPath,detName,canv_Summary2D.GetName()))
                 else:
-                    canv_Summary1D.SaveAs("{0}/{1}/{2}_{1}.png".format(elogPath,chamber_config[ohKey],canv_Summary1D.GetName()))
+                    canv_Summary1D.SaveAs("{0}/{1}/{2}_{1}.png".format(elogPath,detName,canv_Summary1D.GetName()))
             else:
                 if perchannel:
-                    strDirName = getDirByAnaType("sbitRatech", chamber_config[ohKey])
+                    strDirName = getDirByAnaType("sbitRatech", detName)
                     canv_Summary2D.SaveAs("{0}/{1}/{2}.png".format(strDirName,scandate,canv_Summary2D.GetName()))
                 else:
-                    strDirName = getDirByAnaType("sbitRateor", chamber_config[ohKey])
+                    strDirName = getDirByAnaType("sbitRateor", detName)
                     canv_Summary1D.SaveAs("{0}/{1}/{2}.png".format(strDirName,scandate,canv_Summary1D.GetName()))
                     pass
                 pass


### PR DESCRIPTION
A pull request to `vfatqc-python-scripts` (https://github.com/cms-gem-daq-project/vfatqc-python-scripts/pull/276) adds a detector serial number branch to the output trees from all of the scans. This pull request uses this new branch in the analyses

## Description

In the analysis of the DAC scans and the sbitRate scans, in which there are multiple links, the `detName` branch is used to create the output directory paths.

In the analyses of the scurve scans, threshold scans, and latency scans, the `detName` branch is copied from the input tree to the output tree.

Ensures backwards compatibility by checking whether there is a `detName` branch in the input tree before trying to access it.

Also, this fixes several bugs which assumed that all 24 VFATs were present in the input.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This, together with https://github.com/cms-gem-daq-project/vfatqc-python-scripts/pull/276,  are intended to resolve https://github.com/cms-gem-daq-project/vfatqc-python-scripts/issues/273

## How Has This Been Tested?
This was tested to analyze an scurve scan, a DAC scan, a threshold scan, a latency scan, and an sbitRate scan.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
