### PR TITLE
rethrow exceptions from cx_Oracle

### DIFF
--- a/utils/dbutils.py
+++ b/utils/dbutils.py
@@ -102,8 +102,21 @@ def getVFAT3CalInfo(vfatList, debug=False):
     debug       - Prints additional info if true
     """
 
-    df_vfatCalInfo = getVFAT3ProdSumView(vfatList, debug)
-
+    #When using multithreading, the threads pass information back in pickled format. Some exceptions in cx_Oracle cannot be pickled.
+    #Thus, we check here whether the exception can be pickled, and if not rethrow it as an exception that can be.
+    try:
+        df_vfatCalInfo = getVFAT3ProdSumView(vfatList, debug)
+    except Exception as err:
+        import pickle
+        try:
+            pickle.dumps(err)
+        except TypeError:
+            raise Exception("This is a rethrown exception. The original exception type was: "+str(type(err)) +". The original exception message was: "+str(err.message))
+        else:
+            raise err
+            
+            
+        
     return df_vfatCalInfo[['vfatN','vfat3_ser_num', 'vfat3_barcode', 'iref', 'adc0m', 'adc1m', 'adc0b', 'adc1b', 'cal_dacm', 'cal_dacb']]
 
 def getVFAT3ConfView(vfatList, debug=False):


### PR DESCRIPTION
`cx_Oracle` throws exceptions objects that cannot be pickled, which is a problem for our multithreading framework, so this pull requests rethrows exceptions that cannot be pickled.

## Description
In the function `getVFAT3CalInfo`, a try-catch block is added around the call to `getVFAT3ProdSumView`. When an exception is caught, it tries to pickle the exception, and checks whether a `TypeError` exception is throw by the pickler. If there is no `TypeError`, the original exception is rethrown. If there is a `TypeError`, then a new exception is created which records the type and the message of the original exception.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
Partially resolves https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/250. The underlying cause of the exception reported in that issue is not understood.

## How Has This Been Tested?
Yes:

```
Launching scurve analysis processes, this may take some time, please be patient
Caught <type 'exceptions.Exception'>: This is a rethrown exception. The original exception type was: <class 'cx_Oracle.DatabaseError'>. The original exception message was: ORA-01017: invalid username/password; logon denied
, terminating workers
```

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
