### PR TITLE
Ge21 generalizing

### DIFF
--- a/anaSBitMonitor.py
+++ b/anaSBitMonitor.py
@@ -20,7 +20,6 @@ if __name__ == '__main__':
     filename = args.infilename[:-5]
     os.system("mkdir " + args.infilename[:-5])
 
-    print filename
     outfilename = args.outfilename
 
     import ROOT as r

--- a/anaSBitMonitor.py
+++ b/anaSBitMonitor.py
@@ -49,7 +49,7 @@ if __name__ == '__main__':
     ##### END
     from gempython.tools.hw_constants import vfatsPerGemVariant
     nVFATS = vfatsPerGemVariant[gemType]
-    from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFATS as maxChans
+    from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFAT as maxChans
     
     print('Initializing histograms')
     from gempython.utils.nesteddict import nesteddict as ndict, flatten
@@ -491,7 +491,7 @@ if __name__ == '__main__':
     print("| :---: | :------: | :-------: | :----------: |")
     fileMisMappedSbits.write("| :---: | :------: | :-------: | :----------: |\n")
     for idx in range(0,len(wrongSBITMapping)):
-        print("| {0} | {1} | {2} | {3} |".format(
+        print("| {0:5d} | {1:8d} | {2:9d} | {3:12d} |".format(
             wrongSBITMapping[idx]['vfatN'],
             wrongSBITMapping[idx]['vfatSBIT'],
             wrongSBITMapping[idx]['sbitSize'],
@@ -519,7 +519,7 @@ if __name__ == '__main__':
     print("| :--------: | :----------: | :----------: |")
     fileMisMappedVFATs.write("| :--------: | :----------: | :----------: |\n")
     for idx in range(0,len(wrongVFATMapping)):
-        print("| {0} | {1} | {2} |".format(
+        print("| {0:10d} | {1:12d} | {2:12d} |".format(
             wrongVFATMapping[idx]['vfatN'],
             wrongVFATMapping[idx]['vfatObs'],
             wrongVFATMapping[idx]['N_Mismatches']))

--- a/anaSBitMonitor.py
+++ b/anaSBitMonitor.py
@@ -17,8 +17,8 @@ if __name__ == '__main__':
     parser.set_defaults(outfilename="SBitMonitorData.root")
     args = parser.parse_args()
     
-    filename = args.filename[:-5]
-    os.system("mkdir " + args.filename[:-5])
+    filename = args.infilename[:-5]
+    os.system("mkdir " + args.infilename[:-5])
 
     print filename
     outfilename = args.outfilename
@@ -29,7 +29,7 @@ if __name__ == '__main__':
     outF = r.TFile(filename+'/'+outfilename, 'recreate')
     inF = r.TFile(filename+'.root')
 
-    gemType = "ge11"
+    
     
     # Determine the rates scanned
     print('Determining rates tested')
@@ -41,7 +41,14 @@ if __name__ == '__main__':
     calEnableValues = np.unique(initInfo['calEnable'])
     isValidValues = np.unique(initInfo['isValid'])
     ratesUsed = np.unique(initInfo['ratePulsed'])
-
+    ##### NEED TO FIX
+    #### VERY TEMPORARY
+    from gempython.gemplotting.mapping.chamberInfo import gemTypeMapping
+    print rp.tree2array(tree=inF.sbitDataTree, branches ='gemType')
+    gemType = gemTypeMapping[rp.tree2array(tree=inF.sbitDataTree, branches =[ 'gemType' ] )[0][0]]
+    print gemType
+    ##### END
+    
     print('Initializing histograms')
     from gempython.utils.nesteddict import nesteddict as ndict, flatten
 
@@ -302,9 +309,9 @@ if __name__ == '__main__':
         # All Rates
         rateCanvas = getSummaryCanvas(dict_g_rateObsCTP7VsRatePulsed[isValid],
                                       name="rateObservedVsRatePulsed_{0}".format(strValidity),
-                                      drawOpt="APE1")
-        rateCanvas = addPlotToCanvas(rateCanvas, dict_g_rateObsFPGAVsRatePulsed[isValid], drawOpt="PE1")
-        rateCanvas = addPlotToCanvas(rateCanvas, dict_g_rateObsVFATVsRatePulsed[isValid], drawOpt="PE1")
+                                      drawOpt="APE1", gemType=gemType)
+        rateCanvas = addPlotToCanvas(rateCanvas, dict_g_rateObsFPGAVsRatePulsed[isValid], drawOpt="PE1", gemType=gemType)
+        rateCanvas = addPlotToCanvas(rateCanvas, dict_g_rateObsVFATVsRatePulsed[isValid], drawOpt="PE1", gemType=gemType)
         
         # Make the legend
         rateLeg = r.TLegend(0.5,0.5,0.9,0.9)
@@ -328,11 +335,11 @@ if __name__ == '__main__':
         rateCanvas.SaveAs("{0}/rateObservedVsRatePulsed_{1}.png".format(filename,strValidity))
 
         # CalDisable rate 0 case
-        getSummaryCanvas(dict_h_sbitMulti[isValid][0][0], name="{0}/sbitMulti_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="", write2Disk=True)
-        getSummaryCanvas(dict_h_sbitSize[isValid][0][0], name="{0}/sbitSize_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="", write2Disk=True)
+        getSummaryCanvas(dict_h_sbitMulti[isValid][0][0], name="{0}/sbitMulti_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="", gemType=gemType, write2Disk=True)
+        getSummaryCanvas(dict_h_sbitSize[isValid][0][0], name="{0}/sbitSize_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="", gemType=gemType, write2Disk=True)
 
-        getSummaryCanvas(dict_h_sbitObsVsChanPulsed[isValid][0][0], name="{0}/sbitObsVsChanUnmasked_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="COLZ", write2Disk=True)
-        getSummaryCanvas(dict_h_sbitMultiVsSbitSize[isValid][0][0], name="{0}/sbitMultiVsSbitSize_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="COLZ", write2Disk=True)
+        getSummaryCanvas(dict_h_sbitObsVsChanPulsed[isValid][0][0], name="{0}/sbitObsVsChanUnmasked_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="COLZ", gemType=gemType, write2Disk=True)
+        getSummaryCanvas(dict_h_sbitMultiVsSbitSize[isValid][0][0], name="{0}/sbitMultiVsSbitSize_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="COLZ", gemType=gemType, write2Disk=True)
         
         for idx,rate in enumerate(ratesUsed):
             # Sum over all rates
@@ -375,11 +382,11 @@ if __name__ == '__main__':
                         dict_h_sbitObsVsChanPulsed[isValid][1][-1][vfat].Add(dict_h_sbitObsVsChanPulsed[isValid][1][rate][vfat])
                         dict_h_sbitMultiVsSbitSize[isValid][1][-1][vfat].Add(dict_h_sbitMultiVsSbitSize[isValid][1][rate][vfat])
         
-                getSummaryCanvas(dict_h_sbitMulti[isValid][1][-1], name="{0}/sbitMulti_{1}_calEnabled_SumOfAllRates.png".format(filename,strValidity), drawOpt="", write2Disk=True)
-                getSummaryCanvas(dict_h_sbitSize[isValid][1][-1], name="{0}/sbitSize_{1}_calEnabled_SumOfAllRates.png".format(filename,strValidity), drawOpt="", write2Disk=True)
+                getSummaryCanvas(dict_h_sbitMulti[isValid][1][-1], name="{0}/sbitMulti_{1}_calEnabled_SumOfAllRates.png".format(filename,strValidity), drawOpt="", gemType=gemType, write2Disk=True)
+                getSummaryCanvas(dict_h_sbitSize[isValid][1][-1], name="{0}/sbitSize_{1}_calEnabled_SumOfAllRates.png".format(filename,strValidity), drawOpt="", gemType=gemType, write2Disk=True)
 
-                getSummaryCanvas(dict_h_sbitObsVsChanPulsed[isValid][1][-1], name="{0}/sbitObsVsChanPulsed_{1}_calEnabled_SumOfAllRates.png".format(filename,strValidity), drawOpt="COLZ", write2Disk=True)
-                getSummaryCanvas(dict_h_sbitMultiVsSbitSize[isValid][1][-1], name="{0}/sbitMultiVsSbitSize_{1}_calEnabled_SumOfAllRates.png".format(filename,strValidity), drawOpt="COLZ", write2Disk=True)
+                getSummaryCanvas(dict_h_sbitObsVsChanPulsed[isValid][1][-1], name="{0}/sbitObsVsChanPulsed_{1}_calEnabled_SumOfAllRates.png".format(filename,strValidity), drawOpt="COLZ", gemType=gemType, write2Disk=True)
+                getSummaryCanvas(dict_h_sbitMultiVsSbitSize[isValid][1][-1], name="{0}/sbitMultiVsSbitSize_{1}_calEnabled_SumOfAllRates.png".format(filename,strValidity), drawOpt="COLZ", gemType=gemType, write2Disk=True)
 
     print("Storing TObjects in output TFile")
     # Per VFAT Plots

--- a/anaSBitMonitor.py
+++ b/anaSBitMonitor.py
@@ -39,8 +39,7 @@ if __name__ == '__main__':
     isValidValues = np.unique(initInfo['isValid'])
     ratesUsed = np.unique(initInfo['ratePulsed'])
 
-    ##### NEED TO FIX
-    #### VERY TEMPORARY
+    ##### FIXME
     from gempython.gemplotting.mapping.chamberInfo import gemTypeMapping
     if 'gemType' not in inF.sbitDataTree.GetListOfBranches():
         gemType = "ge11"

--- a/anaSBitMonitor.py
+++ b/anaSBitMonitor.py
@@ -41,14 +41,17 @@ if __name__ == '__main__':
     calEnableValues = np.unique(initInfo['calEnable'])
     isValidValues = np.unique(initInfo['isValid'])
     ratesUsed = np.unique(initInfo['ratePulsed'])
+
     ##### NEED TO FIX
     #### VERY TEMPORARY
     from gempython.gemplotting.mapping.chamberInfo import gemTypeMapping
-    print rp.tree2array(tree=inF.sbitDataTree, branches ='gemType')
-    gemType = gemTypeMapping[rp.tree2array(tree=inF.sbitDataTree, branches =[ 'gemType' ] )[0][0]]
+    if 'gemType' not in inF.sbitDataTree.GetListOfBranches():
+        gemType = "ge21"
+    else:
+        gemType = gemTypeMapping[rp.tree2array(tree=inF.sbitDataTree, branches =[ 'gemType' ] )[0][0]]
     print gemType
     ##### END
-    
+
     print('Initializing histograms')
     from gempython.utils.nesteddict import nesteddict as ndict, flatten
 

--- a/anaSBitMonitor.py
+++ b/anaSBitMonitor.py
@@ -142,7 +142,7 @@ if __name__ == '__main__':
                         rateMap[rate]=binX+1 # Used later to translate rate to bin position
                     dict_h_chanVsRatePulsed_ZRateObs[isValid][calEnable][vfat].GetXaxis().SetBinLabel(binX+1,formatSciNotation(str(rate)))
 
-                    # VFAT level
+                    # VFAT levpel
                     if (calEnable or (not calEnable and rate == 0.0)):
                         # 1D Obs
                         dict_h_sbitMulti[isValid][calEnable][rate][vfat] = r.TH1F(
@@ -289,7 +289,7 @@ if __name__ == '__main__':
                             dict_h_sbitMultiVsSbitSize[isValid][calEnable][rate][vfat].Fill(size,multi)
     
     print("Making summary plots")
-    from gempython.gemplotting.utils.anautilities import make3x8Canvas, getSummary
+    from gempython.gemplotting.utils.anautilities import addPlotToCanvas, getSummaryCanvas
     for isValid in isValidValues:
         if not isValid and not args.checkInvalid:
             continue
@@ -300,17 +300,11 @@ if __name__ == '__main__':
             strValidity="invalidSbits"
 
         # All Rates
-        rateCanvas = make3x8Canvas(
-                name="rateObservedVsRatePulsed_{0}".format(strValidity),
-                initialContent=dict_g_rateObsCTP7VsRatePulsed[isValid],
-                initialDrawOpt="APE1",
-                secondaryContent=dict_g_rateObsFPGAVsRatePulsed[isValid],
-                secondaryDrawOpt="PE1")
-        rateCanvas = make3x8Canvas(
-                name="",
-                secondaryContent=dict_g_rateObsVFATVsRatePulsed[isValid],
-                secondaryDrawOpt="PE1",
-                canv=rateCanvas)
+        rateCanvas = getSummaryCanvas(dict_g_rateObsCTP7VsRatePulsed[isValid],
+                                      name="rateObservedVsRatePulsed_{0}".format(strValidity),
+                                      drawOpt="APE1")
+        rateCanvas = addPlotToCanvas(rateCanvas, dict_g_rateObsFPGAVsRatePulsed[isValid], drawOpt="PE1")
+        rateCanvas = addPlotToCanvas(rateCanvas, dict_g_rateObsVFATVsRatePulsed[isValid], drawOpt="PE1")
         
         # Make the legend
         rateLeg = r.TLegend(0.5,0.5,0.9,0.9)
@@ -334,11 +328,11 @@ if __name__ == '__main__':
         rateCanvas.SaveAs("{0}/rateObservedVsRatePulsed_{1}.png".format(filename,strValidity))
 
         # CalDisable rate 0 case
-        getSummary(dict_h_sbitMulti[isValid][0][0], name="{0}/sbitMulti_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="", write2Disk=True)
-        getSummary(dict_h_sbitSize[isValid][0][0], name="{0}/sbitSize_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="", write2Disk=True)
+        getSummaryCanvas(dict_h_sbitMulti[isValid][0][0], name="{0}/sbitMulti_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="", write2Disk=True)
+        getSummaryCanvas(dict_h_sbitSize[isValid][0][0], name="{0}/sbitSize_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="", write2Disk=True)
 
-        getSummary(dict_h_sbitObsVsChanPulsed[isValid][0][0], name="{0}/sbitObsVsChanUnmasked_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="COLZ", write2Disk=True)
-        getSummary(dict_h_sbitMultiVsSbitSize[isValid][0][0], name="{0}/sbitMultiVsSbitSize_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="COLZ", write2Disk=True)
+        getSummaryCanvas(dict_h_sbitObsVsChanPulsed[isValid][0][0], name="{0}/sbitObsVsChanUnmasked_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="COLZ", write2Disk=True)
+        getSummaryCanvas(dict_h_sbitMultiVsSbitSize[isValid][0][0], name="{0}/sbitMultiVsSbitSize_{1}_calDisabled_0Hz.png".format(filename,strValidity), drawOpt="COLZ", write2Disk=True)
         
         for idx,rate in enumerate(ratesUsed):
             # Sum over all rates
@@ -381,11 +375,11 @@ if __name__ == '__main__':
                         dict_h_sbitObsVsChanPulsed[isValid][1][-1][vfat].Add(dict_h_sbitObsVsChanPulsed[isValid][1][rate][vfat])
                         dict_h_sbitMultiVsSbitSize[isValid][1][-1][vfat].Add(dict_h_sbitMultiVsSbitSize[isValid][1][rate][vfat])
         
-                getSummary(dict_h_sbitMulti[isValid][1][-1], name="{0}/sbitMulti_{1}_calEnabled_SumOfAllRates.png".format(filename,strValidity), drawOpt="", write2Disk=True)
-                getSummary(dict_h_sbitSize[isValid][1][-1], name="{0}/sbitSize_{1}_calEnabled_SumOfAllRates.png".format(filename,strValidity), drawOpt="", write2Disk=True)
+                getSummaryCanvas(dict_h_sbitMulti[isValid][1][-1], name="{0}/sbitMulti_{1}_calEnabled_SumOfAllRates.png".format(filename,strValidity), drawOpt="", write2Disk=True)
+                getSummaryCanvas(dict_h_sbitSize[isValid][1][-1], name="{0}/sbitSize_{1}_calEnabled_SumOfAllRates.png".format(filename,strValidity), drawOpt="", write2Disk=True)
 
-                getSummary(dict_h_sbitObsVsChanPulsed[isValid][1][-1], name="{0}/sbitObsVsChanPulsed_{1}_calEnabled_SumOfAllRates.png".format(filename,strValidity), drawOpt="COLZ", write2Disk=True)
-                getSummary(dict_h_sbitMultiVsSbitSize[isValid][1][-1], name="{0}/sbitMultiVsSbitSize_{1}_calEnabled_SumOfAllRates.png".format(filename,strValidity), drawOpt="COLZ", write2Disk=True)
+                getSummaryCanvas(dict_h_sbitObsVsChanPulsed[isValid][1][-1], name="{0}/sbitObsVsChanPulsed_{1}_calEnabled_SumOfAllRates.png".format(filename,strValidity), drawOpt="COLZ", write2Disk=True)
+                getSummaryCanvas(dict_h_sbitMultiVsSbitSize[isValid][1][-1], name="{0}/sbitMultiVsSbitSize_{1}_calEnabled_SumOfAllRates.png".format(filename,strValidity), drawOpt="COLZ", write2Disk=True)
 
     print("Storing TObjects in output TFile")
     # Per VFAT Plots

--- a/anaSBitReadout.py
+++ b/anaSBitReadout.py
@@ -110,7 +110,7 @@ if __name__ == '__main__':
     #from subprocess import call
 
     from gempython.utils.wrappers import runCommand
-    print("Analyzing: '%s'" % path)
+    print("Analyzing: '{0}'".format( path))
     runCommand(["mkdir", "-p", filename])
 
     """
@@ -157,22 +157,22 @@ if __name__ == '__main__':
     # searching for all the files with this format and adding them to the TTree
     import glob
     if args.debug:
-        print ("\nReading .dat files from the folder %s" % path)
+        print("\nReading .dat files from the folder {0}".format(path))
     for idx, file in enumerate(glob.glob(path+'/sbitReadOut_run*.dat')):
         os.system("cat "+file+" | tail -n +2 >> "+path + "catfile.txt")
         os.system("echo" + "" + " >>" + path + "catfile.txt")
     inT.ReadFile(path+"catfile.txt", "evtNum/I:sbitClusterData0/I:sbitClusterData1/I:sbitClusterData2/I:sbitClusterData3/I:sbitClusterData4/I:sbitClusterData5/I:sbitClusterData6/I:sbitClusterData7/I")
     if args.debug:
-        print ("%d input files have been read and added to the TTree" % (idx+1))
+        print("{0} input files have been read and added to the TTree".format(idx+1))
 
     inT.Write()
     if args.debug:
-        print ('TTree written\n')
-        print ("Removing the catfile.txt ...")
+        print('TTree written\n')
+        print("Removing the catfile.txt ...")
     runCommand(["rm", path+"catfile.txt"])
 
     if args.debug:
-        print ("Done\n")
+        print("Done\n")
     """
     Going to build the output tree starting from the previous TTree converted into an array.
     First of all, going to initilize the array which will hold the data
@@ -392,14 +392,14 @@ if __name__ == '__main__':
     canv.SaveAs(filename+'/L1A_DelaySummary.png')
 
     # getSummaryByiEta
-    getSummaryCanvasByiEta(ieta_h_strip, name='%s/ietaStripSummary.png' %
-                      filename, trimPt=None, drawOpt="", gemType=gemType, write2Disk=True)
-    getSummaryCanvasByiEta(ieta_h_ch, name='%s/ietaChanSummary.png' %
-                      filename, trimPt=None, drawOpt="", gemType=gemType, write2Disk=True)
-    getSummaryCanvasByiEta(ieta_h_sbitSize, name='%s/ietaSbitSizeSummary.png' %
-                      filename, trimPt=None, drawOpt="", gemType=gemType, write2Disk=True)
-    getSummaryCanvasByiEta(ieta_h_delay, name='%s/ietaDelaySummary.png' %
-                      filename, trimPt=None, drawOpt="", gemType=gemType, write2Disk=True)
+    getSummaryCanvasByiEta(ieta_h_strip, name='{0}/ietaStripSummary.png'.format(filename),
+                           trimPt=None, drawOpt="", gemType=gemType, write2Disk=True)
+    getSummaryCanvasByiEta(ieta_h_ch, name='{0}/ietaChanSummary.png'.format(filename),
+                           trimPt=None, drawOpt="", gemType=gemType, write2Disk=True)
+    getSummaryCanvasByiEta(ieta_h_sbitSize, name='{0}/ietaSbitSizeSummary.png'.format(filename),
+                           trimPt=None, drawOpt="", gemType=gemType, write2Disk=True)
+    getSummaryCanvasByiEta(ieta_h_delay, name='{0}/ietaDelaySummary.png'.format(filename),
+                           trimPt=None, drawOpt="", gemType=gemType, write2Disk=True)
 
     # Making&Filling folders in the TFile
     outF.cd()
@@ -411,7 +411,7 @@ if __name__ == '__main__':
     
     vfatDir.cd()
     for vfat in range(0, vfatsPerGemVariant[gemType]):
-        tempDir = vfatDir.mkdir("VFAT%i" % vfat)
+        tempDir = vfatDir.mkdir("VFAT{0}".format(vfat))
         tempDir.cd()
         vfat_h_strip[vfat].Write()
         vfat_h_ch[vfat].Write()
@@ -420,7 +420,7 @@ if __name__ == '__main__':
 
     ietaDir.cd()
     for ieta in range(1, maxiEta):
-        tempDir = ietaDir.mkdir("iETA%i" % ieta)
+        tempDir = ietaDir.mkdir("iETA{0}".format(ieta))
         tempDir.cd()
         ieta_h_strip[ieta].Write()
         ieta_h_ch[ieta].Write()
@@ -453,9 +453,9 @@ if __name__ == '__main__':
     canv.SaveAs(filename+'/ChvsiEta.png')
 
     outF.Close()
-    print ("\n---Took %f seconds for each .dat file---" %
-           ((time.time() - start_time) / int(idx)))
-    print ("\nGaranting permission to %s..." % filename)
+    print("\n---Took {0} seconds for each .dat file---".format(
+        (time.time() - start_time) / int(idx)))
+    print("\nGaranting permission to {0}...".format(filename))
     runCommand(["chmod", "-R", "770", filename])
-    print ("Data stored in %s" % (filename+'/'+outfilename))
+    print("Data stored in {0}".format(filename+'/'+outfilename))
     print("Bye now")

--- a/anaSBitReadout.py
+++ b/anaSBitReadout.py
@@ -82,9 +82,9 @@ if __name__ == '__main__':
     size = ((args.GEBtype).lower())
     mapping = args.mapping
 
-    #### NEED TO SPECIFY READING
+    ##### FIXME
     gemType="ge11"
-    #### END
+    ##### END
     from gempython.tools.hw_constants import vfatsPerGemVariant
     nVFATS = vfatsPerGemVariant[gemType]
     from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFATS as maxChans
@@ -236,7 +236,7 @@ if __name__ == '__main__':
         vfat_h_ch[vfat] = r.TH1F("h_VFAT{0}_chan_vs_hit".format(vfat), "VFAT{0}".format(vfat), maxChans, 0., maxChans)
         vfat_h_delay[vfat] = r.TH1F("h_VFAT{0}_L1A_sbit_delay".format(vfat), "VFAT{0}: L1A delay".format(vfat), 4096, 0., 4096.)
         vfat_h_sbitSize[vfat] = r.TH1F("h_VFAT{0}_sbitSize_vs_hit".format(vfat), "VFAT{0}: SBIT Size".format(vfat), 8, 0., 8.)
-        vfat_h_strip[vfat] = r.TH1F("h_VFAT{0}_strips_vs_hit".format(vfat), "VFAT{0}".format(vfat), 128, 0., 128.)
+        vfat_h_strip[vfat] = r.TH1F("h_VFAT{0}_strips_vs_hit".format(vfat), "VFAT{0}".format(vfat), maxChans, 0., maxChans)
 
         vfat_h_ch[vfat].SetXTitle("Chan Num")
         vfat_h_ch[vfat].SetFillColorAlpha(r.kBlue, 0.35)
@@ -251,7 +251,7 @@ if __name__ == '__main__':
     ieta_h_delay = ndict()
 
     for ieta in range(1, maxiEta+1):
-        ieta_h_strip[ieta] = r.TH1F("h_ieta{0}_strips_vs_hit".format(ieta), "i#eta = {0} | i#phi (1,2,3)".format(ieta), 128*maxiPhi, 0., 128.*maxiPhi)
+        ieta_h_strip[ieta] = r.TH1F("h_ieta{0}_strips_vs_hit".format(ieta), "i#eta = {0} | i#phi (1,2,3)".format(ieta), maxChans*maxiPhi, 0., maxChans*maxiPhi)
         ieta_h_ch[ieta] = r.TH1F("h_ieta{0}_chan_vs_hit".format(ieta), "i#eta = {0} | i#phi (1,2,3)".format(ieta), maxChans*maxiPhi, 0., maxChans*maxiPhi)
         ieta_h_sbitSize[ieta] = r.TH1F("h_ieta{0}_sbitSize_vs_hit".format(ieta), "i#eta = {0} SBIT Size".format(ieta), 8, 0., 8.)
         ieta_h_delay[ieta] = r.TH1F("h_ieta{0}_L1A_Sbit_delay".format(ieta), "i#eta = {0} L1A delay".format(ieta), 4096, 0., 4096.)
@@ -264,7 +264,7 @@ if __name__ == '__main__':
     # initializing 2Dhisto
     dict_h2d_ieta_strip = ndict()
     dict_h2d_ieta_ch = ndict()
-    dict_h2d_ieta_strip[0] = r.TH2I('h2d_ieta_strip', 'Strips summary        (i#phi = 1,2,3);strip number;i#eta', 128*maxiPhi, 0, 128*maxiPhi, maxiEta, 0.5, 0.5+maxiEta)
+    dict_h2d_ieta_strip[0] = r.TH2I('h2d_ieta_strip', 'Strips summary        (i#phi = 1,2,3);strip number;i#eta', maxChans*maxiPhi, 0, maxChans*maxiPhi, maxiEta, 0.5, 0.5+maxiEta)
     dict_h2d_ieta_ch[0] = r.TH2I('h_2d_ieta_ch', 'Channels summary        (i#phi = 1,2,3);chan number;i#eta', maxChans*maxiPhi, 0, maxChans*maxiPhi, maxiEta, 0.5, 0.5+maxiEta)
 
     # loop over all branch names but the first (evnt num)
@@ -320,16 +320,16 @@ if __name__ == '__main__':
             vfat_h_sbitSize[vfatN[0]].Fill(sbitSize[0])
 
             # filling ieta 1Dhistos
-            ieta_h_strip[eta].Fill((phi-1)*128+strip[0])
-            ieta_h_strip[eta].Fill((phi-1)*128+strip[1])
+            ieta_h_strip[eta].Fill((phi-1)*maxChans+strip[0])
+            ieta_h_strip[eta].Fill((phi-1)*maxChans+strip[1])
             ieta_h_ch[eta].Fill((phi-1)*maxChans+vfatCH[0])
             ieta_h_ch[eta].Fill((phi-1)*maxChans+vfatCH[1])
             ieta_h_delay[eta].Fill(L1Delay[0])
             ieta_h_sbitSize[eta].Fill(sbitSize[0])
 
             # filling 2Dhisto
-            dict_h2d_ieta_strip[0].Fill(strip[0]+128*(phi-1), eta)
-            dict_h2d_ieta_strip[0].Fill(strip[1]+128*(phi-1), eta)
+            dict_h2d_ieta_strip[0].Fill(strip[0]+maxChans*(phi-1), eta)
+            dict_h2d_ieta_strip[0].Fill(strip[1]+maxChans*(phi-1), eta)
             dict_h2d_ieta_ch[0].Fill(vfatCH[0]+maxChans*(phi-1), eta)
             dict_h2d_ieta_ch[0].Fill(vfatCH[1]+maxChans*(phi-1), eta)
 
@@ -362,9 +362,9 @@ if __name__ == '__main__':
                 vfat_h_strip[vfatN[0]].Fill(strip[i])
                 vfat_h_ch[vfatN[0]].Fill(vfatCH[i])
 
-                ieta_h_strip[eta].Fill((phi-1)*128+strip[i])
+                ieta_h_strip[eta].Fill((phi-1)*maxChans+strip[i])
                 ieta_h_ch[eta].Fill((phi-1)*maxChans+vfatCH[i])
-                dict_h2d_ieta_strip[0].Fill(strip[i]+128*(phi-1), eta)
+                dict_h2d_ieta_strip[0].Fill(strip[i]+maxChans*(phi-1), eta)
                 dict_h2d_ieta_ch[0].Fill(vfatCH[i]+maxChans*(phi-1), eta)
                 pass
             outT.Fill()

--- a/anaSBitReadout.py
+++ b/anaSBitReadout.py
@@ -126,8 +126,8 @@ if __name__ == '__main__':
     r.gStyle.SetOptStat(1111111)
 
     # Loading the dictionary with the mapping
-    from gempython.gemplotting.utils.anautilities import make3x8Canvas, getSummaryByiEta, getMapping
-    vfat_ch_strips = getMapping(mapping, isVFAT2=False, gemType)
+    from gempython.gemplotting.utils.anautilities import getSummaryCanvas, getSummaryCanvasByiEta, getMapping
+    vfat_ch_strips = getMapping(mapping, isVFAT2=False, gemType=gemType)
 
     if args.debug:
         print("\nVFAT channels to strips \n"+mapping+"\nMAP loaded")
@@ -392,13 +392,13 @@ if __name__ == '__main__':
     canv.SaveAs(filename+'/L1A_DelaySummary.png')
 
     # getSummaryByiEta
-    getSummaryByiEta(ieta_h_strip, name='%s/ietaStripSummary.png' %
+    getSummaryCanvasByiEta(ieta_h_strip, name='%s/ietaStripSummary.png' %
                       filename, trimPt=None, drawOpt="", write2Disk=True)
-    getSummaryByiEta(ieta_h_ch, name='%s/ietaChanSummary.png' %
+    getSummaryCanvasByiEta(ieta_h_ch, name='%s/ietaChanSummary.png' %
                       filename, trimPt=None, drawOpt="", write2Disk=True)
-    getSummaryByiEta(ieta_h_sbitSize, name='%s/ietaSbitSizeSummary.png' %
+    getSummaryCanvasByiEta(ieta_h_sbitSize, name='%s/ietaSbitSizeSummary.png' %
                       filename, trimPt=None, drawOpt="", write2Disk=True)
-    getSummaryByiEta(ieta_h_delay, name='%s/ietaDelaySummary.png' %
+    getSummaryCanvasByiEta(ieta_h_delay, name='%s/ietaDelaySummary.png' %
                       filename, trimPt=None, drawOpt="", write2Disk=True)
 
     # Making&Filling folders in the TFile

--- a/anaSBitReadout.py
+++ b/anaSBitReadout.py
@@ -371,35 +371,35 @@ if __name__ == '__main__':
     # Summaries Canvas
     #
     # make3x8Canvas
-    canv = getSummaryCanvas(vfat_h_strip, drawOpt="hist")
+    canv = getSummaryCanvas(vfat_h_strip, drawOpt="hist", gemType=gemType)
     canv.SetName("Strip_canv")
     canv.SetTitle("Strip_canv")
     canv.SaveAs(filename+'/StripSummary.png')
 
-    canv = getSummaryCanvas(vfat_h_ch, drawOpt="hist")
+    canv = getSummaryCanvas(vfat_h_ch, drawOpt="hist", gemType=gemType)
     canv.SetName("Chan_canv")
     canv.SetTitle("Chan_canv")
     canv.SaveAs(filename+'/ChanSummary.png')
 
-    canv = getSummaryCanvas(vfat_h_sbitSize, drawOpt="hist")
+    canv = getSummaryCanvas(vfat_h_sbitSize, drawOpt="hist", gemType=gemType)
     canv.SetName("SbitSize_canv")
     canv.SetTitle("SbitSize_canv")
     canv.SaveAs(filename+'/SbitSizeSummary.png')
 
-    canv = getSummaryCanvas(vfat_h_delay, drawOpt="hist")
+    canv = getSummaryCanvas(vfat_h_delay, drawOpt="hist", gemType=gemType)
     canv.SetName("L1A_Delay_canv")
     canv.SetTitle("L1A_Delay_canv")
     canv.SaveAs(filename+'/L1A_DelaySummary.png')
 
     # getSummaryByiEta
     getSummaryCanvasByiEta(ieta_h_strip, name='%s/ietaStripSummary.png' %
-                      filename, trimPt=None, drawOpt="", write2Disk=True)
+                      filename, trimPt=None, drawOpt="", gemType=gemType, write2Disk=True)
     getSummaryCanvasByiEta(ieta_h_ch, name='%s/ietaChanSummary.png' %
-                      filename, trimPt=None, drawOpt="", write2Disk=True)
+                      filename, trimPt=None, drawOpt="", gemType=gemType, write2Disk=True)
     getSummaryCanvasByiEta(ieta_h_sbitSize, name='%s/ietaSbitSizeSummary.png' %
-                      filename, trimPt=None, drawOpt="", write2Disk=True)
+                      filename, trimPt=None, drawOpt="", gemType=gemType, write2Disk=True)
     getSummaryCanvasByiEta(ieta_h_delay, name='%s/ietaDelaySummary.png' %
-                      filename, trimPt=None, drawOpt="", write2Disk=True)
+                      filename, trimPt=None, drawOpt="", gemType=gemType, write2Disk=True)
 
     # Making&Filling folders in the TFile
     outF.cd()

--- a/anaSBitReadout.py
+++ b/anaSBitReadout.py
@@ -87,7 +87,7 @@ if __name__ == '__main__':
     ##### END
     from gempython.tools.hw_constants import vfatsPerGemVariant
     nVFATS = vfatsPerGemVariant[gemType]
-    from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFATS as maxChans
+    from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFAT as maxChans
     
     # Check the validity of the parsed arguments
     if size not in ('long', 'short'):

--- a/anaXDAQLatency.py
+++ b/anaXDAQLatency.py
@@ -54,10 +54,10 @@ if __name__ == "__main__":
         gemType = gemTypeMapping[rp.tree2array(tree=inFile.latTree, branches =[ 'gemType' ] )[0][0]]
     print gemType
     ##### END
-
-
-    
     from gempython.tools.hw_constants import vfatsPerGemVariant
+    nVFATS = vfatsPerGemVariant[gemType]
+    from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFATS as maxChans
+
     # Open input file
     print("Opening input file: {0}".format(args.infile))
     infile = r.TFile(args.infile,"READ")
@@ -87,7 +87,7 @@ if __name__ == "__main__":
     # Make nested containers
     from gempython.utils.nesteddict import nesteddict as ndict
     baseDir = ndict() # baseDir[slot][oh] -> string
-    vfatDirs = ["VFAT-{0}".format(x) for x in range(vfatsPerGemVariant[gemType])]
+    vfatDirs = ["VFAT-{0}".format(x) for x in range(nVFATS)]
 
     allVFATsLatency = ndict()   #   allVFATsLatency[slot][oh]      -> histogram
     dictMapping = ndict()       #   dictMapping[slot][oh]          -> mapping dict
@@ -252,7 +252,7 @@ if __name__ == "__main__":
         canvLat1D = getSummaryCanvas(vfatLatHists[args.slot][oh], name="canvLatScan1D_AMC{0}_OH{1}".format(args.slot,oh), drawOpt="hist", gemType=gemType)
         canvLat2D = getSummaryCanvas(vfatLatHists2D[args.slot][oh], name="canvLatScan2D_AMC{0}_OH{1}".format(args.slot,oh), drawOpt="colz", gemType=gemType)
         
-        for vfat in range(0,vfatsPerGemVariant[gemType]):
+        for vfat in range(0,nVFATS):
             canvHitMulti.cd(vfat).SetLogx()
             canvHitMulti.cd(vfat).SetLogy()
             canvLat1D.cd(vfat).SetLogy()

--- a/anaXDAQLatency.py
+++ b/anaXDAQLatency.py
@@ -45,9 +45,19 @@ if __name__ == "__main__":
     r.gROOT.SetBatch(True)
     r.gStyle.SetOptStat(1111111)
 
-    gemType = "ge11"
-    from gempython.tools.hw_constants import vfatsPerGemVariant
+        ##### NEED TO FIX
+    #### VERY TEMPORARY
+    from gempython.gemplotting.mapping.chamberInfo import gemTypeMapping
+    if 'gemType' not in inFile.latTree.GetListOfBranches():
+        gemType = "ge11"
+    else:
+        gemType = gemTypeMapping[rp.tree2array(tree=inFile.latTree, branches =[ 'gemType' ] )[0][0]]
+    print gemType
+    ##### END
+
+
     
+    from gempython.tools.hw_constants import vfatsPerGemVariant
     # Open input file
     print("Opening input file: {0}".format(args.infile))
     infile = r.TFile(args.infile,"READ")
@@ -157,6 +167,7 @@ if __name__ == "__main__":
         # Get Distributions from File
         for vfat,path in enumerate(vfatDirs):
             # Load Dist
+            print baseDir[args.slot][oh]+path+"/n_hits_per_event"
             vfatHitMulti[args.slot][oh][vfat] = infile.Get(baseDir[args.slot][oh]+path+"/n_hits_per_event") 
             vfatLatHists[args.slot][oh][vfat] = infile.Get(baseDir[args.slot][oh]+path+"/latencyScan")
             vfatLatHists2D[args.slot][oh][vfat] = infile.Get(baseDir[args.slot][oh]+path+"/latencyScan2D")

--- a/anaXDAQLatency.py
+++ b/anaXDAQLatency.py
@@ -45,8 +45,7 @@ if __name__ == "__main__":
     r.gROOT.SetBatch(True)
     r.gStyle.SetOptStat(1111111)
 
-        ##### NEED TO FIX
-    #### VERY TEMPORARY
+    ##### FIXME
     from gempython.gemplotting.mapping.chamberInfo import gemTypeMapping
     if 'gemType' not in inFile.latTree.GetListOfBranches():
         gemType = "ge11"

--- a/anaXDAQLatency.py
+++ b/anaXDAQLatency.py
@@ -45,6 +45,9 @@ if __name__ == "__main__":
     r.gROOT.SetBatch(True)
     r.gStyle.SetOptStat(1111111)
 
+    gemType = "ge11"
+    from gempython.tools.hw_constants import vfatsPerGemVariant
+    
     # Open input file
     print("Opening input file: {0}".format(args.infile))
     infile = r.TFile(args.infile,"READ")
@@ -74,7 +77,7 @@ if __name__ == "__main__":
     # Make nested containers
     from gempython.utils.nesteddict import nesteddict as ndict
     baseDir = ndict() # baseDir[slot][oh] -> string
-    vfatDirs = ["VFAT-%d"%x for x in range(24)]
+    vfatDirs = ["VFAT-%d"%x for x in range(vfatsPerGemVariant[gemType])]
 
     allVFATsLatency = ndict()   #   allVFATsLatency[slot][oh]      -> histogram
     dictMapping = ndict()       #   dictMapping[slot][oh]          -> mapping dict
@@ -85,7 +88,7 @@ if __name__ == "__main__":
     vfatLatHists2D = ndict()    #   vfatHists2D[slot][oh][vfatN]   -> histogram
 
     # Get channel mapping?
-    from gempython.gemplotting.utils.anautilities import getMapping, make3x8Canvas
+    from gempython.gemplotting.utils.anautilities import getMapping, getSummaryCanvas
     if args.mapping is not None:
         print("Getting mapping")
         # Try to get the mapping data
@@ -234,11 +237,11 @@ if __name__ == "__main__":
 
         # Print Canvas
         r.gStyle.SetOptStat(0)
-        canvHitMulti = make3x8Canvas("canvHitMulti_AMC{0}_OH{1}".format(args.slot,oh),vfatHitMulti[args.slot][oh],"hist")
-        canvLat1D = make3x8Canvas("canvLatScan1D_AMC{0}_OH{1}".format(args.slot,oh),vfatLatHists[args.slot][oh],"hist")
-        canvLat2D = make3x8Canvas("canvLatScan2D_AMC{0}_OH{1}".format(args.slot,oh),vfatLatHists2D[args.slot][oh],"colz")
+        canvHitMulti = getSummaryCanvas(vfatHitMulti[args.slot][oh], name="canvHitMulti_AMC{0}_OH{1}".format(args.slot,oh), drawOpt="hist", gemType=gemType)
+        canvLat1D = getSummaryCanvas(vfatLatHists[args.slot][oh], name="canvLatScan1D_AMC{0}_OH{1}".format(args.slot,oh), drawOpt="hist", gemType=gemType)
+        canvLat2D = getSummaryCanvas(vfatLatHists2D[args.slot][oh], name="canvLatScan2D_AMC{0}_OH{1}".format(args.slot,oh), drawOpt="colz", gemType=gemType)
         
-        for vfat in range(0,24):
+        for vfat in range(0,vfatsPerGemVariant[gemType]):
             canvHitMulti.cd(vfat).SetLogx()
             canvHitMulti.cd(vfat).SetLogy()
             canvLat1D.cd(vfat).SetLogy()

--- a/anaXDAQLatency.py
+++ b/anaXDAQLatency.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     ##### END
     from gempython.tools.hw_constants import vfatsPerGemVariant
     nVFATS = vfatsPerGemVariant[gemType]
-    from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFATS as maxChans
+    from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFAT as maxChans
 
     # Open input file
     print("Opening input file: {0}".format(args.infile))

--- a/anaXDAQLatency.py
+++ b/anaXDAQLatency.py
@@ -29,11 +29,11 @@ if __name__ == "__main__":
 
     import os
     if (args.slot < 1 or args.slot > 12):
-        print "Please specify a valid AMC [1,12]"
+        print("Please specify a valid AMC [1,12]")
         exit(os.EX_USAGE)
 
     if (args.ohMask < 0x0 or args.ohMask > 0xfff):
-        print "Please specify a valid ohMask [0x0,0xfff]"
+        print("Please specify a valid ohMask [0x0,0xfff]")
         exit(os.EX_USAGE)
 
     from gempython.utils.wrappers import envCheck
@@ -62,13 +62,13 @@ if __name__ == "__main__":
     print("Opening input file: {0}".format(args.infile))
     infile = r.TFile(args.infile,"READ")
     if not infile:
-        print infilename,"does not exist"
+        print("{0} does not exist".format(infilename))
         exit(os.EX_IOERR)
     if infile.IsZombie():
-        print infilename,"is a zombie"
+        print("{0} is a zombie".format(infilename))
         exit(os.EX_IOERR)
     if not infile.IsOpen():
-        print infilename,"is not open"
+        print("{0} is not open".format(infilename))
         exit(os.EX_IOERR)
         pass
 
@@ -87,7 +87,7 @@ if __name__ == "__main__":
     # Make nested containers
     from gempython.utils.nesteddict import nesteddict as ndict
     baseDir = ndict() # baseDir[slot][oh] -> string
-    vfatDirs = ["VFAT-%d"%x for x in range(vfatsPerGemVariant[gemType])]
+    vfatDirs = ["VFAT-{0}".format(x) for x in range(vfatsPerGemVariant[gemType])]
 
     allVFATsLatency = ndict()   #   allVFATsLatency[slot][oh]      -> histogram
     dictMapping = ndict()       #   dictMapping[slot][oh]          -> mapping dict
@@ -105,8 +105,8 @@ if __name__ == "__main__":
         try:
             mapFile = open(args.mapping, 'r')
         except IOError as e:
-            print "Exception:", e
-            print "Failed to open: '%s'"%mappingFileName
+            print("Exception:", e)
+            print("Failed to open: '{0}'".format(mappingFileName))
         else:
             listMapData = mapFile.readlines()
         finally:
@@ -138,7 +138,7 @@ if __name__ == "__main__":
             continue
 
         # Make base directory
-        baseDir[args.slot][oh] = "AMC13-%d/AMC-%d/GEB-%d/"%(args.amc13,args.slot,oh)
+        baseDir[args.slot][oh] = "AMC13-{0}/AMC-{1}/GEB-{2}/".format(args.amc13, args.slot, oh)
     
         # Check to make sure this AMC13 & AMC exist in the file
         currentDir = infile.GetDirectory(baseDir[args.slot][oh])
@@ -167,7 +167,7 @@ if __name__ == "__main__":
         # Get Distributions from File
         for vfat,path in enumerate(vfatDirs):
             # Load Dist
-            print baseDir[args.slot][oh]+path+"/n_hits_per_event"
+            print(baseDir[args.slot][oh]+path+"/n_hits_per_event")
             vfatHitMulti[args.slot][oh][vfat] = infile.Get(baseDir[args.slot][oh]+path+"/n_hits_per_event") 
             vfatLatHists[args.slot][oh][vfat] = infile.Get(baseDir[args.slot][oh]+path+"/latencyScan")
             vfatLatHists2D[args.slot][oh][vfat] = infile.Get(baseDir[args.slot][oh]+path+"/latencyScan2D")
@@ -234,7 +234,7 @@ if __name__ == "__main__":
             if vfatLatHists[args.slot][oh][vfat]:
                 latMean = vfatLatHists[args.slot][oh][vfat].GetMean()
                 latRMS  = vfatLatHists[args.slot][oh][vfat].GetRMS()
-                print "AMC%i OH%i VFAT%i - %2.4f %2.4f"%(args.slot,oh,vfat,latMean,latRMS)
+                print("AMC{0} OH{1} VFAT{2} - {3:2.4f} {4:2.4f}".format(args.slot,oh,vfat,latMean,latRMS))
                 latencyMean[args.slot][oh].Fill(latMean)
                 latencyRMS[args.slot][oh].Fill(latRMS)
                 if not allVFATsLatency[args.slot][oh]:

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -165,14 +165,14 @@ class ScanDataFitter(DeadChannelFinder):
             for ch in range(0,128):
                 self.scanCount[vfat][ch] = 0
                 if self.isVFAT3:
-                    self.scanFuncs[vfat][ch] = r.TF1('scurveFit_vfat%i_chan%i'%(vfat,ch),'[3]*TMath::Erf((TMath::Max([2],x)-[0])/(TMath::Sqrt(2)*[1]))+[3]',
+                    self.scanFuncs[vfat][ch] = r.TF1('scurveFit_vfat{0}_chan{1}'.format(vfat,ch),'[3]*TMath::Erf((TMath::Max([2],x)-[0])/(TMath::Sqrt(2)*[1]))+[3]',
                             self.calDAC2Q_m[vfat]*253+self.calDAC2Q_b[vfat],self.calDAC2Q_m[vfat]*1+self.calDAC2Q_b[vfat])
-                    self.scanHistos[vfat][ch] = r.TH1D('scurve_vfat%i_chan%i_h'%(vfat,ch),'scurve_vfat%i_chan%i_h'%(vfat,ch),
+                    self.scanHistos[vfat][ch] = r.TH1D('scurve_vfat{0}_chan{1}_h'.format(vfat,ch),'scurve_vfat{0}_chan{1}_h'.format(vfat,ch),
                             254,self.calDAC2Q_m[vfat]*254.5+self.calDAC2Q_b[vfat],self.calDAC2Q_m[vfat]*0.5+self.calDAC2Q_b[vfat])
                 else:
-                    self.scanFuncs[vfat][ch] = r.TF1('scurveFit_vfat%i_chan%i'%(vfat,ch),'[3]*TMath::Erf((TMath::Max([2],x)-[0])/(TMath::Sqrt(2)*[1]))+[3]',
+                    self.scanFuncs[vfat][ch] = r.TF1('scurveFit_vfat{0}_chan{1}'.format(vfat,ch),'[3]*TMath::Erf((TMath::Max([2],x)-[0])/(TMath::Sqrt(2)*[1]))+[3]',
                             self.calDAC2Q_m[vfat]*1+self.calDAC2Q_b[vfat],self.calDAC2Q_m[vfat]*253+self.calDAC2Q_b[vfat])
-                    self.scanHistos[vfat][ch] = r.TH1D('scurve_vfat%i_chan%i_h'%(vfat,ch),'scurve_vfat%i_chan%i_h'%(vfat,ch),
+                    self.scanHistos[vfat][ch] = r.TH1D('scurve_vfat{0}_chan{1}_h'.format(vfat,ch),'scurve_vfat{0}_chan{1}_h'.format(vfat,ch),
                             254,self.calDAC2Q_m[vfat]*0.5+self.calDAC2Q_b[vfat],self.calDAC2Q_m[vfat]*254.5+self.calDAC2Q_b[vfat])
                     pass
                 self.scanHistosChargeBins[vfat][ch] = [self.scanHistos[vfat][ch].GetXaxis().GetBinLowEdge(binX) for binX in range(1,self.scanHistos[vfat][ch].GetNbinsX()+2) ] #Include overflow
@@ -257,11 +257,11 @@ class ScanDataFitter(DeadChannelFinder):
             fitTF1.SetLineColor(r.kBlack)
             
             if not debug:
-                print 'fitting vfat %i'%(vfat)
+                print('fitting vfat {0}'.format(vfat))
 
             for ch in range(0,128):
                 if debug:
-                    print 'fitting vfat %i chan %i'%(vfat,ch)
+                    print('fitting vfat {0} chan {1}'.format(vfat,ch))
                 
                 if self.isDead[vfat][ch]:
                     fitTF1.SetLineColor(r.kGray)
@@ -275,8 +275,8 @@ class ScanDataFitter(DeadChannelFinder):
                 stepN = 0
                 
                 if debug:
-                    print "| stepN | vfatN | vfatCH | isVFAT3 | p0_low | p0 | p0_high | p1_low | p1 | p1_high | p2_low | p2 | p2_high |"
-                    print "| ----- | ----- | ------ | ------- | ------ | -- | ------- | ------ | -- | ------- | ------ | -- | ------- |"
+                    print("| stepN | vfatN | vfatCH | isVFAT3 | p0_low | p0 | p0_high | p1_low | p1 | p1_high | p2_low | p2 | p2_high |")
+                    print("| ----- | ----- | ------ | ------- | ------ | -- | ------- | ------ | -- | ------- | ------ | -- | ------- |")
                 while(stepN < 30):
                     #rand = max(0.0, random.Gaus(10, 5)) # do not accept negative numbers
                     rand = abs(random.Gaus(10, 5)) # take positive definite numbers
@@ -314,7 +314,7 @@ class ScanDataFitter(DeadChannelFinder):
                     
                     if debug:
                         if self.isVFAT3:
-                            print "| %i | %i | %i | %i | %f | %f | %f | %f | %f | %f | %f | %f | %f |"%(
+                            print("| {0} | {1} | {2} | {3} | {4} | {5} | {6} | {7} | {8} | {9} | {10} | {11} | {12} |".format(
                                         stepN,
                                         vfat,
                                         ch,
@@ -328,9 +328,9 @@ class ScanDataFitter(DeadChannelFinder):
                                         -0.01,
                                         init_guess_p2,
                                         self.Nev[vfat][ch]
-                                    )
+                                    ))
                         else:
-                            print "| %i | %i | %i | %i | %f | %f | %f | %f | %f | %f | %f | %f | %f |"%(
+                            print("| {0} | {1} | {2} | {3} | {4} | {5} | {6} | {7} | {8} | {9} | {10} | {11} | {12} |".format(
                                         stepN,
                                         vfat,
                                         ch,
@@ -344,8 +344,7 @@ class ScanDataFitter(DeadChannelFinder):
                                         -0.01,
                                         init_guess_p2,
                                         self.Nev[vfat][ch]
-                                    )
-
+                                    ))
                     # Fit
                     fitResult = self.scanHistos[vfat][ch].Fit('myERF','SQ')
                     fitEmpty = fitResult.IsEmpty()
@@ -360,7 +359,7 @@ class ScanDataFitter(DeadChannelFinder):
                     fitNDF = fitTF1.GetNDF()
                     stepN +=1
                     if (fitChi2 < MinChi2Temp and fitChi2 > 0.0):
-                        self.scanFuncs[vfat][ch] = fitTF1.Clone('scurveFit_vfat%i_chan%i_h'%(vfat,ch))
+                        self.scanFuncs[vfat][ch] = fitTF1.Clone('scurveFit_vfat{0}_chan{1}_h'.format(vfat,ch))
                         self.scanFuncs[vfat][ch].SetLineColor(r.kBlue-2)
                         self.scanFitResults[0][vfat][ch] = fitTF1.GetParameter(0)
                         self.scanFitResults[1][vfat][ch] = fitTF1.GetParameter(1)
@@ -376,9 +375,9 @@ class ScanDataFitter(DeadChannelFinder):
                     pass
                 if debug:
                     print("Converged fit results:")
-                    print "| stepN | vfatN | vfatCH | isVFAT3 | p0 | p1 | p2 | Chi2 | NDF | NormChi2 |"
-                    print "| :---: | :---: | :----: | :-----: | :-: | :-: | :-: | :--: | :-: | :------: |"
-                    print "| %i | %i | %i | %i | %f | %f | %f | %f | %i | %f |"%(
+                    print("| stepN | vfatN | vfatCH | isVFAT3 | p0 | p1 | p2 | Chi2 | NDF | NormChi2 |")
+                    print("| :---: | :---: | :----: | :-----: | :-: | :-: | :-: | :--: | :-: | :------: |")
+                    print("| {0} | {1} | {2} | {3} | {4} | {5} | {6} | {7} | {8} | {9} |".format(
                             stepN,
                             vfat,
                             ch,
@@ -388,7 +387,7 @@ class ScanDataFitter(DeadChannelFinder):
                             self.scanFitResults[2][vfat][ch],
                             self.scanFitResults[3][vfat][ch],
                             self.scanFitResults[5][vfat][ch],
-                            self.scanFitResults[3][vfat][ch] / self.scanFitResults[5][vfat][ch])
+                            self.scanFitResults[3][vfat][ch] / self.scanFitResults[5][vfat][ch]))
                     pass
                 pass
             pass

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -134,7 +134,7 @@ class ScanDataFitter(DeadChannelFinder):
         super(ScanDataFitter, self).__init__(nVFats)
 
         from gempython.utils.nesteddict import nesteddict as ndict
-        from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFATS as maxChans
+        from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFAT as maxChans
         r.gStyle.SetOptStat(0)
 
         self.Nev = ndict()
@@ -245,7 +245,7 @@ class ScanDataFitter(DeadChannelFinder):
 
         r.gROOT.SetBatch(True)
         r.gStyle.SetOptStat(0)
-        from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFATS as maxChans
+        from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFAT as maxChans
     
         random = r.TRandom3()
         random.SetSeed(0)

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -430,7 +430,7 @@ def fitScanData(treeFileName, isVFAT3=False, calFileName=None, calTuple=None, ge
     nVFATS = vfatsPerGemVariant[gemType]
     # Get the fitter
     if calFileName is not None:
-        tuple_calInfo = parseCalFile(calFileName)
+        tuple_calInfo = parseCalFile(calFileName, gemType)
         fitter = ScanDataFitter(
                 calDAC2Q_m = tuple_calInfo[0],
                 calDAC2Q_b = tuple_calInfo[1],
@@ -445,7 +445,7 @@ def fitScanData(treeFileName, isVFAT3=False, calFileName=None, calTuple=None, ge
                 nVFATS=nVFATS
                 )
     else:
-        fitter = ScanDataFitter(isVFAT3=isVFAT3)
+        fitter = ScanDataFitter(isVFAT3=isVFAT3, nVFATS=nVFATS)
         pass
 
     # Read the output data

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -134,6 +134,7 @@ class ScanDataFitter(DeadChannelFinder):
         super(ScanDataFitter, self).__init__(nVFats)
 
         from gempython.utils.nesteddict import nesteddict as ndict
+        from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFATS as maxChans
         r.gStyle.SetOptStat(0)
 
         self.Nev = ndict()
@@ -155,14 +156,14 @@ class ScanDataFitter(DeadChannelFinder):
             self.calDAC2Q_b = calDAC2Q_b
 
         for vfat in range(0,self.nVFats):
-            self.scanFitResults[0][vfat] = np.zeros(128)
-            self.scanFitResults[1][vfat] = np.zeros(128)
-            self.scanFitResults[2][vfat] = np.zeros(128)
-            self.scanFitResults[3][vfat] = np.zeros(128)
-            self.scanFitResults[4][vfat] = np.zeros(128)
-            self.scanFitResults[5][vfat] = np.zeros(128)
-            self.scanFitResults[6][vfat] = np.zeros(128, dtype=bool)
-            for ch in range(0,128):
+            self.scanFitResults[0][vfat] = np.zeros(maxChans)
+            self.scanFitResults[1][vfat] = np.zeros(maxChans)
+            self.scanFitResults[2][vfat] = np.zeros(maxChans)
+            self.scanFitResults[3][vfat] = np.zeros(maxChans)
+            self.scanFitResults[4][vfat] = np.zeros(maxChans)
+            self.scanFitResults[5][vfat] = np.zeros(maxChans)
+            self.scanFitResults[6][vfat] = np.zeros(maxChans, dtype=bool)
+            for ch in range(0,maxChans):
                 self.scanCount[vfat][ch] = 0
                 if self.isVFAT3:
                     self.scanFuncs[vfat][ch] = r.TF1('scurveFit_vfat{0}_chan{1}'.format(vfat,ch),'[3]*TMath::Erf((TMath::Max([2],x)-[0])/(TMath::Sqrt(2)*[1]))+[3]',
@@ -179,7 +180,7 @@ class ScanDataFitter(DeadChannelFinder):
                 pass
             pass
 
-        self.fitValid = [ np.zeros(128, dtype=bool) for vfat in range(self.nVFats) ]
+        self.fitValid = [ np.zeros(maxChans, dtype=bool) for vfat in range(self.nVFats) ]
 
         return
 
@@ -244,7 +245,8 @@ class ScanDataFitter(DeadChannelFinder):
 
         r.gROOT.SetBatch(True)
         r.gStyle.SetOptStat(0)
-
+        from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFATS as maxChans
+    
         random = r.TRandom3()
         random.SetSeed(0)
         for vfat in range(0,self.nVFats):
@@ -259,7 +261,7 @@ class ScanDataFitter(DeadChannelFinder):
             if not debug:
                 print('fitting vfat {0}'.format(vfat))
 
-            for ch in range(0,128):
+            for ch in range(0,maxChans):
                 if debug:
                     print('fitting vfat {0} chan {1}'.format(vfat,ch))
                 

--- a/macros/calibrateThrDac.py
+++ b/macros/calibrateThrDac.py
@@ -128,9 +128,6 @@ if __name__ == '__main__':
         debug=args.debug
     )
 
-    print ns
-    print ns.inputFile
-    
     try:
         retCode = calibrateThrDAC(ns)
     except IOError as err:

--- a/macros/calibrateThrDac.py
+++ b/macros/calibrateThrDac.py
@@ -127,6 +127,10 @@ if __name__ == '__main__':
         savePlots=args.savePlots,
         debug=args.debug
     )
+
+    print ns
+    print ns.inputFile
+    
     try:
         retCode = calibrateThrDAC(ns)
     except IOError as err:

--- a/macros/gemPlotter.py
+++ b/macros/gemPlotter.py
@@ -310,15 +310,15 @@ def arbitraryPlotter(anaType, listDataPtTuples, rootFileName, treeName, branchNa
         # Setup Paths
         dirPath = getDirByAnaType(anaType.strip("Ana"), cName, ztrim)
         if not filePathExists(dirPath, scandate):
-            print 'Filepath %s/%s does not exist!'%(dirPath, scandate)
+            print('Filepath {0}/{1} does not exist!'.format(dirPath, scandate))
             if skipBad:
-                print 'Skipping'
+                print('Skipping')
                 continue
             else:
-                print 'Please cross-check, exiting!'
+                print('Please cross-check, exiting!')
                 exit(os.EX_DATAERR)
                 pass
-        filename = "%s/%s/%s"%(dirPath, scandate, rootFileName)
+        filename = "{0}/{1}/{2}".format(dirPath, scandate, rootFileName)
 
         # Get TTree
         try:
@@ -326,13 +326,13 @@ def arbitraryPlotter(anaType, listDataPtTuples, rootFileName, treeName, branchNa
             dataTree = dataFile.Get(treeName)
             knownBranches = dataTree.GetListOfBranches()
         except AttributeError as e:
-            print '%s may not exist in %s'%(treeName,filename)
-            print e
+            print('{0} may not exist in {1}'.format(treeName,filename))
+            print(e)
             if skipBad:
-                print 'Skipping'
+                print('Skipping')
                 continue
             else:
-                print 'Please cross-check, exiting!'
+                print('Please cross-check, exiting!')
                 exit(os.EX_DATAERR)
                 pass
             pass
@@ -340,11 +340,11 @@ def arbitraryPlotter(anaType, listDataPtTuples, rootFileName, treeName, branchNa
         # Check to make sure listNames are present in dataTree
         for testBranch in listNames:
             if testBranch not in knownBranches:
-                print "Branch %s not in TTree %s of file %s"%(branchName, treeName, filename)
-                print "Existing Branches are:"
+                print("Branch {0} not in TTree {1} of file {2}".format(branchName, treeName, filename))
+                print("Existing Branches are:")
                 for realBranch in knownBranches:
-                    print realBranch
-                print "Please try again using one of the existing branches"
+                    print(realBranch)
+                print("Please try again using one of the existing branches")
                 exit(os.EX_DATAERR)
 
         # Get dependent variable value
@@ -425,15 +425,15 @@ def arbitraryPlotter2D(anaType, listDataPtTuples, rootFileName, treeName, branch
         # Setup Paths
         dirPath = getDirByAnaType(anaType.strip("Ana"), cName, ztrim)
         if not filePathExists(dirPath, scandate):
-            print 'Filepath %s/%s does not exist!'%(dirPath, scandate)
+            print('Filepath {0}/{1} does not exist!'.format(dirPath, scandate))
             if skipBad:
-                print 'Skipping'
+                print('Skipping')
                 continue
             else:
-                print 'Please cross-check, exiting!'
+                print('Please cross-check, exiting!')
                 exit(os.EX_DATAERR)
                 pass
-        filename = "%s/%s/%s"%(dirPath, scandate, rootFileName)
+        filename = "{0}/{1}/{2}".format(dirPath, scandate, rootFileName)
 
         # Get TTree
         try:
@@ -441,13 +441,13 @@ def arbitraryPlotter2D(anaType, listDataPtTuples, rootFileName, treeName, branch
             dataTree = dataFile.Get(treeName)
             knownBranches = dataTree.GetListOfBranches()
         except AttributeError as e:
-            print '%s may not exist in %s'%(treeName,filename)
-            print e
+            print('{0} may not exist in {1}'.format(treeName,filename))
+            print(e)
             if skipBad:
-                print 'Skipping'
+                print('Skipping')
                 continue
             else:
-                print 'Please cross-check, exiting!'
+                print('Please cross-check, exiting!')
                 exit(os.EX_DATAERR)
                 pass
             pass
@@ -455,11 +455,11 @@ def arbitraryPlotter2D(anaType, listDataPtTuples, rootFileName, treeName, branch
         # Check to make sure listNames are present in dataTree
         for testBranch in listNames:
             if testBranch not in knownBranches:
-                print "Branch %s not in TTree %s of file %s"%(branchName, treeName, filename)
-                print "Existing Branches are:"
+                print("Branch {0} not in TTree {1} of file {2}".format(branchName, treeName, filename))
+                print("Existing Branches are:")
                 for realBranch in knownBranches:
-                    print realBranch
-                print "Please try again using one of the existing branches"
+                    print(realBranch)
+                print("Please try again using one of the existing branches")
                 exit(os.EX_DATAERR)
 
         # Get dependent variable value - VFAT Level
@@ -538,13 +538,13 @@ if __name__ == '__main__':
     elif options.vfat != None:
         listVFATs.append(options.vfat)
     else:
-        print "You must specify at least one VFAT to be considered"
+        print("You must specify at least one VFAT to be considered")
         exit(os.EX_USAGE)
     
     # Check anaType is understood
     if options.anaType not in tree_names.keys():
-        print "Invalid analysis specificed, please select only from the list:"
-        print tree_names.keys()
+        print("Invalid analysis specificed, please select only from the list:")
+        print(tree_names.keys())
         exit(os.EX_USAGE)
         pass
     
@@ -562,10 +562,10 @@ if __name__ == '__main__':
         # Set the strip or channel name
         if options.channels:
             vfatCH = options.strip
-            strStripOrChan = "vfatCH%i"%options.strip
+            strStripOrChan = "vfatCH{0}".format(options.strip)
         else:
             strip = options.strip
-            strStripOrChan = "ROBstr%i"%options.strip
+            strStripOrChan = "ROBstr{0}".format(options.strip)
     elif options.make2D:
         strDrawOpt = "COLZ"
 
@@ -603,7 +603,7 @@ if __name__ == '__main__':
 
     # Loop over the vfats in listVFATs and make the requested plot for each
     strIndepVarNoBraces = strIndepVar.replace('{','').replace('}','').replace('_','')
-    strRootName = "%s/gemPlotterOutput_%s_vs_%s.root"%(elogPath,options.branchName, strIndepVarNoBraces)
+    strRootName = "{0}/gemPlotterOutput_{1}_vs_{2}.root".format(elogPath,options.branchName, strIndepVarNoBraces)
     r.gROOT.SetBatch(True)
     outF = r.TFile(strRootName,options.rootOpt)
     listPlots = []
@@ -611,14 +611,14 @@ if __name__ == '__main__':
         # Make the output directory
         dirVFAT = r.TDirectory()
         if options.rootOpt.upper() == "UPDATE":
-            dirVFAT = outF.GetDirectory("VFAT%i"%vfat, False, "GetDirectory")
+            dirVFAT = outF.GetDirectory("VFAT{0}".format(vfat), False, "GetDirectory")
         else:
-            dirVFAT = outF.mkdir("VFAT%i"%vfat)
+            dirVFAT = outF.mkdir("VFAT{0}".format(vfat))
             pass
 
         # Make the output canvas, use a temp name and temp title for now
         strCanvName = ""
-        canvPlot = r.TCanvas("canv_VFAT%i"%(vfat),"VFAT%i"%(vfat),2400,800)
+        canvPlot = r.TCanvas("canv_VFAT{0}".format(vfat),"VFAT{0}".format(vfat),2400,800)
 
         # Make the plot, either 2D or 1D
         if options.make2D:
@@ -633,21 +633,21 @@ if __name__ == '__main__':
                     options.ztrim,
                     skipBad=options.skipBadFiles)
 
-            # Print to the user
+            # Print(to the user)
             if options.printData:
-                print "===============Printing Data for VFAT%i==============="%(vfat)
-                print "[BEGIN_DATA]"
-                print "\tVAR_INDEP,VAR_DEP,VALUE"
+                print("===============Printing Data for VFAT{0}===============".format(vfat))
+                print("[BEGIN_DATA]")
+                print("\tVAR_INDEP,VAR_DEP,VALUE")
                 for dataPt in listData:
-                    print "\t%f,%f,%f"%(dataPt[0],dataPt[1],dataPt[2])
-                print "[END_DATA]"
-                print ""
+                    print("\t{0},{1},{2}".format(dataPt[0],dataPt[1],dataPt[2]))
+                print("[END_DATA]")
+                print("")
             
 
             # Make the plot
             binsIndepVarLowEdge = array.array('d',listIndepVarLowEdge)
-            hPlot2D = r.TH2F("h_%s_vs_%s_Obs%s_VFAT%i"%(strStripOrChan, strIndepVarNoBraces, options.branchName, vfat),
-                            "VFAT%i"%(vfat),
+            hPlot2D = r.TH2F("h_{0}_vs_{1}_Obs{2}_VFAT{3}".format(strStripOrChan, strIndepVarNoBraces, options.branchName, vfat),
+                            "VFAT{0}".format(vfat),
                             len(listIndepVarLowEdge)-1, binsIndepVarLowEdge,
                             128, -0.5, 127.5)
             hPlot2D.SetXTitle(strIndepVar)
@@ -670,9 +670,9 @@ if __name__ == '__main__':
                 r.gStyle.SetOptStat(0000000)
                 
             # Draw this plot on a canvas
-            strCanvName = "%s/canv_%s_vs_%s_Obs%s_VFAT%i.png"%(elogPath, strStripOrChan, strIndepVarNoBraces, options.branchName, vfat)
-            canvPlot.SetName("canv_%s_vs_%s_Obs%s_VFAT%i.png"%(strStripOrChan, strIndepVarNoBraces, options.branchName, vfat))
-            canvPlot.SetTitle("VFAT%i: %s vs. %s - Obs %s"%(vfat,strStripOrChan,strIndepVarNoBraces, options.branchName))
+            strCanvName = "{0}/canv_{1}_vs_{2}_Obs{3}_VFAT{4}.png".format(elogPath, strStripOrChan, strIndepVarNoBraces, options.branchName, vfat)
+            canvPlot.SetName("canv_{0}_vs_{1}_Obs{2}_VFAT{3}.png".format(strStripOrChan, strIndepVarNoBraces, options.branchName, vfat))
+            canvPlot.SetTitle("VFAT{0}: {1} vs. {2} - Obs {3}".format(vfat,strStripOrChan,strIndepVarNoBraces, options.branchName))
             canvPlot.SetRightMargin(0.15)
             canvPlot.cd()
             hPlot2D.GetZaxis().SetRangeUser(options.axisMin, options.axisMax)
@@ -697,16 +697,16 @@ if __name__ == '__main__':
                     options.ztrim,
                     skipBad=options.skipBadFiles)
 
-            # Print to the user
+            # Print(to the user)
             # Using format compatible with: https://github.com/cms-gem-detqc-project/CMS_GEM_Analysis_Framework#4eiviii-header-parameters---data
             if options.printData:
-                print "===============Printing Data for VFAT%i==============="%(vfat)
-                print "[BEGIN_DATA]"
-                print "\tVAR_INDEP,VAR_DEP,VAR_DEP_ERR"
+                print("===============Printing Data for VFAT{0}===============".format(vfat))
+                print("[BEGIN_DATA]")
+                print("\tVAR_INDEP,VAR_DEP,VAR_DEP_ERR")
                 for dataPt in listData:
-                    print "\t%f,%f,%f"%(dataPt[0],dataPt[1],dataPt[2])
-                print "[END_DATA]"
-                print ""
+                    print("\t{0},{1},{2}".format(dataPt[0],dataPt[1],dataPt[2]))
+                print("[END_DATA]")
+                print("")
 
             # Make the plot
             thisPlot = r.TGraphErrors(len(listData))
@@ -714,8 +714,8 @@ if __name__ == '__main__':
                 strDrawOpt = "PE1v"
                 
                 binsIndepVarLowEdge = array.array('d',listIndepVarLowEdge)
-                thisPlot = r.TH1F("h_%s_vs_%s_VFAT%i_%s"%(options.branchName, strIndepVarNoBraces, vfat, strStripOrChan),
-                                  "VFAT%i_%s"%(vfat,strStripOrChan),
+                thisPlot = r.TH1F("h_{0}_vs_{1}_VFAT{2}_{3}".format(options.branchName, strIndepVarNoBraces, vfat, strStripOrChan),
+                                  "VFAT{0}_{1}".format(vfat,strStripOrChan),
                                   len(listIndepVarLowEdge)-1, binsIndepVarLowEdge)
            
                 for binX,item in enumerate(listDataPtTuples):
@@ -726,8 +726,8 @@ if __name__ == '__main__':
                     if thisPlot.GetXaxis().GetBinLabel(idx+1) == listDataPtTuples[idx][2]:
                         thisPlot.SetBinError(idx+1, listData[idx][2])
             else:
-                thisPlot.SetTitle("VFAT%i_%s"%(vfat,strStripOrChan))
-                thisPlot.SetName("g_%s_vs_%s_VFAT%i_%s"%(options.branchName, strIndepVarNoBraces, vfat, strStripOrChan))
+                thisPlot.SetTitle("VFAT{0}_{1}".format(vfat,strStripOrChan))
+                thisPlot.SetName("g_{0}_vs_{1}_VFAT{2}_{3}".format(options.branchName, strIndepVarNoBraces, vfat, strStripOrChan))
                 for idx in range(len(listData)):
                     thisPlot.SetPoint(idx, listData[idx][0], listData[idx][1])
                     thisPlot.SetPointError(idx, 0., listData[idx][2])
@@ -735,9 +735,9 @@ if __name__ == '__main__':
             # Draw this plot on a canvas
             thisPlot.SetMarkerStyle(20)
             thisPlot.SetLineWidth(2)
-            strCanvName = "%s/canv_%s_vs_%s_VFAT%i_%s.png"%(elogPath, options.branchName,strIndepVarNoBraces, vfat,strStripOrChan)
-            canvPlot.SetName("canv_%s_vs_%s_VFAT%i_%s"%(options.branchName,strIndepVarNoBraces, vfat, strStripOrChan))
-            canvPlot.SetTitle("VFAT%i_%s: %s vs. %s"%(vfat,strStripOrChan,options.branchName,strIndepVarNoBraces))
+            strCanvName = "{0}/canv_{1}_vs_{2}_VFAT{3}_{4}.png".format(elogPath, options.branchName,strIndepVarNoBraces, vfat,strStripOrChan)
+            canvPlot.SetName("canv_{0}_vs_{1}_VFAT{2}_{3}".format(options.branchName,strIndepVarNoBraces, vfat, strStripOrChan))
+            canvPlot.SetTitle("VFAT{0}_{1}: {2} vs. {3}".format(vfat,strStripOrChan,options.branchName,strIndepVarNoBraces))
             canvPlot.cd()
             thisPlot.Draw(strDrawOpt)
             thisPlot.GetXaxis().SetTitle(strIndepVar)
@@ -754,10 +754,10 @@ if __name__ == '__main__':
             pass
         
         if not options.all_plots:
-            print ""
-            print "To view your plot, execute:"
-            print ("eog " + strCanvName)
-            print ""
+            print("")
+            print("To view your plot, execute:")
+            print("eog " + strCanvName)
+            print("")
 
         # Store the Canvas
         canvPlot.Update()
@@ -769,21 +769,21 @@ if __name__ == '__main__':
     # Make Summary Plot
     if options.all_plots:
         from gempython.gemplotting.utils.anautilities import getSummaryCanvas
-        strSummaryName = "summary_%s_vs_%s_%s"%(options.branchName, strIndepVarNoBraces,strStripOrChan)
+        strSummaryName = "summary_{0}_vs_{1}_{2}".format(options.branchName, strIndepVarNoBraces,strStripOrChan)
         canv_summary = getSummaryCanvas(listPlots, name=strSummaryName, drawOpt=strDrawOpt, gemType=gemType)
         
-        strCanvName = "%s/%s.png"%(elogPath,strSummaryName)
+        strCanvName = "{0}/{1}.png".format(elogPath,strSummaryName)
         canv_summary.SaveAs(strCanvName)
         
         outF.cd()
         canv_summary.Write()
 
-        print ""
-        print "To view your plot, execute:"
-        print ("eog " + strCanvName)
-        print ""
+        print("")
+        print("To view your plot, execute:")
+        print("eog " + strCanvName)
+        print("")
 
-    print ""
-    print "Your plot is stored in a TFile, to open it execute:"
-    print ("root " + strRootName)
-    print ""
+    print("")
+    print("Your plot is stored in a TFile, to open it execute:")
+    print("root " + strRootName)
+    print("")

--- a/macros/gemPlotter.py
+++ b/macros/gemPlotter.py
@@ -526,10 +526,13 @@ if __name__ == '__main__':
     envCheck('ELOG_PATH')
     elogPath  = os.getenv('ELOG_PATH')
 
+    gemType="ge11"
+    from gempython.tools.hw_constants import vfatsPerGemVariant
+    
     # Get VFAT List
     listVFATs = []
     if options.all_plots:
-        listVFATs = (x for x in range(0,24))
+        listVFATs = (x for x in range(0,vfatsPerGemVariant[gemType]))
     elif options.vfatList != None:
         listVFATs = map(int, options.vfatList.split(','))
     elif options.vfat != None:
@@ -765,9 +768,9 @@ if __name__ == '__main__':
 
     # Make Summary Plot
     if options.all_plots:
-        from gempython.gemplotting.utils.anautilities import make3x8Canvas
+        from gempython.gemplotting.utils.anautilities import getSummaryCanvas
         strSummaryName = "summary_%s_vs_%s_%s"%(options.branchName, strIndepVarNoBraces,strStripOrChan)
-        canv_summary = make3x8Canvas( strSummaryName, listPlots, strDrawOpt)
+        canv_summary = getSummaryCanvas(listPlots, name=strSummaryName, drawOpt=strDrawOpt)
         
         strCanvName = "%s/%s.png"%(elogPath,strSummaryName)
         canv_summary.SaveAs(strCanvName)

--- a/macros/gemPlotter.py
+++ b/macros/gemPlotter.py
@@ -770,7 +770,7 @@ if __name__ == '__main__':
     if options.all_plots:
         from gempython.gemplotting.utils.anautilities import getSummaryCanvas
         strSummaryName = "summary_%s_vs_%s_%s"%(options.branchName, strIndepVarNoBraces,strStripOrChan)
-        canv_summary = getSummaryCanvas(listPlots, name=strSummaryName, drawOpt=strDrawOpt)
+        canv_summary = getSummaryCanvas(listPlots, name=strSummaryName, drawOpt=strDrawOpt, gemType=gemType)
         
         strCanvName = "%s/%s.png"%(elogPath,strSummaryName)
         canv_summary.SaveAs(strCanvName)

--- a/macros/plotSCurveFitResults.py
+++ b/macros/plotSCurveFitResults.py
@@ -183,11 +183,11 @@ if __name__ == '__main__':
         # Setup the path
         dirPath = getDirByAnaType(options.anaType.strip("Ana"), chamberAndScanDatePair[0], options.ztrim)
         if not filePathExists(dirPath, chamberAndScanDatePair[1]):
-            print 'Filepath %s/%s does not exist!'%(dirPath, chamberAndScanDatePair[1])
-            print 'Please cross-check, exiting!'
+            print('Filepath {0}/{1} does not exist!'.format(dirPath, chamberAndScanDatePair[1]))
+            print('Please cross-check, exiting!')
             outF.Close()
             exit(os.EX_DATAERR)
-        filename = "%s/%s/%s"%(dirPath, chamberAndScanDatePair[1], tree_names[options.anaType][0])
+        filename = "{0}/{1}/{2}".format(dirPath, chamberAndScanDatePair[1], tree_names[options.anaType][0])
 
         # Load the file
         r.TH1.AddDirectory(False)
@@ -196,9 +196,9 @@ if __name__ == '__main__':
         # Get all plots from scanFile - vfat level
         for vfat in range(0,vfatsPerGemVariant[gemType]):
             # Fit summary
-            dict_fitSum[chamberAndScanDatePair][vfat] = scanFile.Get("VFAT%i/gFitSummary_VFAT%i"%(vfat,vfat))
+            dict_fitSum[chamberAndScanDatePair][vfat] = scanFile.Get("VFAT{0}/gFitSummary_VFAT{0}".format(vfat))
             dict_fitSum[chamberAndScanDatePair][vfat].SetName(
-                    "%s_%s_%s"%(
+                    "{0}_{1}_{2}".format(
                         dict_fitSum[chamberAndScanDatePair][vfat].GetName(),
                         chamberAndScanDatePair[0],
                         chamberAndScanDatePair[1])
@@ -208,9 +208,9 @@ if __name__ == '__main__':
             dict_fitSum[chamberAndScanDatePair][vfat].SetMarkerStyle(20+idx)
 
             # Scurve Mean
-            dict_ScurveMean[chamberAndScanDatePair][vfat] = scanFile.Get("VFAT%i/gScurveMeanDist_vfat%i"%(vfat,vfat))
+            dict_ScurveMean[chamberAndScanDatePair][vfat] = scanFile.Get("VFAT{0}/gScurveMeanDist_vfat{0}".format(vfat))
             dict_ScurveMean[chamberAndScanDatePair][vfat].SetName(
-                    "%s_%s_%s"%(
+                    "{0}_{1}_{2}".format(
                         dict_ScurveMean[chamberAndScanDatePair][vfat].GetName(),
                         chamberAndScanDatePair[0],
                         chamberAndScanDatePair[1])
@@ -220,9 +220,9 @@ if __name__ == '__main__':
             dict_ScurveMean[chamberAndScanDatePair][vfat].SetMarkerStyle(20+idx)
 
             # Scurve Width
-            dict_ScurveSigma[chamberAndScanDatePair][vfat] = scanFile.Get("VFAT%i/gScurveSigmaDist_vfat%i"%(vfat,vfat))
+            dict_ScurveSigma[chamberAndScanDatePair][vfat] = scanFile.Get("VFAT{0}/gScurveSigmaDist_vfat{0}".format(vfat))
             dict_ScurveSigma[chamberAndScanDatePair][vfat].SetName(
-                    "%s_%s_%s"%(
+                    "{0}_{1}_{2}".format(
                         dict_ScurveSigma[chamberAndScanDatePair][vfat].GetName(),
                         chamberAndScanDatePair[0],
                         chamberAndScanDatePair[1])
@@ -235,9 +235,9 @@ if __name__ == '__main__':
 
         for ieta in range(1,maxiEta+1):
             # Scurve Mean
-            dict_ScurveMeanByiEta[chamberAndScanDatePair][ieta] = scanFile.Get("Summary/ieta%i/gScurveMeanDist_ieta%i"%(ieta,ieta))
+            dict_ScurveMeanByiEta[chamberAndScanDatePair][ieta] = scanFile.Get("Summary/ieta{0}/gScurveMeanDist_ieta{0}".format(ieta))
             dict_ScurveMeanByiEta[chamberAndScanDatePair][ieta].SetName(
-                    "%s_%s_%s"%(
+                    "{0}_{1}_{2}".format(
                         dict_ScurveMeanByiEta[chamberAndScanDatePair][ieta].GetName(),
                         chamberAndScanDatePair[0],
                         chamberAndScanDatePair[1])
@@ -247,9 +247,9 @@ if __name__ == '__main__':
             dict_ScurveMeanByiEta[chamberAndScanDatePair][ieta].SetMarkerStyle(20+idx)
 
             # Scurve Sigma
-            dict_ScurveSigmaByiEta[chamberAndScanDatePair][ieta] = scanFile.Get("Summary/ieta%i/gScurveSigmaDist_ieta%i"%(ieta,ieta))
+            dict_ScurveSigmaByiEta[chamberAndScanDatePair][ieta] = scanFile.Get("Summary/ieta{0}/gScurveSigmaDist_ieta{0}".format(ieta))
             dict_ScurveSigmaByiEta[chamberAndScanDatePair][ieta].SetName(
-                    "%s_%s_%s"%(
+                    "{0}_{1}_{2}".format(
                         dict_ScurveSigmaByiEta[chamberAndScanDatePair][ieta].GetName(),
                         chamberAndScanDatePair[0],
                         chamberAndScanDatePair[1])
@@ -262,7 +262,7 @@ if __name__ == '__main__':
         # Get the detector level plots
         dict_ScurveMean[chamberAndScanDatePair][-1] = scanFile.Get("Summary/gScurveMeanDist_All")
         dict_ScurveMean[chamberAndScanDatePair][-1].SetName(
-                    "%s_%s_%s"%(
+                    "{0}_{1}_{2}".format(
                         dict_ScurveMean[chamberAndScanDatePair][-1].GetName(),
                         chamberAndScanDatePair[0],
                         chamberAndScanDatePair[1])
@@ -273,7 +273,7 @@ if __name__ == '__main__':
 
         dict_ScurveSigma[chamberAndScanDatePair][-1] = scanFile.Get("Summary/gScurveSigmaDist_All")
         dict_ScurveSigma[chamberAndScanDatePair][-1].SetName(
-                    "%s_%s_%s"%(
+                    "{0}_{1}_{2}".format(
                         dict_ScurveSigma[chamberAndScanDatePair][-1].GetName(),
                         chamberAndScanDatePair[0],
                         chamberAndScanDatePair[1])
@@ -284,7 +284,7 @@ if __name__ == '__main__':
 
         dict_ScurveEffPed[chamberAndScanDatePair][-1] = scanFile.Get("Summary/hScurveEffPedDist_All")
         dict_ScurveEffPed[chamberAndScanDatePair][-1].SetName(
-                    "%s_%s_%s"%(
+                    "{0}_{1}_{2}".format(
                         dict_ScurveEffPed[chamberAndScanDatePair][-1].GetName(),
                         chamberAndScanDatePair[0],
                         chamberAndScanDatePair[1])
@@ -295,7 +295,7 @@ if __name__ == '__main__':
 
         dict_ScurveEffPed_boxPlot[chamberAndScanDatePair] = scanFile.Get("Summary/ScurveEffPed_All")
         dict_ScurveEffPed_boxPlot[chamberAndScanDatePair].SetName(
-                    "%s_%s_%s"%(
+                    "{0}_{1}_{2}".format(
                         dict_ScurveEffPed_boxPlot[chamberAndScanDatePair].GetName(),
                         chamberAndScanDatePair[0],
                         chamberAndScanDatePair[1])
@@ -303,7 +303,7 @@ if __name__ == '__main__':
 
         dict_ScurveThresh_boxPlot[chamberAndScanDatePair] = scanFile.Get("Summary/ScurveMean_All")
         dict_ScurveThresh_boxPlot[chamberAndScanDatePair].SetName(
-                    "%s_%s_%s"%(
+                    "{0}_{1}_{2}".format(
                         dict_ScurveThresh_boxPlot[chamberAndScanDatePair].GetName(),
                         chamberAndScanDatePair[0],
                         chamberAndScanDatePair[1])
@@ -311,7 +311,7 @@ if __name__ == '__main__':
 
         dict_ScurveSigma_boxPlot[chamberAndScanDatePair] = scanFile.Get("Summary/ScurveSigma_All")
         dict_ScurveSigma_boxPlot[chamberAndScanDatePair].SetName(
-                    "%s_%s_%s"%(
+                    "{0}_{1}_{2}".format(
                         dict_ScurveSigma_boxPlot[chamberAndScanDatePair].GetName(),
                         chamberAndScanDatePair[0],
                         chamberAndScanDatePair[1])
@@ -354,13 +354,13 @@ if __name__ == '__main__':
         # Draw per VFAT distributions
         for vfat in range(0,vfatsPerGemVariant[gemType]):
             if idx == 0:
-                dict_mGraph_fitSum[vfat]    = r.TMultiGraph("mGraph_FitSummary_VFAT%i"%(vfat),"VFAT%i"%(vfat))
-                dict_mGraph_ScurveMean[vfat]= r.TMultiGraph("mGraph_ScurveMeanDist_vfat%i"%(vfat),"VFAT%i"%(vfat))
-                dict_mGraph_ScurveSigma[vfat]=r.TMultiGraph("mGraph_ScurveSigmaDist_vfat%i"%(vfat),"VFAT%i"%(vfat))
+                dict_mGraph_fitSum[vfat]    = r.TMultiGraph("mGraph_FitSummary_VFAT{0}".format(vfat),"VFAT{0}".format(vfat))
+                dict_mGraph_ScurveMean[vfat]= r.TMultiGraph("mGraph_ScurveMeanDist_vfat{0}".format(vfat),"VFAT{0}".format(vfat))
+                dict_mGraph_ScurveSigma[vfat]=r.TMultiGraph("mGraph_ScurveSigmaDist_vfat{0}".format(vfat),"VFAT{0}".format(vfat))
 
-                dict_canvSCurveFitSum[vfat] = r.TCanvas("canvScurveFitSum_VFAT%i"%(vfat),"SCurve Fit Summary - VFAT%i"%(vfat),600,600)
-                dict_canvSCurveMean[vfat]   = r.TCanvas("canvScurveMean_VFAT%i"%(vfat),"SCurve Mean - VFAT%i"%(vfat),600,600)
-                dict_canvSCurveSigma[vfat]  = r.TCanvas("canvScurveSigma_VFAT%i"%(vfat),"SCurve Sigma - VFAT%i"%(vfat),600,600)
+                dict_canvSCurveFitSum[vfat] = r.TCanvas("canvScurveFitSum_VFAT{0}".format(vfat),"SCurve Fit Summary - VFAT{0}".format(vfat),600,600)
+                dict_canvSCurveMean[vfat]   = r.TCanvas("canvScurveMean_VFAT{0}".format(vfat),"SCurve Mean - VFAT{0}".format(vfat),600,600)
+                dict_canvSCurveSigma[vfat]  = r.TCanvas("canvScurveSigma_VFAT{0}".format(vfat),"SCurve Sigma - VFAT{0}".format(vfat),600,600)
                 pass
 
             dict_mGraph_fitSum[vfat].Add(dict_fitSum[chamberAndScanDatePair][vfat])
@@ -392,11 +392,11 @@ if __name__ == '__main__':
         # Draw per ieta distributions
         for ieta in range(1,maxiEta+1):
             if idx == 0:
-                dict_mGraph_ScurveMeanByiEta[ieta] = r.TMultiGraph("mGraph_ScurveMeanDist_ieta%i"%(ieta),"i#eta = %i"%(ieta))
-                dict_mGraph_ScurveSigmaByiEta[ieta] = r.TMultiGraph("mGraph_ScurveSigmaDist_ieta%i"%(ieta),"i#eta = %i"%(ieta))
+                dict_mGraph_ScurveMeanByiEta[ieta] = r.TMultiGraph("mGraph_ScurveMeanDist_ieta{0}".format(ieta),"i#eta = {0}".format(ieta))
+                dict_mGraph_ScurveSigmaByiEta[ieta] = r.TMultiGraph("mGraph_ScurveSigmaDist_ieta{0}".format(ieta),"i#eta = {0}".format(ieta))
 
-                dict_canvSCurveMeanByiEta[ieta]   = r.TCanvas("canvScurveMean_ieta%i"%(ieta),"SCurve Mean - ieta%i"%(ieta),600,600)
-                dict_canvSCurveSigmaByiEta[ieta]  = r.TCanvas("canvScurveSigma_ieta%i"%(ieta),"SCurve Sigma - ieta%i"%(ieta),600,600)
+                dict_canvSCurveMeanByiEta[ieta]   = r.TCanvas("canvScurveMean_ieta{0}".format(ieta),"SCurve Mean - ieta{0}".format(ieta),600,600)
+                dict_canvSCurveSigmaByiEta[ieta]  = r.TCanvas("canvScurveSigma_ieta{0}".format(ieta),"SCurve Sigma - ieta{0}".format(ieta),600,600)
                 pass
 
             dict_mGraph_ScurveMeanByiEta[ieta].Add(dict_ScurveMeanByiEta[chamberAndScanDatePair][ieta])
@@ -549,25 +549,25 @@ if __name__ == '__main__':
         pass
 
     # Make output images
-    canvFitSum_Grid.SaveAs("%s/%s.png"%(elogPath,canvFitSum_Grid.GetName()))
-    canvScurveMean_Grid.SaveAs("%s/%s.png"%(elogPath,canvScurveMean_Grid.GetName()))
-    canvScurveSigma_Grid.SaveAs("%s/%s.png"%(elogPath,canvScurveSigma_Grid.GetName()))
+    canvFitSum_Grid.SaveAs("{0}/{1}.png".format(elogPath,canvFitSum_Grid.GetName()))
+    canvScurveMean_Grid.SaveAs("{0}/{1}.png".format(elogPath,canvScurveMean_Grid.GetName()))
+    canvScurveSigma_Grid.SaveAs("{0}/{1}.png".format(elogPath,canvScurveSigma_Grid.GetName()))
 
-    canvScurveMean_Grid_iEta.SaveAs("%s/%s.png"%(elogPath,canvScurveMean_Grid_iEta.GetName()))
-    canvScurveSigma_Grid_iEta.SaveAs("%s/%s.png"%(elogPath,canvScurveSigma_Grid_iEta.GetName()))
+    canvScurveMean_Grid_iEta.SaveAs("{0}/{1}.png".format(elogPath,canvScurveMean_Grid_iEta.GetName()))
+    canvScurveSigma_Grid_iEta.SaveAs("{0}/{1}.png".format(elogPath,canvScurveSigma_Grid_iEta.GetName()))
 
-    canvScurveMean_DetSum.SaveAs("%s/%s.png"%(elogPath,canvScurveMean_DetSum.GetName()))
-    canvScurveSigma_DetSum.SaveAs("%s/%s.png"%(elogPath,canvScurveSigma_DetSum.GetName()))
-    canvScurveEffPed_DetSum.SaveAs("%s/%s.png"%(elogPath,canvScurveEffPed_DetSum.GetName()))
-    canvScurveEffPed_boxPlot.SaveAs("%s/%s.png"%(elogPath,canvScurveEffPed_boxPlot.GetName()))
-    canvScurveThresh_boxPlot.SaveAs("%s/%s.png"%(elogPath,canvScurveThresh_boxPlot.GetName()))
-    canvScurveSigma_boxPlot.SaveAs("%s/%s.png"%(elogPath,canvScurveSigma_boxPlot.GetName()))
+    canvScurveMean_DetSum.SaveAs("{0}/{1}.png".format(elogPath,canvScurveMean_DetSum.GetName()))
+    canvScurveSigma_DetSum.SaveAs("{0}/{1}.png".format(elogPath,canvScurveSigma_DetSum.GetName()))
+    canvScurveEffPed_DetSum.SaveAs("{0}/{1}.png".format(elogPath,canvScurveEffPed_DetSum.GetName()))
+    canvScurveEffPed_boxPlot.SaveAs("{0}/{1}.png".format(elogPath,canvScurveEffPed_boxPlot.GetName()))
+    canvScurveThresh_boxPlot.SaveAs("{0}/{1}.png".format(elogPath,canvScurveThresh_boxPlot.GetName()))
+    canvScurveSigma_boxPlot.SaveAs("{0}/{1}.png".format(elogPath,canvScurveSigma_boxPlot.GetName()))
 
     # Save summary canvas objects in output root file
-    outF = r.TFile("%s/%s"%(elogPath,options.rootName),options.rootOpt)
+    outF = r.TFile("{0}/{1}".format(elogPath,options.rootName),options.rootOpt)
 
     for vfat in range(0,vfatsPerGemVariant[gemType]):
-        dirVFAT = outF.mkdir("VFAT%i"%(vfat))
+        dirVFAT = outF.mkdir("VFAT{0}".format(vfat))
         dirVFAT.cd()
 
         dict_canvSCurveFitSum[vfat].Write()
@@ -582,7 +582,7 @@ if __name__ == '__main__':
 
     dirSummary = outF.mkdir("Summary")
     for ieta in range(1,maxiEta+1):
-        dir_iEta = dirSummary.mkdir("ieta%i"%ieta)
+        dir_iEta = dirSummary.mkdir("ieta{0}".format(ieta))
         dir_iEta.cd()
 
         dict_canvSCurveMeanByiEta[ieta].Write()
@@ -607,14 +607,14 @@ if __name__ == '__main__':
     canvScurveThresh_boxPlot.Write()
     canvScurveSigma_boxPlot.Write()
 
-    print "Your plots can be found in:"
-    print ""
-    print "     %s"%elogPath
-    print ""
+    print("Your plots can be found in:")
+    print("")
+    print("     {0}".format(elogPath))
+    print("")
 
-    print "You can open the output TFile via:"
-    print ""
-    print "     root -l %s/%s"%(elogPath,options.rootName)
+    print("You can open the output TFile via:")
+    print("")
+    print("     root -l {0}/{1}".format(elogPath,options.rootName))
 
-    print ""
-    print "Good-bye"
+    print("")
+    print("Good-bye")

--- a/macros/plotSCurveFitResults.py
+++ b/macros/plotSCurveFitResults.py
@@ -112,12 +112,12 @@ Environment
 
 if __name__ == '__main__':
     from gempython.gemplotting.utils.anaInfo import tree_names
-    from gempython.gemplotting.utils.anautilities import getCyclicColor, getDirByAnaType, filePathExists, make2x4Canvas, make3x8Canvas, parseListOfScanDatesFile
+    from gempython.gemplotting.utils.anautilities import getCyclicColor, getDirByAnaType, filePathExists, getSummaryCanvasByiEta, getSummaryCanvas, parseListOfScanDatesFile
     from gempython.utils.nesteddict import nesteddict as ndict
     from gempython.utils.wrappers import envCheck, runCommand
     from gempython.gemplotting.macros.plotoptions import parser
     from gempython.gemplotting.macros.scurvePlottingUtitilities import overlay_scurve
-   
+
     import os
     import ROOT as r
 
@@ -133,10 +133,10 @@ if __name__ == '__main__':
                     help="Option for the output TFile, e.g. {'RECREATE','UPDATE'}", metavar="rootOpt")
     parser.add_option("--ztrim", type="float", dest="ztrim", default=4.0,
                     help="Specify the p value of the trim", metavar="ztrim")
-    
+
     parser.set_defaults(filename="listOfScanDates.txt")
     (options, args) = parser.parse_args()
- 
+
     # Suppress all pop-ups from ROOT
     r.gROOT.SetBatch(True)
 
@@ -144,7 +144,9 @@ if __name__ == '__main__':
     envCheck('DATA_PATH')
     envCheck('ELOG_PATH')
     elogPath  = os.getenv('ELOG_PATH')
-    
+
+    gemType = "ge11"
+
     # Check anaType is understood
     supportedAnaTypes = ['scurveAna','trimAna']
     if options.anaType not in supportedAnaTypes:
@@ -162,7 +164,7 @@ if __name__ == '__main__':
     #   Inner key -> vfat position
     dict_fitSum = ndict()
     dict_ScurveMean = ndict() # Inner key: (0,23) follows vfat #, -1 is summary over all det
-    dict_ScurveSigma = ndict() 
+    dict_ScurveSigma = ndict()
     dict_ScurveEffPed = ndict()
 
     dict_ScurveMeanByiEta = ndict()
@@ -172,6 +174,10 @@ if __name__ == '__main__':
     dict_ScurveThresh_boxPlot = {}  # key: (chamberName,scandate)
     dict_ScurveSigma_boxPlot = {}  # key: (chamberName,scandate)
 
+    from gempython.tools.hw_constants import vfatsPerGemVariant
+    from gempython.gemplotting.mapping.chamberInfo import chamber_maxiEtaiPhiPair
+    maxiEta, maxiPhi = chamber_maxiEtaiPhiPair[gemType]
+    
     # Get the plots from all files
     for idx,chamberAndScanDatePair in enumerate(listChamberAndScanDate):
         # Setup the path
@@ -186,10 +192,10 @@ if __name__ == '__main__':
         # Load the file
         r.TH1.AddDirectory(False)
         scanFile   = r.TFile(filename,"READ")
-
+        
         # Get all plots from scanFile - vfat level
-        for vfat in range(0,24):
-            # Fit summary 
+        for vfat in range(0,vfatsPerGemVariant[gemType]):
+            # Fit summary
             dict_fitSum[chamberAndScanDatePair][vfat] = scanFile.Get("VFAT%i/gFitSummary_VFAT%i"%(vfat,vfat))
             dict_fitSum[chamberAndScanDatePair][vfat].SetName(
                     "%s_%s_%s"%(
@@ -212,7 +218,7 @@ if __name__ == '__main__':
             dict_ScurveMean[chamberAndScanDatePair][vfat].SetLineColor(getCyclicColor(idx))
             dict_ScurveMean[chamberAndScanDatePair][vfat].SetMarkerColor(getCyclicColor(idx))
             dict_ScurveMean[chamberAndScanDatePair][vfat].SetMarkerStyle(20+idx)
-            
+
             # Scurve Width
             dict_ScurveSigma[chamberAndScanDatePair][vfat] = scanFile.Get("VFAT%i/gScurveSigmaDist_vfat%i"%(vfat,vfat))
             dict_ScurveSigma[chamberAndScanDatePair][vfat].SetName(
@@ -227,7 +233,7 @@ if __name__ == '__main__':
 
             pass
 
-        for ieta in range(1,9):
+        for ieta in range(1,maxiEta+1):
             # Scurve Mean
             dict_ScurveMeanByiEta[chamberAndScanDatePair][ieta] = scanFile.Get("Summary/ieta%i/gScurveMeanDist_ieta%i"%(ieta,ieta))
             dict_ScurveMeanByiEta[chamberAndScanDatePair][ieta].SetName(
@@ -275,7 +281,7 @@ if __name__ == '__main__':
         dict_ScurveSigma[chamberAndScanDatePair][-1].SetLineColor(getCyclicColor(idx))
         dict_ScurveSigma[chamberAndScanDatePair][-1].SetMarkerColor(getCyclicColor(idx))
         dict_ScurveSigma[chamberAndScanDatePair][-1].SetMarkerStyle(20+idx)
-        
+
         dict_ScurveEffPed[chamberAndScanDatePair][-1] = scanFile.Get("Summary/hScurveEffPedDist_All")
         dict_ScurveEffPed[chamberAndScanDatePair][-1].SetName(
                     "%s_%s_%s"%(
@@ -316,7 +322,7 @@ if __name__ == '__main__':
     dict_mGraph_fitSum = ndict()        # key: (0,23) follows vfat #
     dict_mGraph_ScurveMean = ndict()    # key: (0,23) follows vfat #, -1 is summary over all det
     dict_mGraph_ScurveSigma = ndict()   # key: (0,23) follows vfat #, -1 is summary over all det
-       
+
 
     dict_mGraph_ScurveMean[-1] = r.TMultiGraph("mGraph_ScurveMeanDist_All","")
     dict_mGraph_ScurveMean[-1].GetXaxis().SetTitle("scurve mean #left(fC#right)")
@@ -325,8 +331,8 @@ if __name__ == '__main__':
     dict_mGraph_ScurveSigma[-1].GetXaxis().SetTitle("scurve sigma #left(fC#right)")
 
     dict_mGraph_ScurveMeanByiEta = ndict()
-    dict_mGraph_ScurveSigmaByiEta = ndict() 
-    
+    dict_mGraph_ScurveSigmaByiEta = ndict()
+
     # Make the canvas dictionaries
     dict_canvSCurveFitSum = ndict()
     dict_canvSCurveMean = ndict()
@@ -346,7 +352,7 @@ if __name__ == '__main__':
         drawOpt="APE1"
 
         # Draw per VFAT distributions
-        for vfat in range(0,24):
+        for vfat in range(0,vfatsPerGemVariant[gemType]):
             if idx == 0:
                 dict_mGraph_fitSum[vfat]    = r.TMultiGraph("mGraph_FitSummary_VFAT%i"%(vfat),"VFAT%i"%(vfat))
                 dict_mGraph_ScurveMean[vfat]= r.TMultiGraph("mGraph_ScurveMeanDist_vfat%i"%(vfat),"VFAT%i"%(vfat))
@@ -360,10 +366,10 @@ if __name__ == '__main__':
             dict_mGraph_fitSum[vfat].Add(dict_fitSum[chamberAndScanDatePair][vfat])
             dict_mGraph_ScurveMean[vfat].Add(dict_ScurveMean[chamberAndScanDatePair][vfat])
             dict_mGraph_ScurveSigma[vfat].Add(dict_ScurveSigma[chamberAndScanDatePair][vfat])
-            
+
             if (idx == (len(listChamberAndScanDate) - 1) ):
                 chanStripOrPanPin = dict_fitSum[chamberAndScanDatePair][vfat].GetXaxis().GetTitle()
-                
+
                 dict_canvSCurveFitSum[vfat].cd()
                 dict_mGraph_fitSum[vfat].Draw(drawOpt) # The axis doesn't exist unless we draw it first, ROOT magic =/
                 dict_mGraph_fitSum[vfat].GetXaxis().SetTitle(chanStripOrPanPin)
@@ -374,7 +380,7 @@ if __name__ == '__main__':
                 dict_mGraph_ScurveMean[vfat].Draw(drawOpt)
                 dict_mGraph_ScurveMean[vfat].GetXaxis().SetTitle("scurve mean #left(fC#right)")
                 dict_mGraph_ScurveMean[vfat].Draw(drawOpt)
-                
+
                 dict_canvSCurveSigma[vfat].cd()
                 dict_mGraph_ScurveSigma[vfat].Draw(drawOpt)
                 dict_mGraph_ScurveSigma[vfat].GetXaxis().SetTitle("scurve sigma #left(fC#right)")
@@ -384,7 +390,7 @@ if __name__ == '__main__':
             pass
 
         # Draw per ieta distributions
-        for ieta in range(1,9):
+        for ieta in range(1,maxiEta+1):
             if idx == 0:
                 dict_mGraph_ScurveMeanByiEta[ieta] = r.TMultiGraph("mGraph_ScurveMeanDist_ieta%i"%(ieta),"i#eta = %i"%(ieta))
                 dict_mGraph_ScurveSigmaByiEta[ieta] = r.TMultiGraph("mGraph_ScurveSigmaDist_ieta%i"%(ieta),"i#eta = %i"%(ieta))
@@ -418,7 +424,7 @@ if __name__ == '__main__':
             dict_ScurveEffPed[chamberAndScanDatePair][-1].Draw("E1")
         else:
             dict_ScurveEffPed[chamberAndScanDatePair][-1].Draw("sameE1")
-    
+
         dict_ScurveEffPed_boxPlot[chamberAndScanDatePair].SetFillColorAlpha(getCyclicColor(idx), 0.3)
         dict_ScurveEffPed_boxPlot[chamberAndScanDatePair].SetLineColor(getCyclicColor(idx))
 
@@ -439,10 +445,10 @@ if __name__ == '__main__':
 
             canvScurveEffPed_boxPlot.cd()
             dict_ScurveEffPed_boxPlot[chamberAndScanDatePair].Draw("candle1")
-            
+
             canvScurveThresh_boxPlot.cd()
             dict_ScurveThresh_boxPlot[chamberAndScanDatePair].Draw("candle1")
-            
+
             canvScurveSigma_boxPlot.cd()
             dict_ScurveSigma_boxPlot[chamberAndScanDatePair].Draw("candle1")
         else:
@@ -460,13 +466,13 @@ if __name__ == '__main__':
         pass
 
     # Draw multigraphs for summary cases
-    canvFitSum_Grid = make3x8Canvas("scurveFitSummaryGridAllScandates",dict_mGraph_fitSum,"APE1")
-    canvScurveMean_Grid = make3x8Canvas("scurveMeanGridAllScandates",dict_mGraph_ScurveMean,"APE1")
-    canvScurveSigma_Grid = make3x8Canvas("scurveSigmaGridAllScandates",dict_mGraph_ScurveSigma,"APE1")
+    canvFitSum_Grid = getSummaryCanvas(dict_mGraph_fitSum, name="scurveFitSummaryGridAllScandates", drawOpt="APE1")
+    canvScurveMean_Grid = getSummaryCanvas(dict_mGraph_ScurveMean, name="scurveMeanGridAllScandates", drawOpt="APE1")
+    canvScurveSigma_Grid = getSummaryCanvas(dict_mGraph_ScurveSigma, name="scurveSigmaGridAllScandates", drawOpt="APE1")
 
-    canvScurveMean_Grid_iEta = make2x4Canvas("scurveMeanGridByiEtaAllScandates",dict_mGraph_ScurveMeanByiEta,"APE1")
-    canvScurveSigma_Grid_iEta = make2x4Canvas("scurveSigmaGridByiEtaAllScandates",dict_mGraph_ScurveSigmaByiEta,"APE1")
-    
+    canvScurveMean_Grid_iEta = getSummaryCanvasByiEta(dict_mGraph_ScurveMeanByiEta, name="scurveMeanGridByiEtaAllScandates", drawOpt="APE1")
+    canvScurveSigma_Grid_iEta = getSummaryCanvasByiEta(dict_mGraph_ScurveSigmaByiEta, name="scurveSigmaGridByiEtaAllScandates", drawOpt="APE1")
+
     canvScurveMean_DetSum.cd()
     canvScurveMean_DetSum.cd().SetLogy()
     dict_mGraph_ScurveMean[-1].Draw("APE1")
@@ -485,10 +491,10 @@ if __name__ == '__main__':
 
     if options.drawLeg:
         # VFAT level
-        for vfat in range(0,24):
+        for vfat in range(0,vfatsPerGemVariant[gemType]):
             dict_canvSCurveFitSum[vfat].cd()
             plotLeg.Draw("same")
-            
+
             dict_canvSCurveMean[vfat].cd()
             plotLeg.Draw("same")
 
@@ -497,7 +503,7 @@ if __name__ == '__main__':
             pass
 
         # ieta level
-        for ieta in range(1,9):
+        for ieta in range(1,maxiEta+1):
             dict_canvSCurveMeanByiEta[ieta].cd()
             plotLeg.Draw("same")
 
@@ -508,7 +514,7 @@ if __name__ == '__main__':
         # Draw legend once at the vfat level
         canvFitSum_Grid.cd(1)
         plotLeg.Draw("same")
-        
+
         canvScurveMean_Grid.cd(1)
         plotLeg.Draw("same")
 
@@ -521,23 +527,23 @@ if __name__ == '__main__':
 
         canvScurveSigma_Grid_iEta.cd(1)
         plotLeg.Draw("same")
-       
+
         # Draw legend at the detector level
         canvScurveMean_DetSum.cd()
         plotLeg.Draw("same")
-        
+
         canvScurveSigma_DetSum.cd()
         plotLeg.Draw("same")
-        
+
         canvScurveEffPed_DetSum.cd()
         plotLeg.Draw("same")
 
         canvScurveEffPed_boxPlot.cd()
         plotLeg.Draw("same")
-        
+
         canvScurveThresh_boxPlot.cd()
         plotLeg.Draw("same")
-        
+
         canvScurveSigma_boxPlot.cd()
         plotLeg.Draw("same")
         pass
@@ -549,7 +555,7 @@ if __name__ == '__main__':
 
     canvScurveMean_Grid_iEta.SaveAs("%s/%s.png"%(elogPath,canvScurveMean_Grid_iEta.GetName()))
     canvScurveSigma_Grid_iEta.SaveAs("%s/%s.png"%(elogPath,canvScurveSigma_Grid_iEta.GetName()))
-    
+
     canvScurveMean_DetSum.SaveAs("%s/%s.png"%(elogPath,canvScurveMean_DetSum.GetName()))
     canvScurveSigma_DetSum.SaveAs("%s/%s.png"%(elogPath,canvScurveSigma_DetSum.GetName()))
     canvScurveEffPed_DetSum.SaveAs("%s/%s.png"%(elogPath,canvScurveEffPed_DetSum.GetName()))
@@ -559,8 +565,8 @@ if __name__ == '__main__':
 
     # Save summary canvas objects in output root file
     outF = r.TFile("%s/%s"%(elogPath,options.rootName),options.rootOpt)
-    
-    for vfat in range(0,24):
+
+    for vfat in range(0,vfatsPerGemVariant[gemType]):
         dirVFAT = outF.mkdir("VFAT%i"%(vfat))
         dirVFAT.cd()
 
@@ -575,7 +581,7 @@ if __name__ == '__main__':
         pass
 
     dirSummary = outF.mkdir("Summary")
-    for ieta in range(1,9):
+    for ieta in range(1,maxiEta+1):
         dir_iEta = dirSummary.mkdir("ieta%i"%ieta)
         dir_iEta.cd()
 
@@ -605,7 +611,7 @@ if __name__ == '__main__':
     print ""
     print "     %s"%elogPath
     print ""
-    
+
     print "You can open the output TFile via:"
     print ""
     print "     root -l %s/%s"%(elogPath,options.rootName)

--- a/macros/plotSCurveFitResults.py
+++ b/macros/plotSCurveFitResults.py
@@ -466,12 +466,12 @@ if __name__ == '__main__':
         pass
 
     # Draw multigraphs for summary cases
-    canvFitSum_Grid = getSummaryCanvas(dict_mGraph_fitSum, name="scurveFitSummaryGridAllScandates", drawOpt="APE1")
-    canvScurveMean_Grid = getSummaryCanvas(dict_mGraph_ScurveMean, name="scurveMeanGridAllScandates", drawOpt="APE1")
-    canvScurveSigma_Grid = getSummaryCanvas(dict_mGraph_ScurveSigma, name="scurveSigmaGridAllScandates", drawOpt="APE1")
+    canvFitSum_Grid = getSummaryCanvas(dict_mGraph_fitSum, name="scurveFitSummaryGridAllScandates", drawOpt="APE1", gemType=gemType)
+    canvScurveMean_Grid = getSummaryCanvas(dict_mGraph_ScurveMean, name="scurveMeanGridAllScandates", drawOpt="APE1", gemType=gemType)
+    canvScurveSigma_Grid = getSummaryCanvas(dict_mGraph_ScurveSigma, name="scurveSigmaGridAllScandates", drawOpt="APE1", gemType=gemType)
 
-    canvScurveMean_Grid_iEta = getSummaryCanvasByiEta(dict_mGraph_ScurveMeanByiEta, name="scurveMeanGridByiEtaAllScandates", drawOpt="APE1")
-    canvScurveSigma_Grid_iEta = getSummaryCanvasByiEta(dict_mGraph_ScurveSigmaByiEta, name="scurveSigmaGridByiEtaAllScandates", drawOpt="APE1")
+    canvScurveMean_Grid_iEta = getSummaryCanvasByiEta(dict_mGraph_ScurveMeanByiEta, name="scurveMeanGridByiEtaAllScandates", drawOpt="APE1", gemType=gemType)
+    canvScurveSigma_Grid_iEta = getSummaryCanvasByiEta(dict_mGraph_ScurveSigmaByiEta, name="scurveSigmaGridByiEtaAllScandates", drawOpt="APE1", gemType=gemType)
 
     canvScurveMean_DetSum.cd()
     canvScurveMean_DetSum.cd().SetLogy()

--- a/macros/plotSbitThreshComp.py
+++ b/macros/plotSbitThreshComp.py
@@ -75,7 +75,7 @@ def compareSBitThreshResults(args):
     elogPath = os.getenv('ELOG_PATH')
 
     # Get info from input file
-    from gempython.gemplotting.utils.anautilities import getCyclicColor, getDirByAnaType, filePathExists, make3x8Canvas, parseArmDacCalFile, parseListOfScanDatesFile
+    from gempython.gemplotting.utils.anautilities import getCyclicColor, getDirByAnaType, filePathExists, getSummaryCanvas, parseArmDacCalFile, parseListOfScanDatesFile
     parsedTuple = parseListOfScanDatesFile(args.filename,alphaLabels=args.alphaLabels)
     listChamberAndScanDate = parsedTuple[0]
     chamberName = listChamberAndScanDate[0][0]
@@ -203,7 +203,7 @@ def compareSBitThreshResults(args):
         pass
 
     # Make summary canvases, always save these
-    canvSBitRate_Summary = make3x8Canvas("canvSBitRate_Summary",dict_MultiGraphs.values()[0:24],"APE1")
+    canvSBitRate_Summary = getSummaryCanvas(dict_MultiGraphs.values()[0:24], name="canvSBitRate_Summary", drawOpt="APE1")
     for vfatCanv in range(1,25):
         canvSBitRate_Summary.cd(vfatCanv).SetLogy()
                 

--- a/macros/plotSbitThreshComp.py
+++ b/macros/plotSbitThreshComp.py
@@ -81,10 +81,13 @@ def compareSBitThreshResults(args):
     chamberName = listChamberAndScanDate[0][0]
     thrDacName = parsedTuple[1]
 
+    gemType="ge11"
+    from gempython.tools.hw_constants import vfatsPerGemVariant
+    
     # Parse calibration file if present
     arrayCalInfo = None 
     if args.calFileARM is not None:
-        arrayCalInfo = parseArmDacCalFile(args.calFileARM) # arrayCalInfo[i][vfatN] for coef of x^(4-i)
+        arrayCalInfo = parseArmDacCalFile(args.calFileARM, gemType=gemType) # arrayCalInfo[i][vfatN] for coef of x^(4-i)
 
     legPlot = r.TLegend(0.5,0.5,0.9,0.9)
     
@@ -114,7 +117,7 @@ def compareSBitThreshResults(args):
         ###################
         # Get individual distributions
         ###################
-        for vfat in range(24):
+        for vfat in range(vfatsPerGemVariant[gemType]):
             dict_Histos[infoTuple[2]][vfat] = scanFile.Get("VFAT{0}/THR_ARM_DAC/g1D_rate_vs_THR-ARM-DAC_vfat{0}".format(vfat))
             dict_Graphs[infoTuple[2]][vfat] = r.TGraph(dict_Histos[infoTuple[2]][vfat])
 
@@ -168,7 +171,8 @@ def compareSBitThreshResults(args):
     ###################
     # Now Make plots
     ###################
-    for vfat in range(24):
+
+    for vfat in range(vfatsPerGemVariant[gemType]):
         # Make Output Canvas
         dict_canv[vfat] = r.TCanvas("canvSBitRate_VFAT{0}".format(vfat),"SBIT Rate by THR DAC",700,700)
         dict_canv[vfat].cd()
@@ -203,8 +207,8 @@ def compareSBitThreshResults(args):
         pass
 
     # Make summary canvases, always save these
-    canvSBitRate_Summary = getSummaryCanvas(dict_MultiGraphs.values()[0:24], name="canvSBitRate_Summary", drawOpt="APE1")
-    for vfatCanv in range(1,25):
+    canvSBitRate_Summary = getSummaryCanvas(dict_MultiGraphs.values()[0:vfatsPerGemVariant[gemType]], name="canvSBitRate_Summary", drawOpt="APE1", gemType=gemType)
+    for vfatCanv in range(1,vfatsPerGemVariant[gemType]+1):
         canvSBitRate_Summary.cd(vfatCanv).SetLogy()
                 
     # Draw Legend?

--- a/macros/summary_plots.py
+++ b/macros/summary_plots.py
@@ -39,12 +39,12 @@ if __name__ == '__main__':
     from gempython.tools.hw_constants import vfatsPerGemVariant
     
     for vfat in range(0,vfatsPerGemVariant[gemType]):
-        vNoise[vfat] = r.TH1D('Noise%i'%vfat,'Noise%i;Noise [DAC units]'%vfat,35,-0.5,34.5)
-        vPedestal[vfat] = r.TH1D('Pedestal%i'%vfat,'Pedestal%i;Pedestal [DAC units]'%vfat,256,-0.5,255.5)
-        vThreshold[vfat] = r.TH1D('Threshold%i'%vfat,'Threshold%i;Threshold [DAC units]'%vfat,60,-0.5,299.5)
-        vChi2[vfat] = r.TH1D('ChiSquared%i'%vfat,'ChiSquared%i;Chi2'%vfat,100,-0.5,999.5)
-        vComparison[vfat] = r.TH2D('vComparison%i'%vfat,'Fit Summary %i;Threshold [DAC units];Noise [DAC units]'%vfat,60,-0.5,299.5,70,-0.5,34.5)
-        vNoiseTrim[vfat] = r.TH2D('vNoiseTrim%i'%vfat,'Noise vs. Trim Summary %i;Trim [DAC units];Noise [DAC units]'%vfat,32,-0.5,31.5,70,-0.5,34.5)
+        vNoise[vfat] = r.TH1D('Noise{0}'.format(vfat),'Noise{0};Noise [DAC units]'.format(vfat),35,-0.5,34.5)
+        vPedestal[vfat] = r.TH1D('Pedestal{0}'.format(vfat),'Pedestal{0};Pedestal [DAC units]'.format(vfat),256,-0.5,255.5)
+        vThreshold[vfat] = r.TH1D('Threshold{0}'.format(vfat),'Threshold{0};Threshold [DAC units]'.format(vfat),60,-0.5,299.5)
+        vChi2[vfat] = r.TH1D('ChiSquared{0}'.format(vfat),'ChiSquared{0};Chi2'.format(vfat),100,-0.5,999.5)
+        vComparison[vfat] = r.TH2D('vComparison{0}'.format(vfat),'Fit Summary {0};Threshold [DAC units];Noise [DAC units]'.format(vfat),60,-0.5,299.5,70,-0.5,34.5)
+        vNoiseTrim[vfat] = r.TH2D('vNoiseTrim{0}'.format(vfat),'Noise vs. Trim Summary {0};Trim [DAC units];Noise [DAC units]'.format(vfat),32,-0.5,31.5,70,-0.5,34.5)
         vComparison[vfat].GetYaxis().SetTitleOffset(1.5)
         vNoiseTrim[vfat].GetYaxis().SetTitleOffset(1.5)
         pass
@@ -64,13 +64,13 @@ if __name__ == '__main__':
 
     if options.fit_plots or options.all_plots:
         r.gStyle.SetOptStat(111100)
-        getSummmaryCanvas(dictSummary=vComparison, name=("%s_FitSummary.png"%filename),drawOpt="colz", write2Disk=True)
-        getSummmaryCanvas(dictSummary=vNoiseTrim, name=("%s_TrimNoiseSummary.png"%filename),drawOpt="colz", write2Disk=True)
-        getSummmaryCanvas(dictSummary=vThreshold, name=("%s_FitThreshSummary.png"%filename),drawOpt="", write2Disk=True)
-        getSummmaryCanvas(dictSummary=vPedestal, name=("%s_FitPedestalSummary.png"%filename),drawOpt="", write2Disk=True)
-        getSummmaryCanvas(dictSummary=vNoise, name=("%s_FitNoiseSummary.png"%filename),drawOpt="", write2Disk=True)
+        getSummmaryCanvas(dictSummary=vComparison, name=("{0}_FitSummary.png".format(filename)),drawOpt="colz", write2Disk=True)
+        getSummmaryCanvas(dictSummary=vNoiseTrim, name=("{0}_TrimNoiseSummary.png".format(filename)),drawOpt="colz", write2Disk=True)
+        getSummmaryCanvas(dictSummary=vThreshold, name=("{0}_FitThreshSummary.png".format(filename)),drawOpt="", write2Disk=True)
+        getSummmaryCanvas(dictSummary=vPedestal, name=("{0}_FitPedestalSummary.png".format(filename)),drawOpt="", write2Disk=True)
+        getSummmaryCanvas(dictSummary=vNoise, name=("{0}_FitNoiseSummary.png".format(filename)),drawOpt="", write2Disk=True)
         pass
 
     if options.chi2_plots or options.all_plots:
-        getSummmaryCanvas(dictSummary=vChi2, name=("%s_FitChi2Summary.png"%filename),drawOpt="", write2Disk=True)
+        getSummmaryCanvas(dictSummary=vChi2, name=("{0}_FitChi2Summary.png".format(filename)),drawOpt="", write2Disk=True)
         pass

--- a/macros/summary_plots.py
+++ b/macros/summary_plots.py
@@ -8,7 +8,7 @@ summary\_plots
 if __name__ == '__main__':
     import os
 
-    from gempython.gemplotting.utils.anautilities import saveSummary
+    from gempython.gemplotting.utils.anautilities import getSummaryCanvas
     from gempython.utils.nesteddict import nesteddict as ndict
     from gempython.gemplotting.macros.plotoptions import parser
 
@@ -35,7 +35,10 @@ if __name__ == '__main__':
     vNoiseTrim  = ndict()
     vPedestal   = ndict()
 
-    for vfat in range(0,24):
+    gemType = "ge11"
+    from gempython.tools.hw_constants import vfatsPerGemVariant
+    
+    for vfat in range(0,vfatsPerGemVariant[gemType]):
         vNoise[vfat] = r.TH1D('Noise%i'%vfat,'Noise%i;Noise [DAC units]'%vfat,35,-0.5,34.5)
         vPedestal[vfat] = r.TH1D('Pedestal%i'%vfat,'Pedestal%i;Pedestal [DAC units]'%vfat,256,-0.5,255.5)
         vThreshold[vfat] = r.TH1D('Threshold%i'%vfat,'Threshold%i;Threshold [DAC units]'%vfat,60,-0.5,299.5)
@@ -61,13 +64,13 @@ if __name__ == '__main__':
 
     if options.fit_plots or options.all_plots:
         r.gStyle.SetOptStat(111100)
-        saveSummary(dictSummary=vComparison, name=("%s_FitSummary.png"%filename),drawOpt="colz")
-        saveSummary(dictSummary=vNoiseTrim, name=("%s_TrimNoiseSummary.png"%filename),drawOpt="colz")
-        saveSummary(dictSummary=vThreshold, name=("%s_FitThreshSummary.png"%filename),drawOpt="")
-        saveSummary(dictSummary=vPedestal, name=("%s_FitPedestalSummary.png"%filename),drawOpt="")
-        saveSummary(dictSummary=vNoise, name=("%s_FitNoiseSummary.png"%filename),drawOpt="")
+        getSummmaryCanvas(dictSummary=vComparison, name=("%s_FitSummary.png"%filename),drawOpt="colz", write2Disk=True)
+        getSummmaryCanvas(dictSummary=vNoiseTrim, name=("%s_TrimNoiseSummary.png"%filename),drawOpt="colz", write2Disk=True)
+        getSummmaryCanvas(dictSummary=vThreshold, name=("%s_FitThreshSummary.png"%filename),drawOpt="", write2Disk=True)
+        getSummmaryCanvas(dictSummary=vPedestal, name=("%s_FitPedestalSummary.png"%filename),drawOpt="", write2Disk=True)
+        getSummmaryCanvas(dictSummary=vNoise, name=("%s_FitNoiseSummary.png"%filename),drawOpt="", write2Disk=True)
         pass
 
     if options.chi2_plots or options.all_plots:
-        saveSummary(dictSummary=vChi2, name=("%s_FitChi2Summary.png"%filename),drawOpt="")
+        getSummmaryCanvas(dictSummary=vChi2, name=("%s_FitChi2Summary.png"%filename),drawOpt="", write2Disk=True)
         pass

--- a/macros/timeHistoryAnalyzer.py
+++ b/macros/timeHistoryAnalyzer.py
@@ -304,7 +304,7 @@ if __name__ == '__main__':
         sys.exit(os.EX_USAGE)
 
     if not os.path.isdir(options.inputDir):
-        print("Error: Not a directory: %s" % options.inputDir)
+        print("Error: Not a directory: {0}".format(options.inputDir))
         sys.exit(os.EX_USAGE)
 
     from gempython.gemplotting.utils.anahistory import (
@@ -327,7 +327,7 @@ if __name__ == '__main__':
         findRangesKwArgs['minNoise'] = options.minNoise
         findRangesKwArgs['maxNoise'] = options.maxNoise
     else:
-        print("Error: Invalid argument for --ranges: %s " % options.ranges)
+        print("Error: Invalid argument for --ranges: {0} ".format(options.ranges))
         sys.exit(os.EX_USAGE)
 
     gemType="ge11"
@@ -390,7 +390,7 @@ if __name__ == '__main__':
     from tabulate import tabulate
 
     headers = [
-        '`%s`' % data.stripOrChanMode,
+        '`{0}`'.format(data.stripOrChanMode),
         'Last known good',
         'Range begins',
         'Range ends',
@@ -400,9 +400,9 @@ if __name__ == '__main__':
         'Other subsequent `maskReason`s' ]
 
     for vfat in range(vfatsPerGemVariant[gemType]):
-        print '''
-## VFAT %d
-''' % vfat
+        print('''
+        ## VFAT {0}
+        '''.format(vfat))
 
         print(tabulate(rangesTables[vfat],
                        headers = headers,

--- a/macros/timeHistoryAnalyzer.py
+++ b/macros/timeHistoryAnalyzer.py
@@ -330,16 +330,19 @@ if __name__ == '__main__':
         print("Error: Invalid argument for --ranges: %s " % options.ranges)
         sys.exit(os.EX_USAGE)
 
-    data = TimeSeriesData(options.inputDir)
+    gemType="ge11"
+        
+    data = TimeSeriesData(options.inputDir, gemType)
     data.removeBadScans(minAverageNoise = options.minScanAvgNoise,
                         maxMaskedStripOrChanFraction = options.maxScanMaskedFrac)
 
     from gempython.gemplotting.utils.anaInfo import MaskReason
     from gempython.gemplotting.utils.anautilities import getEmptyPerVFATList
-
+    from gempython.tools.hw_constants import vfatsPerGemVariant
+    
     # Find ranges
     ranges = getEmptyPerVFATList() # [vfat][stripOrChan][ranges]
-    for vfat in range(24):
+    for vfat in range(vfatsPerGemVariant[gemType]):
         for stripOrChan in range(128):
             ranges[vfat].append(findRangesFct(data, vfat, stripOrChan, **findRangesKwArgs))
             pass
@@ -347,7 +350,7 @@ if __name__ == '__main__':
 
     # Filter if needed
     if options.onlyCurrent:
-        for vfat in range(24):
+        for vfat in range(vfatsPerGemVariant[gemType]):
             for stripOrChan in range(128):
                 ranges[vfat][stripOrChan] = list(filter(lambda r: r.end == data.numScans(),
                                                         ranges[vfat][stripOrChan]))
@@ -356,10 +359,10 @@ if __name__ == '__main__':
     rangesTables = getEmptyPerVFATList()
 
     maskReasonList = MaskReason.listReasons()
-    summaryTable = np.zeros((24, len(maskReasonList)))
+    summaryTable = np.zeros((vfatsPerGemVariant[gemType], len(maskReasonList)))
 
     # Fill tables
-    for vfat in range(24):
+    for vfat in range(vfatsPerGemVariant[gemType]):
         for stripOrChan in range(128):
             for rng in ranges[vfat][stripOrChan]:
                 # Per-vfat table
@@ -396,7 +399,7 @@ if __name__ == '__main__':
         'Initial `maskReason`',
         'Other subsequent `maskReason`s' ]
 
-    for vfat in range(24):
+    for vfat in range(vfatsPerGemVariant[gemType]):
         print '''
 ## VFAT %d
 ''' % vfat

--- a/mapping/chamberInfo.py
+++ b/mapping/chamberInfo.py
@@ -37,7 +37,10 @@ except ImportError as e:
 ##### NEED TO FIX
 #### VERY TEMPORARY
 gemTypeMapping = {0:"ge11", 1:"ge21"}
-##### END    
+##### END
+
+CHANNELS_PER_VFAT = 128
+
 chamber_iEta2VFATPos = {}
 chamber_iEta2VFATPos["ge11"] = {
         1: { 7:1, 15:2, 23:3 }, #ieta: [ (vfat, iphi), (vfat, iphi), (vfat, iphi) ]

--- a/mapping/chamberInfo.py
+++ b/mapping/chamberInfo.py
@@ -34,8 +34,7 @@ except ImportError as e:
             #placeholder
         }
 
-##### NEED TO FIX
-#### VERY TEMPORARY
+##### FIXME
 gemTypeMapping = {0:"ge11", 1:"ge21"}
 ##### END
 

--- a/mapping/chamberInfo.py
+++ b/mapping/chamberInfo.py
@@ -34,8 +34,12 @@ except ImportError as e:
             #placeholder
         }
 
-# Matches CMS coordinates
-chamber_iEta2VFATPos = {
+##### NEED TO FIX
+#### VERY TEMPORARY
+gemTypeMapping = {0:"ge11", 1:"ge21"}
+##### END    
+chamber_iEta2VFATPos = {}
+chamber_iEta2VFATPos["ge11"] = {
         1: { 7:1, 15:2, 23:3 }, #ieta: [ (vfat, iphi), (vfat, iphi), (vfat, iphi) ]
         2: { 6:1, 14:2, 22:3 },
         3: { 5:1, 13:2, 21:3 },
@@ -45,13 +49,25 @@ chamber_iEta2VFATPos = {
         7: { 1:1,  9:2, 17:3 },
         8: { 0:1,  8:2, 16:3 }
         }
+chamber_iEta2VFATPos["ge21"] = {
+        1: { 3:1, 7:2, 11:3 },#ieta: [ (vfat, iphi), (vfat, iphi), (vfat, iphi) ]
+        2: { 2:1, 6:2, 10:3 },
+        3: { 1:1, 5:2,  9:3 },
+        4: { 0:1, 4:2,  8:3 }
+        }
 
 chamber_vfatPos2iEta = {}
 chamber_vfatPos2iEtaiPhi = {}
-for ieta, vfatRow in chamber_iEta2VFATPos.iteritems():
-    for vfat,phi in vfatRow.iteritems():
-        chamber_vfatPos2iEta[vfat] = ieta
-        chamber_vfatPos2iEtaiPhi[vfat] = (ieta,phi)
+chamber_maxiEtaiPhiPair = {}
+for key in chamber_iEta2VFATPos:
+    chamber_vfatPos2iEta[key] = {}
+    chamber_vfatPos2iEtaiPhi[key] = {}
+    chamber_maxiEtaiPhiPair[key] = (len(chamber_iEta2VFATPos[key]), len(chamber_iEta2VFATPos[key][1]))
+    for ieta, vfatRow in chamber_iEta2VFATPos[key].iteritems():
+        for vfat,phi in vfatRow.iteritems():
+            chamber_vfatPos2iEta[key][vfat] = ieta
+            chamber_vfatPos2iEtaiPhi[key][vfat] = (ieta,phi)
+            pass
         pass
     pass
 
@@ -95,13 +111,18 @@ except ImportError as e:
         }
 
 # Canvas to VFAT Position Mapping
-chamber_vfatPos2PadIdx = { }
-for vfat in range(0,24):
-    if (0 <= vfat and vfat < 8):
-        chamber_vfatPos2PadIdx[vfat] = vfat+17
-    elif (8 <= vfat and vfat < 16):
-        chamber_vfatPos2PadIdx[vfat] = vfat+1
-    elif (16 <= vfat and vfat < 24):
-        chamber_vfatPos2PadIdx[vfat] = vfat-15
-        pass # end if-elif statement
-    pass # end loop over all VFATs
+chamber_vfatPos2PadIdx = {}
+for key in chamber_iEta2VFATPos:
+    chamber_vfatPos2PadIdx[key] = {}
+    niEta = chamber_maxiEtaiPhiPair[key][0]
+    nVFats = chamber_maxiEtaiPhiPair[key][1]*niEta
+
+    shift = nVFats + niEta + 1
+    for vfat in range(0, nVFats):
+        if vfat % niEta == 0:
+            shift -= niEta*2
+        chamber_vfatPos2PadIdx[key][vfat] = vfat + shift
+        pass
+    pass
+
+

--- a/utils/anahistory.py
+++ b/utils/anahistory.py
@@ -296,32 +296,31 @@ class TimeSeriesData(object):
 
         self.gemType = gemType
         
-        file_mask = r.TFile('%s/gemPlotterOutput_mask_vs_scandate.root' % inputDir, 'READ')
+        file_mask = r.TFile('{0}/gemPlotterOutput_mask_vs_scandate.root'.format(inputDir), 'READ')
         if file_mask.IsZombie():
-            raise IOError('Could not open %s. Is %s the output directory of plotTimeSeries.py?' % (
+            raise IOError('Could not open {0}. Is {1} the output directory of plotTimeSeries.py?'.format(
                 file_mask.GetPath(), inputDir))
 
-        file_maskReason = r.TFile('%s/gemPlotterOutput_maskReason_vs_scandate.root' % inputDir, 'READ')
+        file_maskReason = r.TFile('{0}/gemPlotterOutput_maskReason_vs_scandate.root'.format(inputDir), 'READ')
         if file_maskReason.IsZombie():
-            raise IOError('Could not open %s. Is %s the output directory of plotTimeSeries.py?' % (
+            raise IOError('Could not open {0}. Is {1} the output directory of plotTimeSeries.py?'.format(
                 file_maskReason.GetPath(), inputDir))
 
-        file_noise = r.TFile('%s/gemPlotterOutput_noise_vs_scandate.root' % inputDir, 'READ')
+        file_noise = r.TFile('{0}/gemPlotterOutput_noise_vs_scandate.root'.format(inputDir), 'READ')
         if file_noise.IsZombie():
-            raise IOError('Could not open %s. Is %s the output directory of plotTimeSeries.py?' % (
+            raise IOError('Could not open {0}. Is {1} the output directory of plotTimeSeries.py?'.format(
                 file_noise.GetPath(), inputDir))
 
         # Auto-detect the meaning of stripOrChan
         possibleModes = ['ROBstr', 'vfatCH'] # See gemPlotter.py
         for mode in possibleModes:
-            if file_mask.Get('VFAT0/h_%s_vs_scandate_Obsmask_VFAT0' % mode):
+            if file_mask.Get('VFAT0/h_{0}_vs_scandate_Obsmask_VFAT0'.format(mode)):
                 self.stripOrChanMode = mode
                 break
         else:
             from string import join
             raise RuntimeError(
-                'No key VFAT0/h_<MODE>_vs_scandate_Obsmask_VFAT0 in file %s\nTried MODE=%s. Was the file produced by plotTimeSeries.py?' % (
-                    file_mask.GetPath(), join(possibleModes, ',')))
+                'No key VFAT0/h_<MODE>_vs_scandate_Obsmask_VFAT0 in file {0}\nTried MODE={1}. Was the file produced by plotTimeSeries.py?'.format(file_mask.GetPath(), join(possibleModes, ',')))
         
         self.mask = [] # [vfat][time][stripOrChan]; warning: reordered after loading
         self.maskReason = [] # [vfat][time][stripOrChan]; warning: reordered after loading

--- a/utils/anahistory.py
+++ b/utils/anahistory.py
@@ -371,7 +371,7 @@ class TimeSeriesData(object):
         """
         from gempython.tools.hw_constants import vfatsPerGemVariant
         badScans = _np.logical_or(_np.mean(self.noise, (0, 1)) < minAverageNoise,
-                                 _np.count_nonzero(self.mask, (0, 1)) / vfatsPerGemVariant[gemType] / 128 > maxMaskedStripOrChanFraction)
+                                 _np.count_nonzero(self.mask, (0, 1)) / vfatsPerGemVariant[self.gemType] / 128 > maxMaskedStripOrChanFraction)
         self.dates = self.dates[_np.logical_not(badScans)]
         self.mask = self.mask[:,:,_np.logical_not(badScans)]
         self.maskReason = self.maskReason[:,:,_np.logical_not(badScans)]

--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -95,9 +95,6 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
     vfatArray = rp.tree2array(tree=dacScanTree,branches=list_bNames)
     dacNameArray = np.unique(vfatArray['nameX'])
 
-                    
-    print dacNameArray
-    
     # Get VFATID's
     vfatIDArray = getSubArray(vfatArray, ['vfatID','vfatN'])
     vfatIDArray = np.sort(vfatIDArray,order='vfatN')['vfatID'] # index now gauranteed to match vfatN
@@ -151,7 +148,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
     from gempython.utils.gemlogger import colormsg
     import logging
     if adcName not in ['ADC0', 'ADC1']:
-        raise ValueError(colormsg("Error: unexpected value of adcName: '%s'"%adcName,logging.ERROR), os.EX_DATAERR)
+        raise ValueError(colormsg("Error: unexpected value of adcName: '{0}'".format(adcName),logging.ERROR), os.EX_DATAERR)
 
     from gempython.gemplotting.utils.anaInfo import nominalDacValues, nominalDacScalingFactors
     nominal = {}
@@ -181,7 +178,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
                 nominal[dacName] *= pow(10.0,-3)
             else:
                 # Maybe a TypeError is more appropriate...?
-                raise ValueError(colormsg("Error: unexpected units: '%s'"%nominalDacValues[dacName][1],logging.ERROR), os.EX_DATAERR)
+                raise ValueError(colormsg("Error: unexpected units: '{0}'".format(nominalDacValues[dacName][1]),logging.ERROR), os.EX_DATAERR)
 
     #the nominal reference current is 10 uA and it has a scaling factor of 0.5
     nominal_iref = 10*0.5
@@ -467,15 +464,15 @@ def filePathExists(searchPath, subPath=None, debug=False):
     
     testPath = searchPath
     if subPath is not None:
-        testPath = "%s/%s"%(searchPath, subPath)
+        testPath = "{0}/{1}".format(searchPath, subPath)
 
     if not os.path.exists(testPath):
         if debug:
-            print "Unable to find location: %s"%(testPath)
+            print("Unable to find location: {0}".format(testPath))
         return False
     else:
         if debug:
-            print "Found %s"%s(testPath)
+            print("Found {0}".format(testPath))
         return True
 
 # Find Inflection Point /////////////////////////////////////////////////////////////////
@@ -595,7 +592,7 @@ def get2DMapOfDetector(vfatChanLUT, obsData, mapName, zLabel, gemType="ge11"):
     import os
 
     if mapName not in mappingNames:
-        print("get2DMapOfDetector(): mapName %s not recognized"%mapName)
+        print("get2DMapOfDetector(): mapName {0} not recognized".format(mapName))
         print("\tAvailable options are:")
         print("\t",mappingNames)
         raise LookupError
@@ -604,7 +601,7 @@ def get2DMapOfDetector(vfatChanLUT, obsData, mapName, zLabel, gemType="ge11"):
     from ..mapping.chamberInfo import chamber_maxiEtaiPhiPair
     maxiEta, maxiPhi = chamber_maxiEtaiPhiPair[gemType]
     
-    hRetMap = r.TH2F("ieta_vs_%s_%s"%(mapName,zLabel),"",maxiPhi*128, -0.5, maxiPhi*128-0.5, maxiEta, 0.5, maxiEta + 0.5)
+    hRetMap = r.TH2F("ieta_vs_{0}_{1}".format(mapName,zLabel),"",maxiPhi*128, -0.5, maxiPhi*128-0.5, maxiEta, 0.5, maxiEta + 0.5)
     hRetMap.SetXTitle(mapName)
     hRetMap.SetYTitle("i#eta")
     hRetMap.SetZTitle(zLabel)
@@ -691,8 +688,8 @@ def getDirByAnaType(anaType, cName, ztrim=4):
 
     # Check anaType is understood
     if anaType not in ana_config.keys():
-        print "getDirByAnaType() - Invalid analysis specificed, please select only from the list:"
-        print ana_config.keys()
+        print("getDirByAnaType() - Invalid analysis specificed, please select only from the list:")
+        print(ana_config.keys())
         exit(os.EX_USAGE)
         pass
 
@@ -701,41 +698,41 @@ def getDirByAnaType(anaType, cName, ztrim=4):
 
     dirPath = ""
     if anaType == "armDacCal":
-        dirPath = "%s/%s/%s"%(dataPath,cName,anaType)
+        dirPath = "{0}/{1}/{2}".format(dataPath,cName,anaType)
     elif anaType == "dacScanV3":
-        dirPath = "%s/%s"%(dataPath,anaType)
+        dirPath = "{0}/{1}".format(dataPath,anaType)
     elif anaType == "latency":
-        dirPath = "%s/%s/%s/trk/"%(dataPath,cName,anaType)
+        dirPath = "{0}/{1}/{2}/trk/".format(dataPath,cName,anaType)
     elif anaType == "sbitMonInt":
-        dirPath = "%s/%s/sbitMonitor/intTrig/"%(dataPath,cName)
+        dirPath = "{0}/{1}/sbitMonitor/intTrig/".format(dataPath,cName)
     elif anaType == "sbitMonRO":
-        dirPath = "%s/%s/sbitMonitor/readout/"%(dataPath,cName)
+        dirPath = "{0}/{1}/sbitMonitor/readout/".format(dataPath,cName)
     elif anaType == "sbitRatech":
         if cName is None:
-            dirPath = "%s/sbitRate/perchannel"%(dataPath)
+            dirPath = "{0}/sbitRate/perchannel".format(dataPath)
         else:
-            dirPath = "%s/%s/sbitRate/perchannel/"%(dataPath,cName)
+            dirPath = "{0}/{1}/sbitRate/perchannel/".format(dataPath,cName)
     elif anaType == "sbitRateor":
         if cName is None:
-            dirPath = "%s/sbitRate/channelOR"%(dataPath)
+            dirPath = "{0}/sbitRate/channelOR".format(dataPath)
         else:
-            dirPath = "%s/%s/sbitRate/channelOR/"%(dataPath,cName)
+            dirPath = "{0}/{1}/sbitRate/channelOR/".format(dataPath,cName)
     elif anaType == "scurve":
-        dirPath = "%s/%s/%s/"%(dataPath,cName,anaType)
+        dirPath = "{0}/{1}/{2}/".format(dataPath,cName,anaType)
     elif anaType == "temperature":
-        dirPath = "%s/%s"%(dataPath,anaType)
+        dirPath = "{0}/{1}".format(dataPath,anaType)
     elif anaType == "thresholdch":
-        dirPath = "%s/%s/threshold/channel/"%(dataPath,cName)
+        dirPath = "{0}/{1}/threshold/channel/".format(dataPath,cName)
     elif anaType == "thresholdvftrig":
-        dirPath = "%s/%s/threshold/vfat/trig/"%(dataPath,cName)
+        dirPath = "{0}/{1}/threshold/vfat/trig/".format(dataPath,cName)
     elif anaType == "thresholdvftrk":
-        dirPath = "%s/%s/threshold/vfat/trk/"%(dataPath,cName)
+        dirPath = "{0}/{1}/threshold/vfat/trk/".format(dataPath,cName)
     elif anaType == "trim":
-        dirPath = "%s/%s/%s/z%f/"%(dataPath,cName,anaType,ztrim)
+        dirPath = "{0}/{1}/{2}/z{3}/".format(dataPath,cName,anaType,ztrim)
     elif anaType == "trimV3":
-        dirPath = "%s/%s/trim/"%(dataPath,cName)
+        dirPath = "{0}/{1}/trim/".format(dataPath,cName)
     elif anaType == "iterTrim":
-        dirPath = "%s/%s/itertrim/"%(dataPath,cName)
+        dirPath = "{0}/{1}/itertrim/".format(dataPath,cName)
 
     return dirPath
 
@@ -826,8 +823,8 @@ def getMapping(mappingFileName, isVFAT2=True, gemType="ge11"):
     try:
         mapFile = open(mappingFileName, 'r')
     except IOError as e:
-        print "Exception:", e
-        print "Failed to open: '%s'"%mappingFileName
+        print("Exception:", e)
+        print("Failed to open: '{0}'".format(mappingFileName))
     else:
         listMapData = mapFile.readlines()
     finally:
@@ -1291,35 +1288,35 @@ def makeListOfScanDatesFile(chamberName, anaType, startDate=None, endDate=None, 
     listOfScanDates = os.listdir(dirPath)
 
     try:
-        listOfScanDatesFile = open('%s/listOfScanDates.txt'%dirPath,'w+')
+        listOfScanDatesFile = open('{0}/listOfScanDates.txt'.format(dirPath),'w+')
     except IOError as e:
-        print "Exception:", e
-        print "Failed to open write output file"
-        print "Is the below directory writeable?"
-        print ""
-        print "\t%s"%dirPath
-        print ""
+        print("Exception:", e)
+        print("Failed to open write output file")
+        print("Is the below directory writeable?")
+        print("")
+        print("\t{0}".format(dirPath))
+        print("")
         exit(os.EX_IOERR)
         pass
     
-    listOfScanDatesFile.write('ChamberName%sscandate\n'%delim)
+    listOfScanDatesFile.write('ChamberName{0}scandate\n'.format(delim))
     for scandate in listOfScanDates:
         if "current" == scandate:
             continue
         try:
             scandateInfo = [ int(info) for info in scandate.split('.') ]
         except ValueError as e:
-            print "Skipping directory %s/%s"%(dirPath,scandate)
+            print("Skipping directory {0}/{1}".format(dirPath,scandate))
             continue
         thisDay = datetime.date(scandateInfo[0],scandateInfo[1],scandateInfo[2])
 
         if (startDay < thisDay and thisDay <= endDay):
-            listOfScanDatesFile.write('%s%s%s\n'%(chamberName,delim,scandate))
+            listOfScanDatesFile.write('{0}{1}{2}\n'.format(chamberName,delim,scandate))
             pass
         pass
 
     listOfScanDatesFile.close()
-    runCommand( ['chmod','g+rw','%s/listOfScanDates.txt'%dirPath] )
+    runCommand( ['chmod','g+rw','{0}/listOfScanDates.txt'.format(dirPath)] )
 
     return
 
@@ -1472,8 +1469,8 @@ def parseListOfScanDatesFile(filename, alphaLabels=False, delim='\t'):
     try:
         fileScanDates = open(filename, 'r') 
     except IOError as e:
-        print '%s does not seem to exist or is not readable'%(filename)
-        print e
+        print('{0} does not seem to exist or is not readable'.format(filename))
+        print(e)
         exit(os.EX_NOINPUT)
         pass
 
@@ -1512,11 +1509,11 @@ def parseListOfScanDatesFile(filename, alphaLabels=False, delim='\t'):
                     print("Exiting")
                     exit(os.EX_USAGE)
         else:
-            print "Input format incorrect"
-            print "I was expecting a delimited file using '%s' with all lines having either 2 or 3 entries"%delim
-            print "But I received:"
-            print "\t%s"%(line)
-            print "Exiting"
+            print("Input format incorrect")
+            print("I was expecting a delimited file using '{0}' with all lines having either 2 or 3 entries".format(delim))
+            print("But I received:")
+            print("\t{0}".format(line))
+            print("Exiting")
             exit(os.EX_USAGE)
             pass
         
@@ -1574,7 +1571,7 @@ def getSummaryCanvas(dictSummary, dictSummaryPanPin2=None, name='Summary', trimP
             if trimPt is not None and trimLine is not None:
                 trimLine = r.TLine(-0.5, trimVcal[vfat], 127.5, trimVcal[vfat])
                 legend.Clear()
-                legend.AddEntry(trimLine, 'trimVCal is %f'%(trimVcal[vfat]))
+                legend.AddEntry(trimLine, 'trimVCal is {0}'.format(trimVcal[vfat]))
                 legend.Draw('SAME')
                 trimLine.SetLineColor(1)
                 trimLine.SetLineWidth(3)

--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -43,7 +43,7 @@ def cleanup(listOfFilePaths,listOfFileObjects=None,listOfTFiles=None,perm="g+rw"
 
     return
 
-def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
+def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate', gemType="gem11"):
     """
     Analyzes DAC scan data to determine nominal bias current/voltage settings for a particular VFAT3 DAC.
     Returns a dictionary where:
@@ -181,7 +181,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
             link    = dataEntry[2]
             calFile = dataEntry[3]
             ohKey = (int(shelf),int(slot),int(link))
-            tuple_calInfo = parseCalFile(calFile)
+            tuple_calInfo = parseCalFile(calFile, gemType=gemType)
             calInfo[ohKey] = {'slope' : tuple_calInfo[0], 'intercept' : tuple_calInfo[1]}
 
     #for each OH, check if calibration files were provided, if not search for the calFile in the $DATA_PATH, if it is not there, then skip that OH for the rest of the script
@@ -193,7 +193,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
             calAdcCalFile = "{0}/{1}/calFile_{2}_{1}.txt".format(dataPath,detName,adcName)
             calAdcCalFileExists = os.path.isfile(calAdcCalFile)
             if calAdcCalFileExists:
-                tuple_calInfo = parseCalFile(calAdcCalFile)
+                tuple_calInfo = parseCalFile(calAdcCalFile, gemType=gemType)
                 calInfo[ohKey] = {'slope' : tuple_calInfo[0], 'intercept' : tuple_calInfo[1]}
             else:    
                 # FIXME should perform a DB query with chipID's in input dacScanTree to get calibration constants
@@ -217,12 +217,13 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
 
     print("Initializing TObjects")
 
+    from gempython.tools.hw_constants import vfatsPerGemVariant
     # Initialize a TGraphErrors and a TF1 for each vfat
     for idx in range(len(dacNameArray)):
         dacName = np.asscalar(dacNameArray[idx])
         for entry in crateMap:
             ohKey = (entry['shelf'],entry['slot'],entry['link'])
-            for vfat in range(0,24):
+            for vfat in range(0,vfatsPerGemVariant[gemType]):
                 dict_RawADCvsDAC_Graphs[dacName][ohKey][vfat] = r.TGraphErrors()
                 dict_RawADCvsDAC_Graphs[dacName][ohKey][vfat].GetXaxis().SetTitle(dacName)
                 dict_RawADCvsDAC_Graphs[dacName][ohKey][vfat].GetYaxis().SetTitle(adcName)
@@ -299,7 +300,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
         dacName = np.asscalar(dacNameArray[idx])
         for entry in crateMap:
             ohKey = (entry['shelf'],entry['slot'],entry['link'])
-            for vfat in range(0,24):
+            for vfat in range(0,vfatsPerGemVariant[gemType]):
                 if vfat not in dict_nonzeroVFATs[ohKey]:
                     #so that the output plots for these VFATs are completely empty
                     dict_DACvsADC_Funcs[dacName][ohKey][vfat].SetLineColor(0)
@@ -331,7 +332,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
             graph_dacVals[dacName][ohKey].GetXaxis().SetTitle("VFATN")
             graph_dacVals[dacName][ohKey].GetYaxis().SetTitle("nominal {} value".format(dacName))
 
-            for vfat in range(0,24):
+            for vfat in range(0,vfatsPerGemVariant[gemType]):
                 if vfat not in dict_nonzeroVFATs[ohKey]:
                     continue
 
@@ -373,7 +374,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
         ohKey = (entry['shelf'],entry['slot'],entry['link'])
         detName = getDetName(entry)
         # Per VFAT Poosition
-        for vfat in range(0,24):
+        for vfat in range(0,vfatsPerGemVariant[gemType]):
             thisVFATDir = outputFiles[ohKey].mkdir("VFAT{0}".format(vfat))
 
             for idx in range(len(dacNameArray)):
@@ -399,7 +400,8 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
             graph_dacVals[dacName][ohKey].Write("g_NominalvsVFATPos_{0}".format(dacName))
 
             # Store summary grid canvas and print images
-            canv_Summary = make3x8Canvas("canv_Summary_{0}".format(dacName),dict_DACvsADC_Graphs[dacName][ohKey],'APE1',dict_DACvsADC_Funcs[dacName][ohKey],'')
+            canv_Summary = getSummaryCanvas(dict_DACvsADC_Graphs[dacName][ohKey], name="canv_Summary_{0}".format(dacName), drawOpt='APE1', gemType=gemType)
+            canv_Summary = addPlotToCanvas(canv_Summary, dict_DACvsADC_Funcs[dacName][ohKey], gemType=gemType)
             if scandate == 'noscandate':
                 canv_Summary.SaveAs("{0}/{1}/Summary_{1}_DACScan_{2}.png".format(elogPath,detName,dacName))
             else:
@@ -415,7 +417,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
             for idx in range(len(dacNameArray)):
                 dacName = np.asscalar(dacNameArray[idx])
             
-                for vfat in range(0,24):
+                for vfat in range(0,vfatsPerGemVariant[gemType]):
                     if vfat not in dict_nonzeroVFATs[ohKey]:
                         continue
 
@@ -560,7 +562,7 @@ def formatSciNotation(value, digits=2):
 
     return sciNotation % Decimal(value)
 
-def get2DMapOfDetector(vfatChanLUT, obsData, mapName, zLabel):
+def get2DMapOfDetector(vfatChanLUT, obsData, mapName, zLabel, gemType="ge11"):
     """
     Generates a 2D map of the detector as a TH2D. Y-axis will be ieta. X-axis will be ROBstr (strip),
     vfat channel or panasonic pin number.  The z-axis will be the elements of obsData with label zLabel
@@ -583,24 +585,28 @@ def get2DMapOfDetector(vfatChanLUT, obsData, mapName, zLabel):
         raise LookupError
 
     import ROOT as r
-    hRetMap = r.TH2F("ieta_vs_%s_%s"%(mapName,zLabel),"",384,-0.5,383.5,8,0.5,8.5)
+    from ..mapping.chamberInfo import chamber_maxiEtaiPhiPair
+    maxiEta, maxiPhi = chamber_maxiEtaiPhiPair[gemType]
+    
+    hRetMap = r.TH2F("ieta_vs_%s_%s"%(mapName,zLabel),"",maxiPhi*128, -0.5, maxiPhi*128-0.5, maxiEta, 0.5, maxiEta + 0.5)
     hRetMap.SetXTitle(mapName)
     hRetMap.SetYTitle("i#eta")
     hRetMap.SetZTitle(zLabel)
 
     from gempython.gemplotting.mapping.chamberInfo import chamber_vfatPos2iEtaiPhi
-    for idx in range(3072):
+    from gempython.tools.hw_constants import vfatsPerGemVariant
+    for idx in range(128*vfatsPerGemVariant[gemType]):
         # Determine vfat, ieta, and iphi
         vfat = idx // 128
-        ieta = chamber_vfatPos2iEtaiPhi[vfat][0]
-        iphi = chamber_vfatPos2iEtaiPhi[vfat][1]
+        ieta = chamber_vfatPos2iEtaiPhi[gemType][vfat][0]
+        iphi = chamber_vfatPos2iEtaiPhi[gemType][vfat][1]
 
         # Determine strip, panasonic pin, or channel
         chan = idx % 128
         stripPinOrChan = vfatChanLUT[vfat][mapName][chan]
 
-        # Set Bin Content of Histogram
-        hRetMap.SetBinContent( ((iphi-1)*128+stripPinOrChan)+1, ieta, obsData[idx])
+        # Set Bin Content of Histogrma
+        hRetMap.SetBinContent(((iphi-1)*128+stripPinOrChan)+1, ieta, obsData[idx])
         pass
 
     return hRetMap
@@ -764,7 +770,7 @@ def getGEBTypeFromFilename(filename, cName=None):
     else:
         return None
 
-def getMapping(mappingFileName, isVFAT2=True):
+def getMapping(mappingFileName, isVFAT2=True, gemType="ge11"):
     """
     Returns a nested dictionary, the outer dictionary uses VFAT position as the has a key,
     the inner most dict has keys from the list anaInfo.py mappingNames.
@@ -794,10 +800,12 @@ def getMapping(mappingFileName, isVFAT2=True):
                         PanPin - the pin number on the panasonic connector
     """
     from ...utils.nesteddict import nesteddict
-
+    
     from anaInfo import mappingNames
     import ROOT as r
-
+    
+    from gempython.tools.hw_constants import vfatsPerGemVariant
+    
     # Try to get the mapping data
     try:
         mapFile = open(mappingFileName, 'r')
@@ -812,9 +820,9 @@ def getMapping(mappingFileName, isVFAT2=True):
     # strip trhe end of line character
     listMapData = [x.strip('\n') for x in listMapData]
 
-    # setup the look up table
+        # setup the look up table
     ret_mapDict = nesteddict()
-    for vfat in range(0,24):
+    for vfat in range(0,vfatsPerGemVariant[gemType]):
         for name in mappingNames:
             ret_mapDict[vfat][name] = [0] * 128
 
@@ -869,7 +877,7 @@ def getNumCores2Use(args):
 
     return int(usageFactor*availableCores)
 
-def getPhaseScanPlots(phaseScanFile,phaseSetPtsFile,identifier=None,ohMask=0xfff,savePlots=True): 
+def getPhaseScanPlots(phaseScanFile,phaseSetPtsFile,identifier=None,ohMask=0xfff,savePlots=True, gemType="ge11"): 
     """
     Plots GBT phase scan data as a TH2F and the GBT phase set points as a TGraph for
     each optohybrid found in the two input files.  Note it's assume that if OHX is in
@@ -1052,7 +1060,7 @@ def getScandateFromFilename(infilename):
     else:    
         return 'noscandate'
 
-def getSinglePhaseScanPlot(ohN,phaseScanFile,phaseSetPtsFile,identifier=None,savePlots=True):
+def getSinglePhaseScanPlot(ohN,phaseScanFile,phaseSetPtsFile,identifier=None,savePlots=True, gemType="ge11"):
     """
     As getPhaseScanPlots but for a single optohybrid, defined by ohN, inside the input files.
     Returns a tuple where elements are given by:
@@ -1072,7 +1080,7 @@ def getSinglePhaseScanPlot(ohN,phaseScanFile,phaseSetPtsFile,identifier=None,sav
     """
 
     ohMask = (0x1 << ohN)
-    tuplePlotDicts = getPhaseScanPlots(phaseScanFile,phaseSetPtsFile,identifier,ohMask,False)
+    tuplePlotDicts = getPhaseScanPlots(phaseScanFile,phaseSetPtsFile,identifier,ohMask,False, gemType=gemType)
     
     phaseScanDist   = tuplePlotDicts[0][ohN]
     phaseScanSetPts = tuplePlotDicts[1][ohN]
@@ -1231,70 +1239,6 @@ def isOutlierMADOneSided(arrayData, thresh=3.5, rejectHighTail=True):
         else:
             return modified_z_score < -1.0 * thresh
 
-def make2x4Canvas(name, initialContent = None, initialDrawOpt = '', secondaryContent = None, secondaryDrawOpt = '', canv=None):
-    """
-    Creates a 2x4 canvas for summary plots.
-
-    name - TName of output TCanvas
-    initialContent - either None or an array of 24 (one per VFAT) TObjects that will be drawn on the canvas.
-    initialDrawOpt - draw option to be used when drawing elements of initialContent
-    secondaryContent - either None or an array of 24 (one per VFAT) TObjects that will be drawn on top of the canvas.
-    secondaryDrawOpt - draw option to be used when drawing elements of secondaryContent
-    canv - TCanvas previously produced by make3x8Canvas() or one that has been subdivided into a 3x8 grid
-    """
-
-    import ROOT as r
-    
-    if canv is None:
-        canv = r.TCanvas(name,name,500*8,500*3)
-        canv.Divide(4,2)
-
-    if initialContent is not None:
-        for ieta in range(1,9):
-            canv.cd(ieta)
-            initialContent[ieta].Draw(initialDrawOpt)
-    if secondaryContent is not None:
-        for ieta in range(1,9):
-            canv.cd(ieta)
-            secondaryContent[ieta].Draw("same%s"%secondaryDrawOpt)
-    canv.Update()
-    return canv
-
-def make3x8Canvas(name, initialContent = None, initialDrawOpt = '', secondaryContent = None, secondaryDrawOpt = '', canv = None ):
-    """
-    Creates a 3x8 canvas for summary plots.
-
-    name - TName of output TCanvas
-    initialContent - either None or an array of 24 (one per VFAT) TObjects that will be drawn on the canvas.
-    initialDrawOpt - draw option to be used when drawing elements of initialContent
-    secondaryContent - either None or an array of 24 (one per VFAT) TObjects that will be drawn on top of the canvas.
-    secondaryDrawOpt - draw option to be used when drawing elements of secondaryContent
-    canv - TCanvas previously produced by make3x8Canvas() or one that has been subdivided into a 3x8 grid
-    """
-
-    import ROOT as r
-    from ..mapping.chamberInfo import chamber_vfatPos2PadIdx
-   
-    if canv is None:
-        canv = r.TCanvas(name,name,500*8,500*3)
-        canv.Divide(8,3)
-
-    if initialContent is not None:
-        for vfat in range(24):
-            canv.cd(chamber_vfatPos2PadIdx[vfat])
-            try:
-                initialContent[vfat].Draw(initialDrawOpt)
-            except KeyError as err:
-                continue
-    if secondaryContent is not None:
-        for vfat in range(24):
-            canv.cd(chamber_vfatPos2PadIdx[vfat])
-            try:
-                secondaryContent[vfat].Draw("same%s"%secondaryDrawOpt)
-            except KeyError as err:
-                continue
-    canv.Update()
-    return canv
 
 def makeListOfScanDatesFile(chamberName, anaType, startDate=None, endDate=None, delim='\t', ztrim=4):
     """
@@ -1363,7 +1307,7 @@ def makeListOfScanDatesFile(chamberName, anaType, startDate=None, endDate=None, 
 
     return
 
-def parseCalFile(filename=None):
+def parseCalFile(filename=None, gemType="ge11"):
     """
     Gives the conversion between VCal/CFG_CAL_DAC to fC from either
     an optional external file (filename) or the hard coded vfat2 
@@ -1398,8 +1342,9 @@ def parseCalFile(filename=None):
     import ROOT as r
 
     # Set the CAL DAC to fC conversion
-    calDAC2Q_b = np.zeros(24)
-    calDAC2Q_m = np.zeros(24)
+    from gempython.tools.hw_constants import vfatsPerGemVariant
+    calDAC2Q_b = np.zeros(vfatsPerGemVariant[gemType])
+    calDAC2Q_m = np.zeros(vfatsPerGemVariant[gemType])
     if filename is not None:
         list_bNames = ["vfatN","slope","intercept"]
         calTree = r.TTree('calTree','Tree holding VFAT Calibration Info')
@@ -1411,13 +1356,13 @@ def parseCalFile(filename=None):
             calDAC2Q_m[dataPt['vfatN']] = dataPt['slope']
             pass
     else:
-        calDAC2Q_b = -0.8 * np.ones(24)
-        calDAC2Q_m = 0.05 * np.ones(24)
+        calDAC2Q_b = -0.8 * np.ones(vfatsPerGemVariant[gemType])
+        calDAC2Q_m = 0.05 * np.ones(vfatsPerGemVariant[gemType])
         pass
 
     return (calDAC2Q_m, calDAC2Q_b)
 
-def parseArmDacCalFile(filename):
+def parseArmDacCalFile(filename, gemType="ge11"):
     """
     Reads a text file and supplies the coefficients of the 
     quartic polynomial used for used for converting between 
@@ -1441,13 +1386,15 @@ def parseArmDacCalFile(filename):
     import numpy as np
     import root_numpy as rp #note need root_numpy-4.7.2 (may need to run 'pip install root_numpy --upgrade')
     import ROOT as r
+    from gempython.tools.hw_constants import vfatsPerGemVariant
 
+    
     # Set the CAL DAC to fC conversion
-    coef4 = np.zeros(24)
-    coef3 = np.zeros(24)
-    coef2 = np.zeros(24)
-    coef1 = np.zeros(24)
-    coef0 = np.zeros(24)
+    coef4 = np.zeros(vfatsPerGemVariant[gemType])
+    coef3 = np.zeros(vfatsPerGemVariant[gemType])
+    coef2 = np.zeros(vfatsPerGemVariant[gemType])
+    coef1 = np.zeros(vfatsPerGemVariant[gemType])
+    coef0 = np.zeros(vfatsPerGemVariant[gemType])
     list_bNames = ["vfatN","coef4","coef3","coef2","coef1","coef0"]
     calTree = r.TTree('calTree','Tree holding VFAT Calibration Info')
     try:
@@ -1573,7 +1520,8 @@ def rejectOutliersMADOneSided(arrayData, thresh=3.5, rejectHighTail=True):
     arrayOutliers = isOutlierMADOneSided(arrayData, thresh, rejectHighTail)
     return arrayData[arrayOutliers != True]
 
-def saveSummary(dictSummary, dictSummaryPanPin2=None, name='Summary', trimPt=None, drawOpt="colz"):
+  
+def getSummaryCanvas(dictSummary, dictSummaryPanPin2=None, name='Summary', trimPt=None, drawOpt="colz", gemType="ge11", write2Disk=False):
     """
     Makes an image with summary canvases drawn on it
 
@@ -1585,17 +1533,28 @@ def saveSummary(dictSummary, dictSummaryPanPin2=None, name='Summary', trimPt=Non
     trimPt             - Optional, list of trim points the dependent variable was aligned
                          to if it is the result of trimming.  One entry per VFAT
     drawOpt            - Draw option
+    write2Disk         - Option to save canvas with the name as the variable
     """
 
     import ROOT as r
-    from ..mapping.chamberInfo import chamber_vfatPos2PadIdx
+    from ..mapping.chamberInfo import chamber_vfatPos2PadIdx, chamber_maxiEtaiPhiPair
+    from gempython.tools.hw_constants import vfatsPerGemVariant
 
     legend = r.TLegend(0.75,0.7,0.88,0.88)
     r.gStyle.SetOptStat(0)
-    if dictSummaryPanPin2 is None:
-        canv = make3x8Canvas('canv', dictSummary, drawOpt)
-        for vfat in range(0,24):
-            canv.cd(chamber_vfatPos2PadIdx[vfat])
+
+    maxiEtaiPhiPair=chamber_maxiEtaiPhiPair[gemType]
+    
+    canv = r.TCanvas('canv', 'canv', 500 * maxiEtaiPhiPair[0], 500 * maxiEtaiPhiPair[1])
+    
+    if dictSummary is not None and dictSummaryPanPin2 is None:
+        canv.Divide(maxiEtaiPhiPair[0], maxiEtaiPhiPair[1])
+        for vfat, padIdx in chamber_vfatPos2PadIdx[gemType].iteritems():
+            canv.cd(padIdx)
+            try:
+                dictSummary[vfat].Draw(drawOpt)
+            except KeyError as err:
+                continue
             if trimPt is not None and trimLine is not None:
                 trimLine = r.TLine(-0.5, trimVcal[vfat], 127.5, trimVcal[vfat])
                 legend.Clear()
@@ -1605,62 +1564,93 @@ def saveSummary(dictSummary, dictSummaryPanPin2=None, name='Summary', trimPt=Non
                 trimLine.SetLineWidth(3)
                 trimLine.Draw('SAME')
                 pass
+            
+    elif dictSummary is not None and dictSummaryPanPin2 is not None:
+        # possibly remove unless fixed, or at the very least needs to be improved!!
+        canv.Divide(maxiEtaiPhiPair[0], 2*maxiEtaiPhiPair[1])
+        shift = maxiEtaiPhiPair[0]*(maxiEtaiPhiPair[1]+4) + 1
+        for vfat in range(0, vfatsPerGemVariant[gemType]):
+            if vfat % niEta == 0:
+                shift -= niEta*3
+            canv.cd(vfat+shift)
+            dictSummary[vfat].Draw(drawOpt)
+            canv.Update()
+            canv.cd(vfat+shift+maxiEtaiPhiPair[0])
+            dictSummaryPanPin2[vfat].Draw(drawOpt)
             canv.Update()
             pass
         pass
-    else:
-        canv = r.TCanvas('canv','canv',500*8,500*3)
-        canv.Divide(8,6)
-        r.gStyle.SetOptStat(0)
-        for ieta in range(0,8):
-            for iphi in range (0,3):
-                r.gStyle.SetOptStat(0)
-                canv.cd((ieta+1 + iphi*16)%48 + 16)
-                dictSummary[ieta+(8*iphi)].Draw(drawOpt)
-                canv.Update()
-                canv.cd((ieta+9 + iphi*16)%48 + 16)
-                dictSummaryPanPin2[ieta+(8*iphi)].Draw(drawOpt)
-                canv.Update()
-                pass
-            pass
-        pass
+    
+    canv.Update()
+    
+    if write2Disk:
+        canv.SaveAs(name)        
 
-    canv.SaveAs(name)
+    return canv
 
-    return
-
-def saveSummaryByiEta(dictSummary, name='Summary', trimPt=None, drawOpt="colz"):
+def getSummaryCanvasByiEta(dictSummary, name='Summary', drawOpt="colz", gemType="ge11", write2Disk=False):
     """
     Makes an image with summary canvases drawn on it
 
     dictSummary        - dict of TObjects to be drawn, one per ieta.  Each will be 
                          drawn on a separate pad
     name               - Name of output image
-    trimPt             - Optional, list of trim points the dependent variable was aligned
-                         to if it is the result of trimming.  One entry per VFAT
     drawOpt            - Draw option
+    write2Disk         - Option to save canvas with the name as the variable "name"
     """
 
     import ROOT as r
+    from ..mapping.chamberInfo import chamber_vfatPos2PadIdx, chamber_maxiEtaiPhiPair
+    from gempython.tools.hw_constants import vfatsPerGemVariant
 
     legend = r.TLegend(0.75,0.7,0.88,0.88)
     r.gStyle.SetOptStat(0)
-    canv = make2x4Canvas(name='canv', initialContent=dictSummary, initialDrawOpt=drawOpt)
-    for ieta in range(0,8):
-        canv.cd(ieta+1)
-        if trimPt is not None and trimLine is not None:
-            trimLine = r.TLine(-0.5, trimVcal[ieta], 127.5, trimVcal[ieta])
-            legend.Clear()
-            legend.AddEntry(trimLine, 'trimVCal is %f'%(trimVcal[vfat]))
-            legend.Draw('SAME')
-            trimLine.SetLineColor(1)
-            trimLine.SetLineWidth(3)
-            trimLine.Draw('SAME')
-            pass
-        canv.Update()
-        pass
+    
+    maxiEta = chamber_maxiEtaiPhiPair[gemType][0]
+    xyPair = (4,maxiEta//4) 
+    
+    canv = r.TCanvas('canv', 'canv', 500 * xyPair[0], 500 * xyPair[1])
+    canv.Divide(xyPair[0], xyPair[1])
 
-    canv.SaveAs(name)
+    if dictSummary is not None:
+        for index in range(maxiEta):
+            canv.cd(index+1)
+            try:
+                dictSummary[index].Draw(drawOpt)
+            except KeyError as err:
+                continue
+                                                                                
+    canv.Update()
 
-    return
+    if write2Disk:
+        canv.SaveAs(name)
+
+    return canv
+
+
+
+
+def addPlotToCanvas(canv=None, content = None, drawOpt = '', gemType="gem11"):
+    """
+    Creates a A by B sized canvas for summary plots.
+    
+    canv - TCanvas previously produced by make3x8Canvas() or one that has been subdivided into a 3x8 grid
+    content - either None or an array of 24 (one per VFAT) TObjects that will be drawn on the canvas.
+    drawOpt - draw option to be used when drawing elements of initialContent
+     
+    """
+
+    import ROOT as r
+    from ..mapping.chamberInfo import chamber_vfatPos2PadIdx
+    
+    
+    for index, padIdx in chamber_vfatPos2PadIdx[gemType].iteritems():
+        canv.cd(padIdx)
+        try:
+            content[index].Draw(drawOpt)
+        except KeyError as err:
+            continue
+
+    canv.Update()
+    return canv
 

--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -86,10 +86,16 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
 	else:
             return chamber_config[(entry['shelf'],entry['slot'],entry['link'])]
 
+    def getGemType(entry):
+        detName = getDetName(entry)
+        return detName[:detName.find('-')].lower()
+        
+
+       
     vfatArray = rp.tree2array(tree=dacScanTree,branches=list_bNames)
     dacNameArray = np.unique(vfatArray['nameX'])
-    detName = np.unique(rp.tree2array(tree=dacScanTree, branches='detName'))[0]
-    gemType = detName[0][:detName[0].find('-')].lower()
+
+                    
     print dacNameArray
     
     # Get VFATID's
@@ -104,7 +110,12 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
     list_bNames.remove('vfatID')
     list_bNames.remove('vfatN')
     crateMap = np.unique(rp.tree2array(tree=dacScanTree,branches=list_bNames))
+    
+    gemType = getGemType(crateMap[0])
+            
 
+
+    
     # get nonzero VFATs
     dict_nonzeroVFATs = {}
     for entry in crateMap:
@@ -1548,12 +1559,12 @@ def getSummaryCanvas(dictSummary, dictSummaryPanPin2=None, name='Summary', trimP
     legend = r.TLegend(0.75,0.7,0.88,0.88)
     r.gStyle.SetOptStat(0)
 
-    maxiEtaiPhiPair=chamber_maxiEtaiPhiPair[gemType]
+    maxiEta, maxiPhi =chamber_maxiEtaiPhiPair[gemType]
     
-    canv = r.TCanvas(name, name, 500 * maxiEtaiPhiPair[0], 500 * maxiEtaiPhiPair[1])
+    canv = r.TCanvas(name, name, 500 * maxiEta, 500 * maxiPhi)
     
     if dictSummary is not None and dictSummaryPanPin2 is None:
-        canv.Divide(maxiEtaiPhiPair[0], maxiEtaiPhiPair[1])
+        canv.Divide(maxiEta, maxiPhi)
         for vfat, padIdx in chamber_vfatPos2PadIdx[gemType].iteritems():
             canv.cd(padIdx)
             try:
@@ -1572,15 +1583,15 @@ def getSummaryCanvas(dictSummary, dictSummaryPanPin2=None, name='Summary', trimP
             
     elif dictSummary is not None and dictSummaryPanPin2 is not None:
         # possibly remove unless fixed, or at the very least needs to be improved!!
-        canv.Divide(maxiEtaiPhiPair[0], 2*maxiEtaiPhiPair[1])
-        shift = maxiEtaiPhiPair[0]*(maxiEtaiPhiPair[1]+4) + 1
+        canv.Divide(maxiEta, 2*maxiPhi)
+        shift = maxiEta*(maxiPhi+4) + 1
         for vfat in range(0, vfatsPerGemVariant[gemType]):
-            if vfat % niEta == 0:
-                shift -= niEta*3
+            if vfat % maxiEta == 0:
+                shift -= maxiEta*3
             canv.cd(vfat+shift)
             dictSummary[vfat].Draw(drawOpt)
             canv.Update()
-            canv.cd(vfat+shift+maxiEtaiPhiPair[0])
+            canv.cd(vfat+shift+maxiEta)
             dictSummaryPanPin2[vfat].Draw(drawOpt)
             canv.Update()
             pass

--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -594,7 +594,7 @@ def get2DMapOfDetector(vfatChanLUT, obsData, mapName, zLabel, gemType="ge11"):
 
     import ROOT as r
     from ..mapping.chamberInfo import chamber_maxiEtaiPhiPair
-    from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFATS as maxChans
+    from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFAT as maxChans
     maxiEta, maxiPhi = chamber_maxiEtaiPhiPair[gemType]
     
     hRetMap = r.TH2F("ieta_vs_{0}_{1}".format(mapName,zLabel),"",maxiPhi*maxChans, -0.5, maxiPhi*maxChans-0.5, maxiEta, 0.5, maxiEta + 0.5)
@@ -1551,7 +1551,7 @@ def getSummaryCanvas(dictSummary, dictSummaryPanPin2=None, name='Summary', trimP
     import ROOT as r
     from ..mapping.chamberInfo import chamber_vfatPos2PadIdx, chamber_maxiEtaiPhiPair
     from gempython.tools.hw_constants import vfatsPerGemVariant
-    from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFATS as maxChans
+    from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFAT as maxChans
     
     legend = r.TLegend(0.75,0.7,0.88,0.88)
     r.gStyle.SetOptStat(0)

--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -88,12 +88,15 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
 
     vfatArray = rp.tree2array(tree=dacScanTree,branches=list_bNames)
     dacNameArray = np.unique(vfatArray['nameX'])
-
+    detName = np.unique(rp.tree2array(tree=dacScanTree, branches='detName'))[0]
+    gemType = detName[0][:detName[0].find('-')].lower()
+    print dacNameArray
+    
     # Get VFATID's
     vfatIDArray = getSubArray(vfatArray, ['vfatID','vfatN'])
     vfatIDArray = np.sort(vfatIDArray,order='vfatN')['vfatID'] # index now gauranteed to match vfatN
 
-    gemType = "ge11"
+    
 
     # make the crateMap
     list_bNames.remove('dacValY')
@@ -1547,7 +1550,7 @@ def getSummaryCanvas(dictSummary, dictSummaryPanPin2=None, name='Summary', trimP
 
     maxiEtaiPhiPair=chamber_maxiEtaiPhiPair[gemType]
     
-    canv = r.TCanvas('canv', 'canv', 500 * maxiEtaiPhiPair[0], 500 * maxiEtaiPhiPair[1])
+    canv = r.TCanvas(name, name, 500 * maxiEtaiPhiPair[0], 500 * maxiEtaiPhiPair[1])
     
     if dictSummary is not None and dictSummaryPanPin2 is None:
         canv.Divide(maxiEtaiPhiPair[0], maxiEtaiPhiPair[1])
@@ -1611,7 +1614,7 @@ def getSummaryCanvasByiEta(dictSummary, name='Summary', drawOpt="colz", gemType=
     maxiEta = chamber_maxiEtaiPhiPair[gemType][0]
     xyPair = (4,maxiEta//4) 
     
-    canv = r.TCanvas('canv', 'canv', 500 * xyPair[0], 500 * xyPair[1])
+    canv = r.TCanvas(name, name, 500 * xyPair[0], 500 * xyPair[1])
     canv.Divide(xyPair[0], xyPair[1])
 
     for index in range(1,maxiEta+1):
@@ -1631,7 +1634,7 @@ def getSummaryCanvasByiEta(dictSummary, name='Summary', drawOpt="colz", gemType=
 
 
 
-def addPlotToCanvas(canv=None, content = None, drawOpt = '', gemType="gem11"):
+def addPlotToCanvas(canv=None, content = None, drawOpt = '', gemType="ge11"):
     """
     Creates a A by B sized canvas for summary plots.
     

--- a/utils/dbutils.py
+++ b/utils/dbutils.py
@@ -26,7 +26,7 @@ knownViews = [
         'GEM_VFAT3_PROD_SUMMARY_V_RH'
         ]
 
-def getGEMDBView(view, vfatList=None, debug=False):
+def getGEMDBView(view, vfatList=None, debug=False, gemType="ge11"):
     """
     Gets the GEM DB view defined by view for the list of vfats provided by vfatList, or
     if no vfatList is provided the full view stored in the DB.
@@ -84,13 +84,13 @@ def getGEMDBView(view, vfatList=None, debug=False):
             pass
         
         # Then add a 'vfatN' column to the output df; this increases row # to len(vfatList)
-        dfGEMView = joinOnVFATSerNum(vfatList,dfGEMView)
+        dfGEMView = joinOnVFATSerNum(vfatList,dfGEMView, gemType)
         
         pass
 
     return dfGEMView
 
-def getVFAT3CalInfo(vfatList, debug=False):
+def getVFAT3CalInfo(vfatList, debug=False, gemType="ge11"):
     """
     Gets from GEM_VFAT3_PROD_SUMMARY_V_RH view a subset of data that is necessary
     for VFAT calibration.  Specifically a pandas dataframe will be returned with
@@ -105,7 +105,7 @@ def getVFAT3CalInfo(vfatList, debug=False):
     #When using multithreading, the threads pass information back in pickled format. Some exceptions in cx_Oracle cannot be pickled.
     #Thus, we check here whether the exception can be pickled, and if not rethrow it as an exception that can be.
     try:
-        df_vfatCalInfo = getVFAT3ProdSumView(vfatList, debug)
+        df_vfatCalInfo = getVFAT3ProdSumView(vfatList, debug, gemType)
     except Exception as err:
         import pickle
         try:
@@ -119,7 +119,7 @@ def getVFAT3CalInfo(vfatList, debug=False):
         
     return df_vfatCalInfo[['vfatN','vfat3_ser_num', 'vfat3_barcode', 'iref', 'adc0m', 'adc1m', 'adc0b', 'adc1b', 'cal_dacm', 'cal_dacb']]
 
-def getVFAT3ConfView(vfatList, debug=False):
+def getVFAT3ConfView(vfatList, debug=False, gemType="ge11"):
     """
     Gets the GEM_VFAT3_CHIP_CONF_V_RH view in the GEM DB for a list of input VFATs.
 
@@ -129,9 +129,9 @@ def getVFAT3ConfView(vfatList, debug=False):
     debug       - Prints additional info if true
     """
 
-    return getGEMDBView("GEM_VFAT3_CHIP_CONF_V_RH",vfatList,debug)
+    return getGEMDBView("GEM_VFAT3_CHIP_CONF_V_RH",vfatList,debug, gemType)
 
-def getVFAT3ProdSumView(vfatList, debug=False):
+def getVFAT3ProdSumView(vfatList, debug=False, gemType="ge11"):
     """
     Gets the GEM_VFAT3_PROD_SUMMARY_V_RH view in the GEM DB for a list of input VFATs.
 
@@ -141,7 +141,7 @@ def getVFAT3ProdSumView(vfatList, debug=False):
     debug       - Prints additional info if true
     """
 
-    return getGEMDBView("GEM_VFAT3_PROD_SUMMARY_V_RH",vfatList,debug)
+    return getGEMDBView("GEM_VFAT3_PROD_SUMMARY_V_RH",vfatList,debug, gemType)
 
 def getVFATFilter(vfatList):
     """
@@ -162,7 +162,7 @@ def getVFATFilter(vfatList):
 
     return strRetFilter
 
-def joinOnVFATSerNum(vfatList, dfGEMView):
+def joinOnVFATSerNum(vfatList, dfGEMView, gemType="ge11"):
     """
     Creates a dataframe object from vfatList with keys 'vfat3_ser_num' and 'vfatN'.
     Then it joins this dataframe with dfGEMView using the 'vfat3_ser_num'.
@@ -170,10 +170,10 @@ def joinOnVFATSerNum(vfatList, dfGEMView):
     vfatList - A list of vfat ChipID's ordered by vfat position (sw)
     dfGEMView - A pandas dataframe containing the column name 'vfat3_ser_num'
     """
-
+    from gempython.tools.hw_constants import vfatsPerGemVariant
     if 'vfat3_ser_num' in dfGEMView.columns:
         dfVFATPos = pd.DataFrame(
-                    {   'vfatN':[vfat for vfat in range(24)], 
+                    {   'vfatN':[vfat for vfat in range(vfatsPerGemVariant[gemType])], 
                         'vfat3_ser_num':["0x{:x}".format(id) for id in vfatList]}
                 )
 

--- a/utils/dbutils.py
+++ b/utils/dbutils.py
@@ -26,7 +26,7 @@ knownViews = [
         'GEM_VFAT3_PROD_SUMMARY_V_RH'
         ]
 
-def getGEMDBView(view, vfatList=None, debug=False, gemType="ge11"):
+def getGEMDBView(view, vfatList=None, debug=False):
     """
     Gets the GEM DB view defined by view for the list of vfats provided by vfatList, or
     if no vfatList is provided the full view stored in the DB.
@@ -84,13 +84,13 @@ def getGEMDBView(view, vfatList=None, debug=False, gemType="ge11"):
             pass
         
         # Then add a 'vfatN' column to the output df; this increases row # to len(vfatList)
-        dfGEMView = joinOnVFATSerNum(vfatList,dfGEMView, gemType)
+        dfGEMView = joinOnVFATSerNum(vfatList,dfGEMView)
         
         pass
 
     return dfGEMView
 
-def getVFAT3CalInfo(vfatList, debug=False, gemType="ge11"):
+def getVFAT3CalInfo(vfatList, debug=False):
     """
     Gets from GEM_VFAT3_PROD_SUMMARY_V_RH view a subset of data that is necessary
     for VFAT calibration.  Specifically a pandas dataframe will be returned with
@@ -105,7 +105,7 @@ def getVFAT3CalInfo(vfatList, debug=False, gemType="ge11"):
     #When using multithreading, the threads pass information back in pickled format. Some exceptions in cx_Oracle cannot be pickled.
     #Thus, we check here whether the exception can be pickled, and if not rethrow it as an exception that can be.
     try:
-        df_vfatCalInfo = getVFAT3ProdSumView(vfatList, debug, gemType)
+        df_vfatCalInfo = getVFAT3ProdSumView(vfatList, debug)
     except Exception as err:
         import pickle
         try:
@@ -119,7 +119,7 @@ def getVFAT3CalInfo(vfatList, debug=False, gemType="ge11"):
         
     return df_vfatCalInfo[['vfatN','vfat3_ser_num', 'vfat3_barcode', 'iref', 'adc0m', 'adc1m', 'adc0b', 'adc1b', 'cal_dacm', 'cal_dacb']]
 
-def getVFAT3ConfView(vfatList, debug=False, gemType="ge11"):
+def getVFAT3ConfView(vfatList, debug=False):
     """
     Gets the GEM_VFAT3_CHIP_CONF_V_RH view in the GEM DB for a list of input VFATs.
 
@@ -129,9 +129,9 @@ def getVFAT3ConfView(vfatList, debug=False, gemType="ge11"):
     debug       - Prints additional info if true
     """
 
-    return getGEMDBView("GEM_VFAT3_CHIP_CONF_V_RH",vfatList,debug, gemType)
+    return getGEMDBView("GEM_VFAT3_CHIP_CONF_V_RH",vfatList,debug)
 
-def getVFAT3ProdSumView(vfatList, debug=False, gemType="ge11"):
+def getVFAT3ProdSumView(vfatList, debug=False):
     """
     Gets the GEM_VFAT3_PROD_SUMMARY_V_RH view in the GEM DB for a list of input VFATs.
 
@@ -141,7 +141,7 @@ def getVFAT3ProdSumView(vfatList, debug=False, gemType="ge11"):
     debug       - Prints additional info if true
     """
 
-    return getGEMDBView("GEM_VFAT3_PROD_SUMMARY_V_RH",vfatList,debug, gemType)
+    return getGEMDBView("GEM_VFAT3_PROD_SUMMARY_V_RH",vfatList,debug)
 
 def getVFATFilter(vfatList):
     """
@@ -162,7 +162,7 @@ def getVFATFilter(vfatList):
 
     return strRetFilter
 
-def joinOnVFATSerNum(vfatList, dfGEMView, gemType="ge11"):
+def joinOnVFATSerNum(vfatList, dfGEMView):
     """
     Creates a dataframe object from vfatList with keys 'vfat3_ser_num' and 'vfatN'.
     Then it joins this dataframe with dfGEMView using the 'vfat3_ser_num'.
@@ -173,7 +173,7 @@ def joinOnVFATSerNum(vfatList, dfGEMView, gemType="ge11"):
     from gempython.tools.hw_constants import vfatsPerGemVariant
     if 'vfat3_ser_num' in dfGEMView.columns:
         dfVFATPos = pd.DataFrame(
-                    {   'vfatN':[vfat for vfat in range(vfatsPerGemVariant[gemType])], 
+                    {   'vfatN':[vfat for vfat in range(len(vfatList))], 
                         'vfat3_ser_num':["0x{:x}".format(id) for id in vfatList]}
                 )
 

--- a/utils/latAlgos.py
+++ b/utils/latAlgos.py
@@ -75,12 +75,19 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
     # Get ChipID's
     import numpy as np
     import root_numpy as rp
+
     ##### NEED TO FIX
     #### VERY TEMPORARY
     from gempython.gemplotting.mapping.chamberInfo import gemTypeMapping
-    gemType = gemTypeMapping[rp.tree2array(inFile.latTree, branches =[ 'gemType' ] )[0][0]]
+    if 'gemType' not in inFile.latTree.GetListOfBranches():
+        gemType = "ge11"
+    else:
+        gemType = gemTypeMapping[rp.tree2array(tree=inFile.latTree, branches =[ 'gemType' ] )[0][0]]
     print gemType
     ##### END
+        
+
+
     
     listOfBranches = inFile.latTree.GetListOfBranches()
     if 'vfatID' in listOfBranches:

--- a/utils/latAlgos.py
+++ b/utils/latAlgos.py
@@ -86,7 +86,7 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
     ##### END
     from gempython.tools.hw_constants import vfatsPerGemVariant
     nVFATS = vfatsPerGemVariant[gemType]
-    from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFATS as maxChans    
+    from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFAT as maxChans    
 
 
     

--- a/utils/latAlgos.py
+++ b/utils/latAlgos.py
@@ -24,7 +24,7 @@ def anaUltraLatencyStar(inputs):
     """
     return anaUltraLatency(*inputs)
 
-def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=None, outputDir=None, outfilename="latencyAna.root", performFit=False):
+def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=None, outputDir=None, outfilename="latencyAna.root", performFit=False, gemType="ge11"):
     """
     Analyzes data taken by ultraLatency.py
 
@@ -71,6 +71,7 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
         inFile.Close()
         raise IOError("Input file {0} is a Zombie, check to make sure you have write permissions and file has expected size".format(infilename))
 
+    from gempython.tools.hw_constants import vfatsPerGemVariant
     # Get ChipID's
     import numpy as np
     import root_numpy as rp
@@ -81,7 +82,7 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
         for entry in array_chipID:
             dict_chipID[entry['vfatN']]=entry['vfatID']
     else:
-        dict_chipID = { vfat:0 for vfat in range(24) }
+        dict_chipID = { vfat:0 for vfat in range(vfatsPerGemVariant[gemType]) }
 
     if debug:
         print("VFAT Position to ChipID Mapping")
@@ -98,7 +99,7 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
     from gempython.utils.gemlogger import printYellow
     from gempython.utils.nesteddict import nesteddict as ndict
     dict_hVFATHitsVsLat = ndict()
-    for vfat in range(0,24):
+    for vfat in range(0,vfatsPerGemVariant[gemType]):
         try:
             chipID = dict_chipID[vfat]
         except KeyError as err:
@@ -129,13 +130,15 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
         pass
 
     from math import sqrt
-    for vfat in range(0,24):
+    for vfat in range(0,vfatsPerGemVariant[gemType]):
         for binX in range(1, dict_hVFATHitsVsLat[vfat].GetNbinsX()+1):
             dict_hVFATHitsVsLat[vfat].SetBinError(binX, sqrt(dict_hVFATHitsVsLat[vfat].GetBinContent(binX)))
 
     hHitsVsLat_AllVFATs = dict_hVFATHitsVsLat[0].Clone("hHitsVsLat_AllVFATs")
     hHitsVsLat_AllVFATs.SetTitle("Sum over all VFATs")
-    for vfat in range(1,24):
+    #### QUESTION 
+    # why is this only [1-24)
+    for vfat in range(1,vfatsPerGemVariant[gemType]):
         hHitsVsLat_AllVFATs.Add(dict_hVFATHitsVsLat[vfat])
 
     # Set Latency Fitting Bounds - Signal
@@ -294,12 +297,13 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
         pass
 
     # Store - Summary
-    from gempython.gemplotting.utils.anautilities import make3x8Canvas
+    from gempython.gemplotting.utils.anautilities import getSummaryCanvas, addPlotToCanvas
     if performFit:
-        canv_Summary = make3x8Canvas('canv_Summary', dict_grNHitsVFAT, 'APE1', dict_fitNHitsVFAT_Noise, '')
+        canv_Summary = getSummaryCanvas(dict_grNHitsVFAT, name='canv_Summary', drawOpt='APE1', gemType=gemType)
+        canv_Summary = addPlotToCanvas(canv_Summary, dict_fitNHitsVFAT_Noise, gemType)
         canv_Summary.SaveAs(outputDir+'/Summary.png')
     else:
-        canv_Summary = make3x8Canvas('canv_Summary', dict_grNHitsVFAT, 'APE1')
+        canv_Summary = getSummaryCanvas(dict_grNHitsVFAT, name='canv_Summary', drawOpt='APE1', gemType)
         canv_Summary.SaveAs(outputDir+'/Summary.png')
 
     # Store - Sig Over Bkg
@@ -316,7 +320,7 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
         grVFATSigOverBkg.GetYaxis().SetTitle("Sig / Bkg)")
         grVFATSigOverBkg.GetYaxis().SetTitleOffset(1.25)
         grVFATSigOverBkg.GetYaxis().SetRangeUser(1e-1,1e2)
-        grVFATSigOverBkg.GetXaxis().SetRangeUser(-0.5,24.5)
+        grVFATSigOverBkg.GetXaxis().SetRangeUser(-0.5,vfatsPerGemVariant[gemType] +0.5)
         grVFATSigOverBkg.Draw("APE1")
         canv_SigOverBkg.SaveAs(outputDir+'/SignalOverBkg.png')
 
@@ -332,7 +336,7 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
         grVFATNSignalNoBkg.GetYaxis().SetTitle("Signal Hits")
         grVFATNSignalNoBkg.GetYaxis().SetTitleOffset(1.5)
         grVFATNSignalNoBkg.GetYaxis().SetRangeUser(0,nTrig)
-        grVFATNSignalNoBkg.GetXaxis().SetRangeUser(-0.5,24.5)
+        grVFATNSignalNoBkg.GetXaxis().SetRangeUser(-0.5, vfatsPerGemVariant[gemType]+0.5)
         grVFATNSignalNoBkg.Draw("APE1")
         canv_Signal.SaveAs(outputDir+'/SignalNoBkg.png')
 
@@ -353,7 +357,7 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
     grNMaxLatBinByVFAT.SetMarkerStyle(21)
     grNMaxLatBinByVFAT.SetMarkerSize(0.7)
     grNMaxLatBinByVFAT.SetLineWidth(2)
-    grNMaxLatBinByVFAT.GetXaxis().SetRangeUser(-0.5,24.5)
+    grNMaxLatBinByVFAT.GetXaxis().SetRangeUser(-0.5,vfatsPerGemVariant[gemType] +0.5)
     grNMaxLatBinByVFAT.GetXaxis().SetTitle("VFAT Pos")
     grNMaxLatBinByVFAT.GetYaxis().SetRangeUser(0,nTrig)
     grNMaxLatBinByVFAT.GetYaxis().SetTitle("Hit Count of Max Lat Bin")
@@ -367,7 +371,7 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
     grMaxLatBinByVFAT.GetXaxis().SetTitle("VFAT Pos")
     grMaxLatBinByVFAT.GetYaxis().SetTitle("Max Lat Bin")
     grMaxLatBinByVFAT.GetYaxis().SetTitleOffset(1.2)
-    grMaxLatBinByVFAT.GetXaxis().SetRangeUser(-0.5,24.5)
+    grMaxLatBinByVFAT.GetXaxis().SetRangeUser(-0.5,vfatsPerGemVariant[gemType]+0.5)
     grMaxLatBinByVFAT.Draw("APE1")
     canv_MaxHitsPerLatByVFAT.SaveAs(outputDir+'/MaxHitsPerLatByVFAT.png')
 

--- a/utils/latAlgos.py
+++ b/utils/latAlgos.py
@@ -303,7 +303,7 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
         canv_Summary = addPlotToCanvas(canv_Summary, dict_fitNHitsVFAT_Noise, gemType)
         canv_Summary.SaveAs(outputDir+'/Summary.png')
     else:
-        canv_Summary = getSummaryCanvas(dict_grNHitsVFAT, name='canv_Summary', drawOpt='APE1', gemType)
+        canv_Summary = getSummaryCanvas(dict_grNHitsVFAT, name='canv_Summary', drawOpt='APE1', gemType=gemType)
         canv_Summary.SaveAs(outputDir+'/Summary.png')
 
     # Store - Sig Over Bkg

--- a/utils/latAlgos.py
+++ b/utils/latAlgos.py
@@ -242,10 +242,10 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
         grMaxLatBinByVFAT.SetPointError(vfat, 0, 0.5) #could be improved upon
 
         # Initialize
-        dict_fitNHitsVFAT_Sig[vfat] = r.TF1("func_N_vs_Lat_VFAT%i_Sig"%vfat,"[0]",latFitMin_Sig,latFitMax_Sig)
-        dict_fitNHitsVFAT_Noise[vfat] = r.TF1("func_N_vs_Lat_VFAT%i_Noise"%vfat,"[0]",latMin,latMax)
+        dict_fitNHitsVFAT_Sig[vfat] = r.TF1("func_N_vs_Lat_VFAT{0}_Sig".format(vfat),"[0]",latFitMin_Sig,latFitMax_Sig)
+        dict_fitNHitsVFAT_Noise[vfat] = r.TF1("func_N_vs_Lat_VFAT{0}_Noise".format(vfat),"[0]",latMin,latMax)
         dict_grNHitsVFAT[vfat] = r.TGraphAsymmErrors(dict_hVFATHitsVsLat[vfat])
-        dict_grNHitsVFAT[vfat].SetName("g_N_vs_Lat_VFAT%i"%vfat)
+        dict_grNHitsVFAT[vfat].SetName("g_N_vs_Lat_VFAT{0}".format(vfat))
 
         # Fitting
         if performFit:
@@ -257,7 +257,7 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
             # Remove Signal Region
             latVal = r.Double()
             hitVal = r.Double()
-            gTempDist = dict_grNHitsVFAT[vfat].Clone("g_N_vs_Lat_VFAT%i_NoSig"%vfat)
+            gTempDist = dict_grNHitsVFAT[vfat].Clone("g_N_vs_Lat_VFAT{0}_NoSig".format(vfat))
             for idx in range(dict_grNHitsVFAT[vfat].GetN()-1,0,-1):
                 gTempDist.GetPoint(idx,latVal,hitVal)
                 if latFitMin_Noise < latVal and latVal < latFitMax_Noise:
@@ -286,7 +286,7 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
 
             # Print if requested
             if debug:
-                print("%i\t%f\t%f"%(vfat, hitCountSig[0], SigOverBkg[0]))
+                print("{0}\t{1}\t{2}".format(vfat, hitCountSig[0], SigOverBkg[0]))
             pass
 
         # Format
@@ -300,7 +300,7 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
         dict_grNHitsVFAT[vfat].GetYaxis().SetTitle("N")
 
         # Write
-        dirVFAT = dirVFATPlots.mkdir("VFAT%i"%vfat)
+        dirVFAT = dirVFATPlots.mkdir("VFAT{0}".format(vfat))
         dirVFAT.cd()
         dict_grNHitsVFAT[vfat].Write()
         dict_hVFATHitsVsLat[vfat].Write()

--- a/utils/latAlgos.py
+++ b/utils/latAlgos.py
@@ -24,7 +24,7 @@ def anaUltraLatencyStar(inputs):
     """
     return anaUltraLatency(*inputs)
 
-def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=None, outputDir=None, outfilename="latencyAna.root", performFit=False, gemType="ge11"):
+def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=None, outputDir=None, outfilename="latencyAna.root", performFit=False):
     """
     Analyzes data taken by ultraLatency.py
 
@@ -75,6 +75,13 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
     # Get ChipID's
     import numpy as np
     import root_numpy as rp
+    ##### NEED TO FIX
+    #### VERY TEMPORARY
+    from gempython.gemplotting.mapping.chamberInfo import gemTypeMapping
+    gemType = gemTypeMapping[rp.tree2array(inFile.latTree, branches =[ 'gemType' ] )[0][0]]
+    print gemType
+    ##### END
+    
     listOfBranches = inFile.latTree.GetListOfBranches()
     if 'vfatID' in listOfBranches:
         array_chipID = np.unique(rp.tree2array(inFile.latTree, branches = [ 'vfatID','vfatN' ] ))

--- a/utils/latAlgos.py
+++ b/utils/latAlgos.py
@@ -85,7 +85,9 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
         gemType = gemTypeMapping[rp.tree2array(tree=inFile.latTree, branches =[ 'gemType' ] )[0][0]]
     print gemType
     ##### END
-        
+    from gempython.tools.hw_constants import vfatsPerGemVariant
+    nVFATS = vfatsPerGemVariant[gemType]
+    from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFATS as maxChans    
 
 
     
@@ -96,7 +98,7 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
         for entry in array_chipID:
             dict_chipID[entry['vfatN']]=entry['vfatID']
     else:
-        dict_chipID = { vfat:0 for vfat in range(vfatsPerGemVariant[gemType]) }
+        dict_chipID = { vfat:0 for vfat in range(nVFATS) }
 
     if debug:
         print("VFAT Position to ChipID Mapping")
@@ -113,7 +115,7 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
     from gempython.utils.gemlogger import printYellow
     from gempython.utils.nesteddict import nesteddict as ndict
     dict_hVFATHitsVsLat = ndict()
-    for vfat in range(0,vfatsPerGemVariant[gemType]):
+    for vfat in range(0,nVFATS):
         try:
             chipID = dict_chipID[vfat]
         except KeyError as err:
@@ -144,15 +146,13 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
         pass
 
     from math import sqrt
-    for vfat in range(0,vfatsPerGemVariant[gemType]):
+    for vfat in range(0,nVFATS):
         for binX in range(1, dict_hVFATHitsVsLat[vfat].GetNbinsX()+1):
             dict_hVFATHitsVsLat[vfat].SetBinError(binX, sqrt(dict_hVFATHitsVsLat[vfat].GetBinContent(binX)))
 
     hHitsVsLat_AllVFATs = dict_hVFATHitsVsLat[0].Clone("hHitsVsLat_AllVFATs")
     hHitsVsLat_AllVFATs.SetTitle("Sum over all VFATs")
-    #### QUESTION 
-    # why is this only [1-24)
-    for vfat in range(1,vfatsPerGemVariant[gemType]):
+    for vfat in range(1,nVFATS):
         hHitsVsLat_AllVFATs.Add(dict_hVFATHitsVsLat[vfat])
 
     # Set Latency Fitting Bounds - Signal
@@ -334,7 +334,7 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
         grVFATSigOverBkg.GetYaxis().SetTitle("Sig / Bkg)")
         grVFATSigOverBkg.GetYaxis().SetTitleOffset(1.25)
         grVFATSigOverBkg.GetYaxis().SetRangeUser(1e-1,1e2)
-        grVFATSigOverBkg.GetXaxis().SetRangeUser(-0.5,vfatsPerGemVariant[gemType] +0.5)
+        grVFATSigOverBkg.GetXaxis().SetRangeUser(-0.5,nVFATS +0.5)
         grVFATSigOverBkg.Draw("APE1")
         canv_SigOverBkg.SaveAs(outputDir+'/SignalOverBkg.png')
 
@@ -350,7 +350,7 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
         grVFATNSignalNoBkg.GetYaxis().SetTitle("Signal Hits")
         grVFATNSignalNoBkg.GetYaxis().SetTitleOffset(1.5)
         grVFATNSignalNoBkg.GetYaxis().SetRangeUser(0,nTrig)
-        grVFATNSignalNoBkg.GetXaxis().SetRangeUser(-0.5, vfatsPerGemVariant[gemType]+0.5)
+        grVFATNSignalNoBkg.GetXaxis().SetRangeUser(-0.5, nVFATS+0.5)
         grVFATNSignalNoBkg.Draw("APE1")
         canv_Signal.SaveAs(outputDir+'/SignalNoBkg.png')
 
@@ -371,7 +371,7 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
     grNMaxLatBinByVFAT.SetMarkerStyle(21)
     grNMaxLatBinByVFAT.SetMarkerSize(0.7)
     grNMaxLatBinByVFAT.SetLineWidth(2)
-    grNMaxLatBinByVFAT.GetXaxis().SetRangeUser(-0.5,vfatsPerGemVariant[gemType] +0.5)
+    grNMaxLatBinByVFAT.GetXaxis().SetRangeUser(-0.5,nVFATS +0.5)
     grNMaxLatBinByVFAT.GetXaxis().SetTitle("VFAT Pos")
     grNMaxLatBinByVFAT.GetYaxis().SetRangeUser(0,nTrig)
     grNMaxLatBinByVFAT.GetYaxis().SetTitle("Hit Count of Max Lat Bin")
@@ -385,7 +385,7 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
     grMaxLatBinByVFAT.GetXaxis().SetTitle("VFAT Pos")
     grMaxLatBinByVFAT.GetYaxis().SetTitle("Max Lat Bin")
     grMaxLatBinByVFAT.GetYaxis().SetTitleOffset(1.2)
-    grMaxLatBinByVFAT.GetXaxis().SetRangeUser(-0.5,vfatsPerGemVariant[gemType]+0.5)
+    grMaxLatBinByVFAT.GetXaxis().SetRangeUser(-0.5,nVFATS+0.5)
     grMaxLatBinByVFAT.Draw("APE1")
     canv_MaxHitsPerLatByVFAT.SaveAs(outputDir+'/MaxHitsPerLatByVFAT.png')
 

--- a/utils/latAlgos.py
+++ b/utils/latAlgos.py
@@ -76,8 +76,7 @@ def anaUltraLatency(infilename, debug=False, latSigMaskRange=None, latSigRange=N
     import numpy as np
     import root_numpy as rp
 
-    ##### NEED TO FIX
-    #### VERY TEMPORARY
+    ##### FIXME
     from gempython.gemplotting.mapping.chamberInfo import gemTypeMapping
     if 'gemType' not in inFile.latTree.GetListOfBranches():
         gemType = "ge11"

--- a/utils/scurveAlgos.py
+++ b/utils/scurveAlgos.py
@@ -177,7 +177,7 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
             for vfat in range(nVFATS):
                 if vfat not in dict_chipID:
                     dict_chipID[vfat] = -1
-        dbInfo = getVFAT3CalInfo(dict_chipID.values(), debug=args.debug, gemType=gemType)
+        dbInfo = getVFAT3CalInfo(dict_chipID.values(), debug=args.debug)
         calDAC2Q_Slope = dbInfo['cal_dacm']
         calDAC2Q_Intercept = dbInfo['cal_dacb']
     else:

--- a/utils/scurveAlgos.py
+++ b/utils/scurveAlgos.py
@@ -172,7 +172,7 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
             for vfat in range(vfatsPerGemVariant[gemType]):
                 if vfat not in dict_chipID:
                     dict_chipID[vfat] = -1
-        dbInfo = getVFAT3CalInfo(dict_chipID.values(), debug=args.debug, gemType)
+        dbInfo = getVFAT3CalInfo(dict_chipID.values(), debug=args.debug, gemType=gemType)
         calDAC2Q_Slope = dbInfo['cal_dacm']
         calDAC2Q_Intercept = dbInfo['cal_dacb']
     else:
@@ -878,7 +878,9 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
         canvasBoxPlot_ENC.Update()
         canvasBoxPlot_ENC.SaveAs("%s/h2ScurveSigmaDist_All.png"%(outputDir))
         canvasBoxPlot_ENC.Close()
-    
+
+
+        
         getSummaryCanvasByiEta(threshSummaryPlotsByiEta, name='%s/ScurveMeanSummaryByiEta.png'%outputDir, drawOpt="AP", gemType=gemType, write2Disk=True)
         getSummaryCanvasByiEta(effPedSummaryPlotsByiEta, name='%s/ScurveEffPedSummaryByiEta.png'%outputDir, drawOpt="E1", gemType=gemType, write2Disk=True)
         getSummaryCanvasByiEta(encSummaryPlotsByiEta, name='%s/ScurveSigmaSummaryByiEta.png'%outputDir, drawOpt="AP", gemType=gemType, write2Disk=True)

--- a/utils/scurveAlgos.py
+++ b/utils/scurveAlgos.py
@@ -178,7 +178,7 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
     else:
         printYellow("Calibration info for {0} taken from input file: {1}".format(dacName,args.calFile))
         from gempython.gemplotting.utils.anautilities import parseCalFile
-        tuple_calInfo = parseCalFile(args.calFile)
+        tuple_calInfo = parseCalFile(args.calFile, gemType)
         calDAC2Q_Slope = tuple_calInfo[0]
         calDAC2Q_Intercept = tuple_calInfo[1]
 
@@ -288,11 +288,11 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
     dict_vfatChanLUT = ndict()
     from gempython.gemplotting.utils.anautilities import getMapping
     if args.extChanMapping is not None:
-        dict_vfatChanLUT = getMapping(args.extChanMapping)
+        dict_vfatChanLUT = getMapping(args.extChanMapping, gemType=gemType)
     elif GEBtype == 'long':
-        dict_vfatChanLUT = getMapping(MAPPING_PATH+'/longChannelMap.txt')
+        dict_vfatChanLUT = getMapping(MAPPING_PATH+'/longChannelMap.txt', gemType=gemType)
     elif GEBtype == 'short':
-        dict_vfatChanLUT = getMapping(MAPPING_PATH+'/shortChannelMap.txt')
+        dict_vfatChanLUT = getMapping(MAPPING_PATH+'/shortChannelMap.txt', gemType=gemType)
     else:
         outF.Close()
         inFile.Close()
@@ -356,7 +356,9 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
             chanMasks=None, 
             calDAC2Q_m=calDAC2Q_Slope, 
             calDAC2Q_b=calDAC2Q_Intercept,
-            vfatList=vfatList)
+            vfatList=vfatList,
+            gemType=gemType
+    )
     
     if performFit:
         # Fit Scurves        
@@ -462,7 +464,9 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
                 chanMasks=masks, 
                 calDAC2Q_m=calDAC2Q_Slope, 
                 calDAC2Q_b=calDAC2Q_Intercept,
-                vfatList=vfatList)
+                vfatList=vfatList,
+                gemType=gemType
+        )
         
         # Set the branches of the TTree and store the results
         # Due to weird ROOT black magic this cannot be done here

--- a/utils/scurveAlgos.py
+++ b/utils/scurveAlgos.py
@@ -239,32 +239,32 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
                     yMin_Charge,
                     yMax_Charge)
             vSummaryPlots[vfat].GetYaxis().SetTitleOffset(1.5)
-            vSummaryPlotsNoMaskedChan[vfat] = r.TH2D('vSummaryPlotsNoMaskedChan%i'%vfat,
+            vSummaryPlotsNoMaskedChan[vfat] = r.TH2D('vSummaryPlotsNoMaskedChan{0}'.format(vfat),
                     'VFAT {0}: chipID {1};{2};{3} #left(fC#right)'.format(vfat,chipID,stripChanOrPinName[1],dacName),
                     128,-0.5,127.5,256,
                     yMin_Charge,
                     yMax_Charge)
             vSummaryPlotsNoMaskedChan[vfat].GetYaxis().SetTitleOffset(1.5)
         else:
-            vSummaryPlots[vfat] = r.TH2D('vSummaryPlots%i'%vfat,
+            vSummaryPlots[vfat] = r.TH2D('vSummaryPlots{0}'.format(vfat),
                     'VFAT{0} chipID {1} Pins [0-63];63 - Panasonic Pin;{2} #left(fC#right)'.format(vfat,chipID,dacName),
                     64,-0.5,63.5,256,
                     yMin_Charge,
                     yMax_Charge)
             vSummaryPlots[vfat].GetYaxis().SetTitleOffset(1.5)
-            vSummaryPlotsNoMaskedChan[vfat] = r.TH2D('vSummaryPlotsNoMaskedChan%i'%vfat,
+            vSummaryPlotsNoMaskedChan[vfat] = r.TH2D('vSummaryPlotsNoMaskedChan{0}'.format(vfat),
                     'VFAT{0} chipID {1} Pins [0-63];63 - Panasonic Pin;{2} #left(fC#right)'.format(vfat,chipID,dacName),
                     64,-0.5,63.5,256,
                     yMin_Charge,
                     yMax_Charge)
             vSummaryPlotsNoMaskedChan[vfat].GetYaxis().SetTitleOffset(1.5)
-            vSummaryPlotsPanPin2[vfat] = r.TH2D('vSummaryPlotsPanPin2_%i'%vfat,
+            vSummaryPlotsPanPin2[vfat] = r.TH2D('vSummaryPlotsPanPin2_{0}'.format(vfat),
                     'VFAT{0} chipID {1} Pins [64-127];127 - Panasonic Pin;{2} #left(fC#right)'.format(vfat,chipID,dacName),
                     64,-0.5,63.5,256,
                     yMin_Charge,
                     yMax_Charge)
             vSummaryPlotsPanPin2[vfat].GetYaxis().SetTitleOffset(1.5)
-            vSummaryPlotsNoMaskedChanPanPin2[vfat] = r.TH2D('vSummaryPlotsNoMaskedChanPanPin2_%i'%vfat,
+            vSummaryPlotsNoMaskedChanPanPin2[vfat] = r.TH2D('vSummaryPlotsNoMaskedChanPanPin2_{0}'.format(vfat),
                     'VFAT{0} chipID {1} Pins [64-127];127 - Panasonic Pin;{2} #left(fC#right)'.format(vfat,chipID,dacName),
                     64,-0.5,63.5,256,
                     yMin_Charge,
@@ -373,7 +373,7 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
 
             for chan in range(0,128):
                 fitSummary.write(
-                        '%i\t%i\t%i\t%f\t%f\t%f\t%f\n'%(
+                        '{0}\t{1}\t{2}\t{3}\t{4}\t{5}\t{6}\n'.format(
                             vfat,
                             dict_vfatID[vfat],
                             chan,
@@ -391,8 +391,8 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
         masks = {}
         reason4Mask = {}
         effectivePedestals = [ np.zeros(128) for vfat in range(vfatsPerGemVariant[gemType]) ]
-        print "| vfatN | Dead Chan | Hot Chan | Failed Fits | High Noise | High Eff Ped |"
-        print "| :---: | :-------: | :------: | :---------: | :--------: | :----------: |"
+        print("| vfatN | Dead Chan | Hot Chan | Failed Fits | High Noise | High Eff Ped |")
+        print("| :---: | :-------: | :------: | :---------: | :--------: | :----------: |")
         for vfat in range(vfatsPerGemVariant[gemType]):
             # If provided, skip all VFATs but the requested one
             if ((vfatList is not None) and (vfat not in vfatList)):
@@ -444,13 +444,13 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
                 pass
             reason4Mask[vfat] = reason
             masks[vfat] = ((reason != MaskReason.NotMasked) * (reason != MaskReason.DeadChannel))
-            print '| %5i | %9i | %8i | %11i | %10i | %12i |'%(
+            print('| {0:5d} | {1:9d} | {2:8d} | {3:11d} | {4:10d} | {5:12d} |'.format(
                     vfat,
                     nDeadChan,
                     np.count_nonzero(hot),
                     np.count_nonzero(fitFailed),
                     np.count_nonzero(channelNoise > args.highNoiseCut),
-                    nHighEffPed)
+                    nHighEffPed))
             pass
         
         # Make Distributions w/o Hot Channels
@@ -607,7 +607,7 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
                 # Set TObjects linked to TBranches
                 holder_curve = fitter.scanHistos[vfat][chan]
                 holder_curve.Copy(scurve_h)
-                holder_fit = fitter.getFunc(vfat,chan).Clone('scurveFit_vfat%i_chan%i'%(vfat,chan))
+                holder_fit = fitter.getFunc(vfat,chan).Clone('scurveFit_vfat{0}_chan{1}'.format(vfat,chan))
                 holder_fit.Copy(scurve_fit)
                 
                 # Filling the arrays for plotting later
@@ -618,7 +618,7 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
                         scurve_h.Draw()
                         scurve_fit.Draw('SAME')
                         canvas.Update()
-                        canvas.SaveAs('Fit_Overlay_vfat%i_vfatCH%i.png'%(VFAT, chan))
+                        canvas.SaveAs('Fit_Overlay_vfat{0}_vfatCH{1}.png'.format(VFAT, chan))
                         pass
                     pass
                 scurveFitTree.Fill()
@@ -632,7 +632,7 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
                     np.zeros(128),
                     allENC[(vfat*128):((vfat+1)*128)]
                     )
-            fitSummaryPlots[vfat].SetTitle("VFAT %i Fit Summary;Channel;Threshold #left(fC#right)"%vfat)
+            fitSummaryPlots[vfat].SetTitle("VFAT {0} Fit Summary;Channel;Threshold #left(fC#right)".format(vfat))
             
             if not (args.channels or args.PanPin):
                 fitSummaryPlots[vfat].GetXaxis().SetTitle("Strip")
@@ -641,13 +641,13 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
                 fitSummaryPlots[vfat].GetXaxis().SetTitle("Panasonic Pin")
                 pass
             
-            fitSummaryPlots[vfat].SetName("gFitSummary_VFAT%i"%(vfat))
+            fitSummaryPlots[vfat].SetName("gFitSummary_VFAT{0}".format(vfat))
             fitSummaryPlots[vfat].SetMarkerStyle(2)
             
             # Make thresh summary plot - bin size is variable
             thisVFAT_ThreshMean = np.mean(allThresh[(vfat*128):((vfat+1)*128)])
             thisVFAT_ThreshStd = np.std(allThresh[(vfat*128):((vfat+1)*128)])
-            histThresh = r.TH1F("scurveMean_vfat%i"%vfat,"VFAT %i;S-Curve Mean #left(fC#right);N"%vfat,
+            histThresh = r.TH1F("scurveMean_vfat{0}".format(vfat),"VFAT {0};S-Curve Mean #left(fC#right);N".format(vfat),
                                 40, thisVFAT_ThreshMean - 5. * thisVFAT_ThreshStd, thisVFAT_ThreshMean + 5. * thisVFAT_ThreshStd )
             histThresh.Sumw2()
             if thisVFAT_ThreshStd != 0: # Don't fill if we still at initial values
@@ -659,13 +659,13 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
                     pass
                 pass
             gThresh = r.TGraphErrors(histThresh)
-            gThresh.SetName("gScurveMeanDist_vfat%i"%vfat)
+            gThresh.SetName("gScurveMeanDist_vfat{0}".format(vfat))
             gThresh.GetXaxis().SetTitle("scurve mean pos #left(fC#right)")
-            gThresh.GetYaxis().SetTitle("Entries / %f fC"%(thisVFAT_ThreshStd/4.))
+            gThresh.GetYaxis().SetTitle("Entries / {0} fC".format(thisVFAT_ThreshStd/4.))
             threshSummaryPlots[vfat] = gThresh
 
             # Make effective pedestal summary plot - bin size is fixed
-            histEffPed = r.TH1F("scurveEffPed_vfat%i"%vfat,"VFAT %i;S-Curve Effective Pedestal #left(N#right);N"%vfat,
+            histEffPed = r.TH1F("scurveEffPed_vfat{0}".format(vfat),"VFAT {0};S-Curve Effective Pedestal #left(N#right);N".format(vfat),
                                 nPulses+1, -0.5, nPulses+0.5)
             histEffPed.Sumw2()
             for effPed in allEffPed[(vfat*128):((vfat+1)*128)]:
@@ -683,7 +683,7 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
             # Make enc summary plot bin size is variable
             thisVFAT_ENCMean = np.mean(allENC[(vfat*128):((vfat+1)*128)])
             thisVFAT_ENCStd = np.std(allENC[(vfat*128):((vfat+1)*128)])
-            histENC = r.TH1F("scurveSigma_vfat%i"%vfat,"VFAT %i;S-Curve Sigma #left(fC#right);N"%vfat,
+            histENC = r.TH1F("scurveSigma_vfat{0}".format(vfat),"VFAT {0};S-Curve Sigma #left(fC#right);N".format(vfat),
                                 40, thisVFAT_ENCMean - 5. * thisVFAT_ENCStd, thisVFAT_ENCMean + 5. * thisVFAT_ENCStd )
             histENC.Sumw2()
             if thisVFAT_ENCStd != 0: # Don't fill if we are still at initial values
@@ -695,9 +695,9 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
                     pass
                 pass
             gENC = r.TGraphErrors(histENC)
-            gENC.SetName("gScurveSigmaDist_vfat%i"%vfat)
+            gENC.SetName("gScurveSigmaDist_vfat{0}".format(vfat))
             gENC.GetXaxis().SetTitle("scurve sigma #left(fC#right)")
-            gENC.GetYaxis().SetTitle("Entries / %f fC"%(thisVFAT_ENCStd/4.))
+            gENC.GetYaxis().SetTitle("Entries / {0} fC".format(thisVFAT_ENCStd/4.))
             encSummaryPlots[vfat] = gENC
             pass
   
@@ -710,11 +710,11 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
             hDetThresh_All.Fill(thresh)
             pass
         hDetThresh_All.GetXaxis().SetTitle("scurve mean pos #left(fC#right)")
-        hDetThresh_All.GetYaxis().SetTitle("Entries / %f fC"%(detThresh_Std/10.))
+        hDetThresh_All.GetYaxis().SetTitle("Entries / {0} fC".format(detThresh_Std/10.))
         gDetThresh_All = r.TGraphErrors(hDetThresh_All)
         gDetThresh_All.SetName("gScurveMeanDist_All")
         gDetThresh_All.GetXaxis().SetTitle("scurve mean pos #left(fC#right)")
-        gDetThresh_All.GetYaxis().SetTitle("Entries / %f fC"%(detThresh_Std/10.))
+        gDetThresh_All.GetYaxis().SetTitle("Entries / {0} fC".format(detThresh_Std/10.))
 
         # Make a thresh map dist for the entire detector
         from gempython.gemplotting.utils.anautilities import get2DMapOfDetector
@@ -753,11 +753,11 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
             hDetENC_All.Fill(enc)
             pass
         hDetENC_All.GetXaxis().SetTitle("scurve sigma #left(fC#right)")
-        hDetENC_All.GetYaxis().SetTitle("Entries / %f fC"%(detENC_Std/10.))
+        hDetENC_All.GetYaxis().SetTitle("Entries / {0} fC".format(detENC_Std/10.))
         gDetENC_All = r.TGraphErrors(hDetENC_All)
         gDetENC_All.SetName("gScurveSigmaDist_All")
         gDetENC_All.GetXaxis().SetTitle("scurve sigma #left(fC#right)")
-        gDetENC_All.GetYaxis().SetTitle("Entries / %f fC"%(detENC_Std/10.))
+        gDetENC_All.GetYaxis().SetTitle("Entries / {0} fC".format(detENC_Std/10.))
         
         # Make a ENC map dist for the entire detector
         hDetMapENC = get2DMapOfDetector(dict_vfatChanLUT, allENC, stripChanOrPinType, "noise", gemType=gemType)
@@ -771,8 +771,8 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
             ietaThresh_Std = np.std(allThreshByiEta[ieta][allThreshByiEta[ieta] != 0])
 
             hThresh_iEta = r.TH1F(
-                    "hScurveMeanDist_ieta%i"%(ieta),
-                    "i#eta=%i;S-Curve Mean #left(fC#right);N"%(ieta),
+                    "hScurveMeanDist_ieta{0}".format(ieta),
+                    "i#eta={0};S-Curve Mean #left(fC#right);N".format(ieta),
                     80, 
                     ietaThresh_Mean - 5. * ietaThresh_Std, 
                     ietaThresh_Mean + 5. * ietaThresh_Std )
@@ -781,15 +781,15 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
                 hThresh_iEta.Fill(thresh)
                 pass
             gThresh_iEta = r.TGraphErrors(hThresh_iEta)
-            gThresh_iEta.SetName("gScurveMeanDist_ieta%i"%(ieta))
+            gThresh_iEta.SetName("gScurveMeanDist_ieta{0}".format(ieta))
             gThresh_iEta.GetXaxis().SetTitle("scurve mean pos #left(fC#right)")
-            gThresh_iEta.GetYaxis().SetTitle("Entries / %f fC"%(ietaThresh_Std/8.))
+            gThresh_iEta.GetYaxis().SetTitle("Entries / {0} fC".format(ietaThresh_Std/8.))
             threshSummaryPlotsByiEta[ieta] = gThresh_iEta
 
             # S-curve effective pedestal
             hEffPed_iEta = r.TH1F(
-                    "hScurveEffPedDist_ieta%i"%(ieta),
-                    "i#eta=%i;S-Curve Effective Pedestal #left(N#right);N"%(ieta),
+                    "hScurveEffPedDist_ieta{0}".format(ieta),
+                    "i#eta={0};S-Curve Effective Pedestal #left(N#right);N".format(ieta),
                      nPulses+1, -0.5, nPulses+0.5)
             
             for effPed in allEffPedByiEta[ieta][allEffPedByiEta[ieta] > -1]:
@@ -805,8 +805,8 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
             ietaENC_Std = np.std(allENCByiEta[ieta][allENCByiEta[ieta] != 0])
 
             hENC_iEta = r.TH1F(
-                    "hScurveSigmaDist_ieta%i"%(ieta),
-                    "i#eta=%i;S-Curve Sigma #left(fC#right);N"%(ieta),
+                    "hScurveSigmaDist_ieta{0}".format(ieta),
+                    "i#eta={0};S-Curve Sigma #left(fC#right);N".format(ieta),
                     80, 
                     ietaENC_Mean - 5. * ietaENC_Std, 
                     ietaENC_Mean + 5. * ietaENC_Std )
@@ -815,9 +815,9 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
                 hENC_iEta.Fill(enc)
                 pass
             gENC_iEta = r.TGraphErrors(hENC_iEta)
-            gENC_iEta.SetName("gScurveSigmaDist_ieta%i"%(ieta))
+            gENC_iEta.SetName("gScurveSigmaDist_ieta{0}".format(ieta))
             gENC_iEta.GetXaxis().SetTitle("scurve sigma pos #left(fC#right)")
-            gENC_iEta.GetYaxis().SetTitle("Entries / %f fC"%(ietaENC_Std/8.))
+            gENC_iEta.GetYaxis().SetTitle("Entries / {0} fC".format(ietaENC_Std/8.))
             encSummaryPlotsByiEta[ieta] = gENC_iEta
             pass
         pass # end if performFit
@@ -825,19 +825,19 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
     # Save the summary plots and channel config file
     from gempython.gemplotting.utils.anautilities import getSummaryCanvas, getSummaryCanvasByiEta
     if args.PanPin:
-        getSummaryCanvas(vSummaryPlots, vSummaryPlotsPanPin2, '%s/Summary.png'%outputDir, gemType=gemType, write2Disk=True) 
+        getSummaryCanvas(vSummaryPlots, vSummaryPlotsPanPin2, '{0}/Summary.png'.format(outputDir), gemType=gemType, write2Disk=True) 
     else: 
-        getSummaryCanvas(vSummaryPlots, None, '%s/Summary.png'%outputDir, gemType=gemType, write2Disk=True)
+        getSummaryCanvas(vSummaryPlots, None, '{0}/Summary.png'.format(outputDir), gemType=gemType, write2Disk=True)
 
     if performFit:
         if args.PanPin:
-            getSummaryCanvas(vSummaryPlotsNoMaskedChan, vSummaryPlotsNoMaskedChanPanPin2, '%s/PrunedSummary.png'%outputDir, gemType=gemType, write2Disk=True)
+            getSummaryCanvas(vSummaryPlotsNoMaskedChan, vSummaryPlotsNoMaskedChanPanPin2, '{0}/PrunedSummary.png'.format(outputDir), gemType=gemType, write2Disk=True)
         else:
-            getSummaryCanvas(vSummaryPlotsNoMaskedChan, None, '%s/PrunedSummary.png'%outputDir, gemType=gemType, write2Disk=True)
-        getSummaryCanvas(fitSummaryPlots, None, '%s/fitSummary.png'%outputDir, None, drawOpt="APE1", gemType=gemType, write2Disk=True)
-        getSummaryCanvas(threshSummaryPlots, None, '%s/ScurveMeanSummary.png'%outputDir, None, drawOpt="AP", gemType=gemType, write2Disk=True)
-        getSummaryCanvas(effPedSummaryPlots, None, '%s/ScurveEffPedSummary.png'%outputDir, None, drawOpt="E1", gemType=gemType, write2Disk=True)
-        getSummaryCanvas(encSummaryPlots, None, '%s/ScurveSigmaSummary.png'%outputDir, None, drawOpt="AP", gemType=gemType, write2Disk=True)
+            getSummaryCanvas(vSummaryPlotsNoMaskedChan, None, '{0}/PrunedSummary.png'.format(outputDir), gemType=gemType, write2Disk=True)
+        getSummaryCanvas(fitSummaryPlots, None, '{0}/fitSummary.png'.format(outputDir), None, drawOpt="APE1", gemType=gemType, write2Disk=True)
+        getSummaryCanvas(threshSummaryPlots, None, '{0}/ScurveMeanSummary.png'.format(outputDir), None, drawOpt="AP", gemType=gemType, write2Disk=True)
+        getSummaryCanvas(effPedSummaryPlots, None, '{0}/ScurveEffPedSummary.png'.format(outputDir), None, drawOpt="E1", gemType=gemType, write2Disk=True)
+        getSummaryCanvas(encSummaryPlots, None, '{0}/ScurveSigmaSummary.png'.format(outputDir), None, drawOpt="AP", gemType=gemType, write2Disk=True)
         
         #BoxPlot
         try:
@@ -858,7 +858,7 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
         h2DetThresh_All.SetFillColor(400)
         h2DetThresh_All.Draw("candle1")
         canvasBoxPlot_Thresh.Update()
-        canvasBoxPlot_Thresh.SaveAs("%s/h2ScurveMeanDist_All.png"%(outputDir))
+        canvasBoxPlot_Thresh.SaveAs("{0}/h2ScurveMeanDist_All.png".format(outputDir))
         canvasBoxPlot_Thresh.Close()
 
         canvasBoxPlot_EffPed = r.TCanvas("h2EffPed","h2EffPed",0,0,1200,1000)
@@ -869,7 +869,7 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
         h2DetEffPed_All.SetFillColor(400)
         h2DetEffPed_All.Draw("candle1")
         canvasBoxPlot_EffPed.Update()
-        canvasBoxPlot_EffPed.SaveAs("%s/h2ScurveEffPedDist_All.png"%(outputDir))
+        canvasBoxPlot_EffPed.SaveAs("{0}/h2ScurveEffPedDist_All.png".format(outputDir))
         canvasBoxPlot_EffPed.Close()
         
         canvasBoxPlot_ENC = r.TCanvas("h2ENC","h2ENC",0,0,1200,1000)
@@ -880,14 +880,14 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
         h2DetENC_All.Draw("candle1")
         # h2DetENC_All.Draw("colz")
         canvasBoxPlot_ENC.Update()
-        canvasBoxPlot_ENC.SaveAs("%s/h2ScurveSigmaDist_All.png"%(outputDir))
+        canvasBoxPlot_ENC.SaveAs("{0}/h2ScurveSigmaDist_All.png".format(outputDir))
         canvasBoxPlot_ENC.Close()
 
 
         
-        getSummaryCanvasByiEta(threshSummaryPlotsByiEta, name='%s/ScurveMeanSummaryByiEta.png'%outputDir, drawOpt="AP", gemType=gemType, write2Disk=True)
-        getSummaryCanvasByiEta(effPedSummaryPlotsByiEta, name='%s/ScurveEffPedSummaryByiEta.png'%outputDir, drawOpt="E1", gemType=gemType, write2Disk=True)
-        getSummaryCanvasByiEta(encSummaryPlotsByiEta, name='%s/ScurveSigmaSummaryByiEta.png'%outputDir, drawOpt="AP", gemType=gemType, write2Disk=True)
+        getSummaryCanvasByiEta(threshSummaryPlotsByiEta, name='{0}/ScurveMeanSummaryByiEta.png'.format(outputDir), drawOpt="AP", gemType=gemType, write2Disk=True)
+        getSummaryCanvasByiEta(effPedSummaryPlotsByiEta, name='{0}/ScurveEffPedSummaryByiEta.png'.format(outputDir), drawOpt="E1", gemType=gemType, write2Disk=True)
+        getSummaryCanvasByiEta(encSummaryPlotsByiEta, name='{0}/ScurveSigmaSummaryByiEta.png'.format(outputDir), drawOpt="AP", gemType=gemType, write2Disk=True)
 
         confF = open(outputDir+'/chConfig.txt','w')
         if isVFAT3:
@@ -898,7 +898,7 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
                     continue
 
                 for chan in range(0, 128):
-                    confF.write('%i\t%i\t%i\t%i\t%i\t%i\t%i\n'%(
+                    confF.write('{0}\t{1}\t{2}\t{3}\t{4}\t{5}\t{6}\n'.format(
                         vfat,
                         dict_vfatID[vfat],
                         chan,
@@ -914,7 +914,7 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
                     continue
 
                 for chan in range (0, 128):
-                    confF.write('%i\t%i\t%i\t%i\t%i\t%i\n'%(
+                    confF.write('{0}\t{1}\t{2}\t{3}\t{4}\t{5}\n'.format(
                         vfat,
                         dict_vfatID[vfat],
                         chan,
@@ -943,7 +943,7 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
             if ((vfatList is not None) and (vfat not in vfatList)):
                 continue
 
-            canvOfScurveFits[vfat] = r.TCanvas("canv_scurveFits_vfat%i"%vfat,"Scurve Fits from VFAT%i"%vfat,600,600)
+            canvOfScurveFits[vfat] = r.TCanvas("canv_scurveFits_vfat{0}".format(vfat),"Scurve Fits from VFAT{0}".format(vfat),600,600)
             canvOfScurveFits[vfat].cd()
             for chan in range (0,128):
                 if masks[vfat][chan]: # Do not draw fit for masked channels
@@ -964,7 +964,7 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
         if ((vfatList is not None) and (vfat not in vfatList)):
             continue
 
-        dirVFAT = outF.mkdir("VFAT%i"%vfat)
+        dirVFAT = outF.mkdir("VFAT{0}".format(vfat))
         dirVFAT.cd()
         vSummaryPlots[vfat].Write()
         if args.PanPin:
@@ -1001,7 +1001,7 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
         hDetMapENC.Write()
 
         for ieta in range(1,maxiEta+1):
-            dir_iEta = dirSummary.mkdir("ieta%i"%ieta)
+            dir_iEta = dirSummary.mkdir("ieta{0}".format(ieta))
             dir_iEta.cd()
             threshSummaryPlotsByiEta[ieta].Write()
             effPedSummaryPlotsByiEta[ieta].Write()
@@ -1046,8 +1046,8 @@ def fill2DScurveSummaryPlots(scurveTree, vfatHistos, vfatChanLUT, vfatHistosPanP
 
     # Check if lutType is expected
     if lutType not in mappingNames:
-        print "fill2DScurveSummaryPlots() - lutType '%s' not supported"
-        print "fill2DScurveSummaryPlots() - I was expecting one of the following: ", mappingNames
+        print("fill2DScurveSummaryPlots() - lutType '{0}' not supported".format{lutType})
+        print("fill2DScurveSummaryPlots() - I was expecting one of the following: ", mappingNames)
         raise LookupError
 
     # Set calDAC2Q slope to unity if not provided
@@ -1127,11 +1127,11 @@ def plotAllSCurvesOnCanvas(vfatHistos, vfatHistosPanPin2=None, obsName="scurves"
     canv_dict = {}
 
     for vfat,histo in vfatHistos.iteritems():
-        canv_dict[vfat] = r.TCanvas("canv_%s_vfat%i"%(obsName,vfat),"%s from VFAT%i"%(obsName,vfat),600,600)
+        canv_dict[vfat] = r.TCanvas("canv_{0}_vfat{1}".format(obsName,vfat),"{0} from VFAT{1}".format(obsName,vfat),600,600)
         canv_dict[vfat].Draw()
         canv_dict[vfat].cd()
         for binX in range(1,histo.GetNbinsX()+1):
-            h_scurve = histo.ProjectionY("h_%s_vfat%i_bin%i"%(obsName,vfat,binX),binX,binX,"")
+            h_scurve = histo.ProjectionY("h_{0}_vfat{1}_bin{2}".format(obsName,vfat,binX),binX,binX,"")
             h_scurve.SetLineColor(r.kBlue+2)
             h_scurve.SetLineWidth(2)
             h_scurve.SetFillStyle(0)
@@ -1146,7 +1146,7 @@ def plotAllSCurvesOnCanvas(vfatHistos, vfatHistosPanPin2=None, obsName="scurves"
         for vfat,histo in vfatHistosPanPin2.iteritems():
             canv_dict[vfat].cd()
             for binX in range(1,histo.GetNbinsX()+1):
-                h_scurve = histo.ProjectionY("h_%s_vfat%i_bin%i"%(obsName,vfat,binX),binX,binX,"")
+                h_scurve = histo.ProjectionY("h_{0}_vfat{1}_bin{2}".format(obsName,vfat,binX),binX,binX,"")
                 h_scurve.SetLineColor(r.kBlue+2)
                 h_scurve.SetLineWidth(2)
                 h_scurve.SetFillStyle(0)

--- a/utils/scurveAlgos.py
+++ b/utils/scurveAlgos.py
@@ -133,8 +133,7 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
     # Get ChipID's
     import numpy as np
     import root_numpy as rp
-    ##### NEED TO FIX
-    #### VERY TEMPORARY
+    ##### FIXME
     from gempython.gemplotting.mapping.chamberInfo import gemTypeMapping
     gemType = gemTypeMapping[rp.tree2array(scurveTree, branches =[ 'gemType' ] )[0][0]]
     print gemType
@@ -249,27 +248,23 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
         else:
             vSummaryPlots[vfat] = r.TH2D('vSummaryPlots{0}'.format(vfat),
                     'VFAT{0} chipID {1} Pins [0-63];63 - Panasonic Pin;{2} #left(fC#right)'.format(vfat,chipID,dacName),
-                    64,-0.5,63.5,256,
-                    yMin_Charge,
-                    yMax_Charge)
+                    maxChans/2, -0.5, maxChans/2-0.5,
+                    256, yMin_Charge, yMax_Charge)
             vSummaryPlots[vfat].GetYaxis().SetTitleOffset(1.5)
             vSummaryPlotsNoMaskedChan[vfat] = r.TH2D('vSummaryPlotsNoMaskedChan{0}'.format(vfat),
                     'VFAT{0} chipID {1} Pins [0-63];63 - Panasonic Pin;{2} #left(fC#right)'.format(vfat,chipID,dacName),
-                    64,-0.5,63.5,256,
-                    yMin_Charge,
-                    yMax_Charge)
+                    maxChans/2, -0.5, maxChans/2-0.5,
+                    256, yMin_Charge, yMax_Charge)
             vSummaryPlotsNoMaskedChan[vfat].GetYaxis().SetTitleOffset(1.5)
             vSummaryPlotsPanPin2[vfat] = r.TH2D('vSummaryPlotsPanPin2_{0}'.format(vfat),
                     'VFAT{0} chipID {1} Pins [64-127];127 - Panasonic Pin;{2} #left(fC#right)'.format(vfat,chipID,dacName),
-                    64,-0.5,63.5,256,
-                    yMin_Charge,
-                    yMax_Charge)
+                    maxChans/2, -0.5, maxChans/2-0.5,
+                    256, yMin_Charge, yMax_Charge)
             vSummaryPlotsPanPin2[vfat].GetYaxis().SetTitleOffset(1.5)
             vSummaryPlotsNoMaskedChanPanPin2[vfat] = r.TH2D('vSummaryPlotsNoMaskedChanPanPin2_{0}'.format(vfat),
                     'VFAT{0} chipID {1} Pins [64-127];127 - Panasonic Pin;{2} #left(fC#right)'.format(vfat,chipID,dacName),
-                    64,-0.5,63.5,256,
-                    yMin_Charge,
-                    yMax_Charge)
+                    maxChans/2, -0.5, maxChans/2-0.5,
+                    256, yMin_Charge, yMax_Charge)
             vSummaryPlotsNoMaskedChanPanPin2[vfat].GetYaxis().SetTitleOffset(1.5)
             pass
         for chan in range (0,maxChans):
@@ -879,7 +874,6 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
         h2DetENC_All.GetYaxis().SetTitle("Noise #left(fC#right)")
         h2DetENC_All.SetFillColor(400)
         h2DetENC_All.Draw("candle1")
-        # h2DetENC_All.Draw("colz")
         canvasBoxPlot_ENC.Update()
         canvasBoxPlot_ENC.SaveAs("{0}/h2ScurveSigmaDist_All.png".format(outputDir))
         canvasBoxPlot_ENC.Close()
@@ -1101,6 +1095,7 @@ def fill2DScurveSummaryPlots(scurveTree, vfatHistos, vfatChanLUT, vfatHistosPanP
         # Fill Summary Histogram 
         if lutType is mappingNames[1] and vfatHistosPanPin2 is not None:
             if (stripPinOrChan < 64):
+                #### Off by one error...?
                 vfatHistos[event.vfatN].SetBinContent(63-(stripPinOrChan+1),chargeBin,event.Nhits)
                 vfatHistos[event.vfatN].SetBinError(63-(stripPinOrChan+1),chargeBin,sqrt(event.Nhits))
                 pass

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -85,18 +85,6 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     import pkg_resources
     MAPPING_PATH = pkg_resources.resource_filename('gempython.gemplotting', 'mapping/')
 
-    from gempython.utils.nesteddict import nesteddict as ndict
-    dict_vfatChanLUT = ndict()
-    from gempython.gemplotting.utils.anautilities import getMapping
-    if args.extChanMapping is not None:
-        dict_vfatChanLUT = getMapping(extChanMapping)
-    elif GEBtype == 'long':
-        dict_vfatChanLUT = getMapping(MAPPING_PATH+'/longChannelMap.txt')
-    elif GEBtype == 'short':
-        dict_vfatChanLUT = getMapping(MAPPING_PATH+'/shortChannelMap.txt')
-    else:
-        raise RuntimeError("No external mapping provided and GEB type was not recognized")
-
     print 'Initializing Histograms'
     if args.isVFAT2:
         dacName = "VThreshold1"
@@ -133,7 +121,20 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     import root_numpy as rp
     from gempython.gemplotting.mapping.chamberInfo import gemTypeMapping
     gemType = gemTypeMapping[rp.tree2array(thrTree, branches =[ 'gemType' ] )[0][0]]
-    
+
+    from gempython.utils.nesteddict import nesteddict as ndict
+    dict_vfatChanLUT = ndict()
+    from gempython.gemplotting.utils.anautilities import getMapping
+    if args.extChanMapping is not None:
+        dict_vfatChanLUT = getMapping(extChanMapping, gemType=gemType)
+    elif GEBtype == 'long':
+        dict_vfatChanLUT = getMapping(MAPPING_PATH+'/longChannelMap.txt', gemType=gemType)
+    elif GEBtype == 'short':
+        dict_vfatChanLUT = getMapping(MAPPING_PATH+'/shortChannelMap.txt', gemType=gemType)
+    else:
+        raise RuntimeError("No external mapping provided and GEB type was not recognized")
+
+
     from gempython.tools.hw_constants import vfatsPerGemVariant
     listOfBranches = thrTree.GetListOfBranches()
     if 'vfatID' in listOfBranches:
@@ -273,7 +274,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
         getSummaryCanvas(dictSummary=dict_h2D_thrDACProj, name='%s/VFATSummary.png'%outputDir, drawOpt="", gemType=gemType, write2Disk=True)
 
         #Save thrDACMax Distributions Before/After Outlier Rejection
-        canv_vt1Max = getSummaryCanvas(name="canv_vt1Max", initialContent=dict_hMaxThrDAC, initialDrawOpt="hist",gemType=gemType)
+        canv_vt1Max = getSummaryCanvas(dict_hMaxThrDAC, name="canv_vt1Max", drawOpt="hist", gemType=gemType)
         canv_vt1Max = addPlotToCanvas(canv=canv_vt1Max, content=dict_hMaxThrDAC_NoOutlier, drawOpt="hist", gemType=gemType)
         canv_vt1Max.SaveAs(outputDir+'/thrDACMaxSummary.png')
         
@@ -355,8 +356,8 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     #Save output plots new hot channels subtracted off
     if not args.doNotSavePlots:
 
-        getSummaryCanvas(dictSummary=dict_h2D_thrDAC, name='%s/ThreshPrunedSummary.png'%outputDir, drawOpt="colz", write2Disk=True)
-        getSummaryCanvas(dictSummary=dict_h2D_thrDACProjPruned, name='%s/VFATPrunedSummary.png'%outputDir, drawOpt="", write2Disk=True)
+        getSummaryCanvas(dictSummary=dict_h2D_thrDAC, name='%s/ThreshPrunedSummary.png'%outputDir, drawOpt="colz", gemType=gemType, write2Disk=True)
+        getSummaryCanvas(dictSummary=dict_h2D_thrDACProjPruned, name='%s/VFATPrunedSummary.png'%outputDir, drawOpt="", gemType=gemType, write2Disk=True)
 
     #Now determine what thrDAC to use for configuration.  The first threshold bin with no entries for now.
     #Make a text file readable by TTree::ReadFile

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -142,7 +142,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     ##### END
     from gempython.tools.hw_constants import vfatsPerGemVariant
     nVFATS = vfatsPerGemVariant[gemType]
-    from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFATS as maxChans
+    from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFAT as maxChans
 
     
     from gempython.utils.nesteddict import nesteddict as ndict
@@ -182,7 +182,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
         dict_h2D_thrDAC[vfat] = r.TH2D(
                 'h_thrDAC_vs_ROBstr_VFAT{0}'.format(vfat),
                 'VFAT{0} chipID {1};{2};{3} [DAC units]'.format(vfat,chipID,stripChanOrPinName[1],dacName),
-                maxChans, -0.5, maxChan-0.5, THR_DAC_MAX+1,-0.5,THR_DAC_MAX+0.5)
+                maxChans, -0.5, maxChans-0.5, THR_DAC_MAX+1,-0.5,THR_DAC_MAX+0.5)
         dict_hMaxThrDAC[vfat] = r.TH1F(
                 'vfat{0}ChanMaxthrDAC'.format(vfat),
                 "VFAT{0} chipID {1}".format(vfat,chipID),
@@ -587,7 +587,7 @@ def calibrateThrDAC(args):
     # ##### END
     from gempython.tools.hw_constants import vfatsPerGemVariant
     nVFATS = vfatsPerGemVariant[gemType]
-    from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFATS as maxChans
+    from gempython.gemplotting.mapping.chamberInfo import CHANNELS_PER_VFAT as maxChans
 
     # Do we load an optional vfat serial number table? (e.g. chips did not have serial number in efuse burned in)
     import numpy as np
@@ -1282,7 +1282,7 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
 
     ##### FIXME
     from gempython.gemplotting.mapping.chamberInfo import gemTypeMapping
-    if 'gemType' not in inFile.latTree.GetListOfBranches():
+    if 'gemType' not in rateTree.GetListOfBranches():
         gemType = "ge11"
     else:
         gemType = gemTypeMapping[rp.tree2array(tree=inFile.latTree, branches =[ 'gemType' ] )[0][0]]

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -70,8 +70,6 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
         args.zscore = 3.5
         pass
 
-    gemType = "ge11"
-    
     # Determine output filepath
     if outputDir is None:
         from gempython.gemplotting.utils.anautilities import getElogPath
@@ -133,6 +131,9 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     # Get chip ID's
     import numpy as np
     import root_numpy as rp
+    from gempython.gemplotting.mapping.chamberInfo import gemTypeMapping
+    gemType = gemTypeMapping[rp.tree2array(thrTree, branches =[ 'gemType' ] )[0][0]]
+    
     from gempython.tools.hw_constants import vfatsPerGemVariant
     listOfBranches = thrTree.GetListOfBranches()
     if 'vfatID' in listOfBranches:
@@ -1254,6 +1255,9 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
     if "detName" in crateMap.dtype.names:
         for entry in crateMap:
             detNamesMap[(entry['shelf'],entry['slot'],entry['link'])] = entry['detName'][0]
+
+    from gempython.gemplotting.mapping.chamberInfo import gemTypeMapping
+    gemType = gemTypeMapping[rp.tree2array(rateTree, branches =[ 'gemType' ] )[0][0]]
     
     # get nonzero VFATs
     dict_nonzeroVFATs = {}

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -70,6 +70,8 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
         args.zscore = 3.5
         pass
 
+    gemType = "ge11"
+    
     # Determine output filepath
     if outputDir is None:
         from gempython.gemplotting.utils.anautilities import getElogPath
@@ -131,6 +133,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     # Get chip ID's
     import numpy as np
     import root_numpy as rp
+    from gempython.tools.hw_constants import vfatsPerGemVariant
     listOfBranches = thrTree.GetListOfBranches()
     if 'vfatID' in listOfBranches:
         array_chipID = np.unique(rp.tree2array(thrTree, branches = [ 'vfatID','vfatN' ] ))
@@ -138,7 +141,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
         for entry in array_chipID:
             dict_chipID[entry['vfatN']]=entry['vfatID']
     else:
-        dict_chipID = { vfat:0 for vfat in range(24) }
+        dict_chipID = { vfat:0 for vfat in range(vfatsPerGemVariant[gemType]) }
 
     r.TH1.SetDefaultSumw2(False)
     r.gROOT.SetBatch(True)
@@ -147,7 +150,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     dict_hMaxThrDAC = {}
     dict_hMaxThrDAC_NoOutlier = {}
     dict_chanMaxThrDAC = {}
-    for vfat in range(0,24):
+    for vfat in range(0,vfatsPerGemVariant[gemType]):
         if vfat not in dict_chipID:
             dict_h2D_thrDAC[vfat] = r.TH2D()
             continue
@@ -170,7 +173,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
 
     print 'Filling Histograms'
     if args.isVFAT2:
-        dict_trimRange = dict((vfat,0) for vfat in range(0,24))
+        dict_trimRange = dict((vfat,0) for vfat in range(0,vfatsPerGemVariant[gemType]))
     for event in thrTree:
         if args.isVFAT2:
             dict_trimRange[int(event.vfatN)] = int(event.dict_trimRange)
@@ -212,7 +215,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     import numpy as np
     import root_numpy as rp #note need root_numpy-4.7.2 (may need to run 'pip install root_numpy --upgrade')
     hot_channels = {}
-    for vfat in range(0,24):
+    for vfat in range(0,vfatsPerGemVariant[gemType]):
         if vfat not in dict_chipID:
             continue
         
@@ -258,25 +261,21 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
         pass
 
     #Save Output
-    from gempython.gemplotting.utils.anautilities import make3x8Canvas, saveSummary
+    from gempython.gemplotting.utils.anautilities import getSummaryCanvas, addPlotToCanvas
     if not args.doNotSavePlots:
-        saveSummary(dictSummary=dict_h2D_thrDAC, name='%s/ThreshSummary.png'%outputDir, drawOpt="colz")
+        getSummaryCanvas(dictSummary=dict_h2D_thrDAC, name='%s/ThreshSummary.png'%outputDir, drawOpt="colz", gemType=gemType, write2Disk=True)
 
         dict_h2D_thrDACProj = {}
-        for vfat in range(0,24):
+        for vfat in range(0, vfatsPerGemVariant[gemType]):
             dict_h2D_thrDACProj[vfat] = dict_h2D_thrDAC[vfat].ProjectionY()
             pass
-        saveSummary(dictSummary=dict_h2D_thrDACProj, name='%s/VFATSummary.png'%outputDir, drawOpt="")
+        getSummaryCanvas(dictSummary=dict_h2D_thrDACProj, name='%s/VFATSummary.png'%outputDir, drawOpt="", gemType=gemType, write2Disk=True)
 
         #Save thrDACMax Distributions Before/After Outlier Rejection
-        canv_vt1Max = make3x8Canvas(
-                name="canv_vt1Max",
-                initialContent=dict_hMaxThrDAC,
-                initialDrawOpt="hist",
-                secondaryContent=dict_hMaxThrDAC_NoOutlier,
-                secondaryDrawOpt="hist")
+        canv_vt1Max = getSummaryCanvas(name="canv_vt1Max", initialContent=dict_hMaxThrDAC, initialDrawOpt="hist",gemType=gemType)
+        canv_vt1Max = addPlotToCanvas(canv=canv_vt1Max, content=dict_hMaxThrDAC_NoOutlier, drawOpt="hist", gemType=gemType)
         canv_vt1Max.SaveAs(outputDir+'/thrDACMaxSummary.png')
-
+        
     # Fetch trimDAC & chMask from scurveFitTree
     import numpy as np
     import root_numpy as rp
@@ -314,7 +313,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     hot_channels = rp.tree2array(thrAnaTree, branches=list_bNames)
     if not args.pervfat:
         print("Subtracting off hot channels")
-        for vfat in range(0,24):
+        for vfat in range(0,vfatsPerGemVariant[gemType]):
             if vfat not in dict_chipID:
                 continue
             vfatChanArray = hot_channels[ hot_channels['vfatN'] == vfat ]
@@ -338,7 +337,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     outFile.cd()
     thrAnaTree.Write()
     dict_h2D_thrDACProjPruned = {}
-    for vfat in range(0,24):
+    for vfat in range(0,vfatsPerGemVariant[gemType]):
         #if we don't have any data for this VFAT, we just need to initialize the TH1D since it is drawn later
         if vfat not in dict_chipID:
             dict_h2D_thrDACProjPruned[vfat] = r.TH1D()
@@ -354,14 +353,15 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
 
     #Save output plots new hot channels subtracted off
     if not args.doNotSavePlots:
-        saveSummary(dictSummary=dict_h2D_thrDAC, name='%s/ThreshPrunedSummary.png'%outputDir, drawOpt="colz")
-        saveSummary(dictSummary=dict_h2D_thrDACProjPruned, name='%s/VFATPrunedSummary.png'%outputDir, drawOpt="")
+
+        getSummaryCanvas(dictSummary=dict_h2D_thrDAC, name='%s/ThreshPrunedSummary.png'%outputDir, drawOpt="colz", write2Disk=True)
+        getSummaryCanvas(dictSummary=dict_h2D_thrDACProjPruned, name='%s/VFATPrunedSummary.png'%outputDir, drawOpt="", write2Disk=True)
 
     #Now determine what thrDAC to use for configuration.  The first threshold bin with no entries for now.
     #Make a text file readable by TTree::ReadFile
     print('Determining the thrDAC values for each VFAT')
-    vt1 = dict((vfat,0) for vfat in range(0,24))
-    for vfat in range(0,24):
+    vt1 = dict((vfat,0) for vfat in range(0,vfatsPerGemVariant[gemType]))
+    for vfat in range(0,vfatsPerGemVariant[gemType]):
         if vfat not in dict_chipID:
             continue        
         proj = dict_h2D_thrDAC[vfat].ProjectionY()
@@ -379,14 +379,14 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     txt_vfat = open(outputDir+"/vfatConfig.txt", 'w')
     if args.isVFAT2:
         txt_vfat.write("vfatN/I:vfatID/I:vt1/I:trimRange/I\n")
-        for vfat in range(0,24):
+        for vfat in range(0,vfatsPerGemVariant[gemType]):
             if vfat not in dict_chipID:
                 continue
             txt_vfat.write('%i\t%i\t%i\t%i\n'%(vfat,dict_chipID[vfat],vt1[vfat],trimRange[vfat]))
             pass
     else:
         txt_vfat.write("vfatN/I:vfatID/I:vt1/I\n")
-        for vfat in range(0,24):
+        for vfat in range(0,vfatsPerGemVariant[gemType]):
             if vfat not in dict_chipID:
                 continue
             txt_vfat.write('%i\t%i\t%i\n'%(vfat,dict_chipID[vfat],vt1[vfat]))
@@ -400,7 +400,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
             confF.write('vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:mask/I\n')
             if args.debug:
                 print 'vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:mask/I\n'
-            for vfat in range (0,24):
+            for vfat in range (0,vfatsPerGemVariant[gemType]):
                 if vfat not in dict_chipID:
                     continue                
                 vfatChanArray = hot_channels[ hot_channels['vfatN'] == vfat ]
@@ -423,7 +423,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
             confF.write('vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:trimPolarity/I:mask/I:maskReason/I\n')
             if args.debug:
                 print 'vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:mask/I\n'
-            for vfat in range (0,24):
+            for vfat in range (0,vfatsPerGemVariant[gemType]):
                 if vfat not in dict_chipID:
                     continue
                 vfatChanArray = hot_channels[ hot_channels['vfatN'] == vfat ]
@@ -553,15 +553,20 @@ def calibrateThrDAC(args):
     redirectStdOutAndErr("anaUltraThreshold",args.outputDir)
 
     # Get info from input file
-    from gempython.gemplotting.utils.anautilities import getCyclicColor, getDirByAnaType, filePathExists, make3x8Canvas, parseListOfScanDatesFile
+    from gempython.gemplotting.utils.anautilities import getCyclicColor, getDirByAnaType, filePathExists, parseListOfScanDatesFile
     parsedTuple = parseListOfScanDatesFile(args.inputFile)
     listChamberAndScanDate = parsedTuple[0]
     thrDacName = parsedTuple[1]
     chamberName = listChamberAndScanDate[0][0]
 
+    gemType="ge11"
+    # from gempython.gemplotting.mapping.chamberInfo import gemTypeMapping
+    # gemType = gemTypeMapping[rp.tree2array(scurveTree, branches =[ 'gemType' ] )[0][0]]
+    
     # Do we load an optional vfat serial number table? (e.g. chips did not have serial number in efuse burned in)
     import numpy as np
     import root_numpy as rp
+    from gempython.tools.hw_constants import vfatsPerGemVariant
     if args.listOfVFATs is not None:
         try:
             mapVFATPos2VFATSN = np.loadtxt(
@@ -575,7 +580,7 @@ def calibrateThrDAC(args):
             print(type(err))
             return os.EX_NOINPUT
     else:
-        mapVFATPos2VFATSN = np.zeros(24,dtype={'names':('vfatN', 'serialNum'),'formats':('u4', 'u4')})
+        mapVFATPos2VFATSN = np.zeros(vfatsPerGemVariant[gemType],dtype={'names':('vfatN', 'serialNum'),'formats':('u4', 'u4')})
 
     # Get list of THR DAC values
     listOfThrValues = []
@@ -667,7 +672,7 @@ def calibrateThrDAC(args):
         ###################
         # Get and fit individual distributions
         ###################
-        for vfat in range(-1,24):
+        for vfat in range(-1,vfatsPerGemVariant[gemType]):
             if vfat == -1:
                 suffix = "All"
                 loadPath = suffix
@@ -911,7 +916,8 @@ def calibrateThrDAC(args):
     if args.debug:
         print("| vfatN | coef4 | coef3 | coef2 | coef1 | coef0 | noise | noise_err |")
         print("| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :-------: |")
-    for vfat in range(-1,24):
+    from gempython.tools.hw_constants import vfatsPerGemVariant
+    for vfat in range(-1,vfatsPerGemVariant[gemType]):
         if vfat == -1:
             suffix = "All"
             directory = "Summary"
@@ -1094,7 +1100,7 @@ def calibrateThrDAC(args):
     print "| vfatN | armDacVal | Dead Chan | High Noise | High Eff Ped | Fit At Init Val |"
     print "| :---: | :-------: | :-------: | :--------: | :----------: | :-------------: |"        
 
-    for vfat in range(-1,24):
+    for vfat in range(-1,vfatsPerGemVariant[gemType]):
         for infoTuple in listChamberAndScanDate:
             if vfat not in dict_nBadChannels or infoTuple[2] not in dict_nBadChannels[vfat]:
                 continue
@@ -1110,7 +1116,7 @@ def calibrateThrDAC(args):
                 dict_nBadChannels[vfat][infoTuple[2]]["FitAtInitVal"])
 
     if args.savePlots:
-        for vfat in range(-1,24):
+        for vfat in range(-1,vfatsPerGemVariant[gemType]):
             dict_canvScurveMeanByThrDac[vfat].SaveAs("{0}/{1}.png".format(args.outputDir,dict_canvScurveMeanByThrDac[vfat].GetName()))
             dict_canvScurveSigmaByThrDac[vfat].SaveAs("{0}/{1}.png".format(args.outputDir,dict_canvScurveSigmaByThrDac[vfat].GetName()))
             dict_canvScurveMeanVsThrDac[vfat].SaveAs("{0}/{1}.png".format(args.outputDir,dict_canvScurveMeanVsThrDac[vfat].GetName()))
@@ -1119,12 +1125,14 @@ def calibrateThrDAC(args):
             dict_canvScurveSigmaVsThrDac_BoxPlot[vfat].SaveAs("{0}/{1}.png".format(args.outputDir,dict_canvScurveSigmaVsThrDac_BoxPlot[vfat].GetName()))
     
     # Make summary canvases, always save these
-    canvScurveMeanByThrDac_Summary = make3x8Canvas("canvScurveMeanByThrDac_Summary",dict_mGraphScurveMean,"APE1")
-    canvScurveSigmaByThrDac_Summary = make3x8Canvas("canvScurveSigmaByThrDac_Summary",dict_mGraphScurveSigma,"APE1")
-    canvScurveMeanVsThrDac_Summary = make3x8Canvas("canvScurveMeanVsThrDac_Summary",dict_ScurveMeanVsThrDac,"APE1",dict_funcScurveMeanVsThrDac)
-    canvScurveSigmaVsThrDac_Summary = make3x8Canvas("canvScurveSigmaVsThrDac_Summary",dict_ScurveSigmaVsThrDac,"APE1")
-    canvScurveMeanVsThrDac_BoxPlot_Summary = make3x8Canvas("canvScurveMeanVsThrDac_BoxPlot_Summary",dict_ScurveMeanVsThrDac_BoxPlot,"candle1")
-    canvScurveSigmaVsThrDac_BoxPlot_Summary = make3x8Canvas("canvScurveSigmaVsThrDac_BoxPlot_Summary",dict_ScurveSigmaVsThrDac_BoxPlot,"candle1")
+    canvScurveMeanByThrDac_Summary = getSummaryCanvas(dict_mGraphScurveMean, name="canvScurveMeanByThrDac_Summary", drawOpt="APE1", gemType=gemType)
+    canvScurveSigmaByThrDac_Summary = getSummaryCanvas(dict_mGraphScurveSigma, name="canvScurveSigmaByThrDac_Summary", drawOpt="APE1", gemType=gemType)
+    ### FIX THIS
+    canvScurveMeanVsThrDac_Summary = getSummaryCanvas(dict_ScurveMeanVsThrDac, name="canvScurveMeanVsThrDac_Summary", drawOpt="APE1", gemType=gemType)
+    canvScurveMeanVsThrDac_Summary = addPlotToCanvas(canv=canvScurveMeanVsThrDac_Summary, content=dict_funcScurveMeanVsThrDac, gemType=gemType)
+    canvScurveSigmaVsThrDac_Summary = getSummaryCanvas(dict_ScurveSigmaVsThrDac, name="canvScurveSigmaVsThrDac_Summary", drawOpt="APE1", gemType=gemType)
+    canvScurveMeanVsThrDac_BoxPlot_Summary = getSummaryCanvas(dict_ScurveMeanVsThrDac_BoxPlot, name="canvScurveMeanVsThrDac_BoxPlot_Summary", drawOpt="candle1", gemType=gemType)
+    canvScurveSigmaVsThrDac_BoxPlot_Summary = getSummaryCanvas(dict_ScurveSigmaVsThrDac_BoxPlot, name="canvScurveSigmaVsThrDac_BoxPlot_Summary", drawOpt="candle1", gemType=gemType)
 
     # Draw Legend?
     if not args.noLeg:
@@ -1288,12 +1296,13 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
     dict_Rate1DVsDACNameX = ndict() #[dacName][ohKey][vfat] = TGraphErrors
     dict_vfatCHVsDACNameX_Rate2D = ndict() #[dacName][ohKey][vfat] = TGraph2D
 
+    from gempython.tools.hw_constants import vfatsPerGemVariant
     # initialize a TGraphErrors and a TF1 for each vfat
     for idx in range(len(dacNameArray)):
         dacName = np.asscalar(dacNameArray[idx])
         for entry in crateMap:
             ohKey = (entry['shelf'],entry['slot'],entry['link'])
-            for vfat in range(0,25): #24th VFAT represents "overall case"
+            for vfat in range(0,vfatsPerGemVariant[gemType]+1): #24th VFAT represents "overall case"
                 # 1D Distributions
                 dict_Rate1DVsDACNameX[dacName][ohKey][vfat] = r.TGraphErrors()
                 dict_Rate1DVsDACNameX[dacName][ohKey][vfat].SetName("g1D_rate_vs_{0}_vfat{1}".format(dacName.replace("_","-"),vfat))
@@ -1383,13 +1392,16 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
     # make a named dictionary to store inflection pts
     dict_dacInflectPts = ndict()
 
+    from gempython.gemplotting.utils.anautilities import getSummaryCanvas
+
+    
     for entry in crateMap:
         ohKey = (entry['shelf'],entry['slot'],entry['link'])
         detName = getDetName(entry)
         # clear the inflection point table for each new link
         inflectTable = []
         # Per VFAT Poosition
-        for vfat in range(0,24):
+        for vfat in range(0, vfatsPerGemVariant[gemType]):
             thisVFATDir = outputFiles[ohKey].mkdir("VFAT{0}".format(vfat))
 
             for idx in range(len(dacNameArray)):
@@ -1444,14 +1456,14 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
         for idx in range(len(dacNameArray)):
             dacName = np.asscalar(dacNameArray[idx])
             if perchannel:
-                canv_Summary2D = make3x8Canvas("canv_Summary_Rate2D_vs_{0}".format(dacName),dict_vfatCHVsDACNameX_Rate2D[dacName][ohKey],"TRI1")
-                for vfat in range(1,25):
+                canv_Summary2D = getSummaryCanvas(dict_vfatCHVsDACNameX_Rate2D[dacName][ohKey], name="canv_Summary_Rate2D_vs_{0}".format(dacName), drawOpt="TRI1", gemType=gemType)
+                for vfat in range(1,vfatsPerGemVariant[gemType]+1):
                     canv_Summary2D.cd(vfat).SetLogz()
             else:
-                canv_Summary1D = make3x8Canvas("canv_Summary_Rate1D_vs_{0}".format(dacName),dict_Rate1DVsDACNameX[dacName][ohKey],"APE1" )
-                # make 24 TLines
+                canv_Summary1D = getSummaryCanvas(dict_Rate1DVsDACNameX[dacName][ohKey], name="canv_Summary_Rate1D_vs_{0}".format(dacName), drawOpt="APE1", gemType=gemType)
+                 # make 24 TLines
                 kneeLine= []
-                for vfat in range(0,24):
+                for vfat in range(0,vfatsPerGemVariant[gemType]):
                     canv_Summary1D.cd(vfat + 1).SetLogy()
 
                     # make sure the inflection point is there

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -85,7 +85,20 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     import pkg_resources
     MAPPING_PATH = pkg_resources.resource_filename('gempython.gemplotting', 'mapping/')
 
-    print 'Initializing Histograms'
+    from gempython.utils.nesteddict import nesteddict as ndict
+    dict_vfatChanLUT = ndict()
+    from gempython.gemplotting.utils.anautilities import getMapping
+    if args.extChanMapping is not None:
+        dict_vfatChanLUT = getMapping(extChanMapping)
+    elif GEBtype == 'long':
+        dict_vfatChanLUT = getMapping(MAPPING_PATH+'/longChannelMap.txt')
+    elif GEBtype == 'short':
+        dict_vfatChanLUT = getMapping(MAPPING_PATH+'/shortChannelMap.txt')
+    else:
+        raise RuntimeError("No external mapping provided and GEB type was not recognized")
+
+    
+    print('Initializing Histograms')
     if args.isVFAT2:
         dacName = "VThreshold1"
     else:
@@ -180,7 +193,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
         dict_hMaxThrDAC_NoOutlier[vfat].SetLineColor(r.kRed)
         pass
 
-    print 'Filling Histograms'
+    print('Filling Histograms')
     if args.isVFAT2:
         dict_trimRange = dict((vfat,0) for vfat in range(0,vfatsPerGemVariant[gemType]))
     for event in thrTree:
@@ -217,7 +230,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     thrAnaTree.Branch( 'vthr', vthr, 'vthr/I' )
 
     #Determine Hot Channels
-    print 'Determining hot channels'
+    print('Determining hot channels')
 
     from gempython.gemplotting.utils.anaInfo import MaskReason
     from gempython.gemplotting.utils.anautilities import isOutlierMADOneSided
@@ -272,13 +285,13 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     #Save Output
     from gempython.gemplotting.utils.anautilities import getSummaryCanvas, addPlotToCanvas
     if not args.doNotSavePlots:
-        getSummaryCanvas(dictSummary=dict_h2D_thrDAC, name='%s/ThreshSummary.png'%outputDir, drawOpt="colz", gemType=gemType, write2Disk=True)
+        getSummaryCanvas(dictSummary=dict_h2D_thrDAC, name='{0}/ThreshSummary.png'.format(outputDir), drawOpt="colz", gemType=gemType, write2Disk=True)
 
         dict_h2D_thrDACProj = {}
         for vfat in range(0, vfatsPerGemVariant[gemType]):
             dict_h2D_thrDACProj[vfat] = dict_h2D_thrDAC[vfat].ProjectionY()
             pass
-        getSummaryCanvas(dictSummary=dict_h2D_thrDACProj, name='%s/VFATSummary.png'%outputDir, drawOpt="", gemType=gemType, write2Disk=True)
+        getSummaryCanvas(dictSummary=dict_h2D_thrDACProj, name='{0}/VFATSummary.png'.format(outputDir), drawOpt="", gemType=gemType, write2Disk=True)
 
         #Save thrDACMax Distributions Before/After Outlier Rejection
         canv_vt1Max = getSummaryCanvas(dict_hMaxThrDAC, name="canv_vt1Max", drawOpt="hist", gemType=gemType)
@@ -334,7 +347,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
                     pass
 
                 if isHotChan:
-                    print('VFAT %i Strip %i is noisy'%(vfat,chan))
+                    print('VFAT {0} Strip {1} is noisy'.format(vfat,chan))
                     for thresh in range(THR_DAC_MAX+1):
                         dict_h2D_thrDAC[vfat].SetBinContent(chan, thresh, 0)
                         pass
@@ -356,15 +369,15 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
         dict_h2D_thrDAC[vfat].Write()
         dict_hMaxThrDAC[vfat].Write()
         dict_hMaxThrDAC_NoOutlier[vfat].Write()
-        dict_h2D_thrDACProjPruned[vfat] = dict_h2D_thrDAC[vfat].ProjectionY("h_thrDAC_VFAT%i"%vfat)
+        dict_h2D_thrDACProjPruned[vfat] = dict_h2D_thrDAC[vfat].ProjectionY("h_thrDAC_VFAT{0}".format(vfat))
         dict_h2D_thrDACProjPruned[vfat].Write()
         pass
 
     #Save output plots new hot channels subtracted off
     if not args.doNotSavePlots:
 
-        getSummaryCanvas(dictSummary=dict_h2D_thrDAC, name='%s/ThreshPrunedSummary.png'%outputDir, drawOpt="colz", gemType=gemType, write2Disk=True)
-        getSummaryCanvas(dictSummary=dict_h2D_thrDACProjPruned, name='%s/VFATPrunedSummary.png'%outputDir, drawOpt="", gemType=gemType, write2Disk=True)
+        getSummaryCanvas(dictSummary=dict_h2D_thrDAC, name='{0}/ThreshPrunedSummary.png'.format(outputDir), drawOpt="colz", gemType=gemType, write2Disk=True)
+        getSummaryCanvas(dictSummary=dict_h2D_thrDACProjPruned, name='{0}/VFATPrunedSummary.png'.format(outputDir), drawOpt="", gemType=gemType, write2Disk=True)
 
     #Now determine what thrDAC to use for configuration.  The first threshold bin with no entries for now.
     #Make a text file readable by TTree::ReadFile
@@ -378,7 +391,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
         for thresh in range(THR_DAC_MAX+1,0,-1):
             if (proj.GetBinContent(thresh+1)) > 10.0:
                 if args.debug:
-                    print('vt1 for VFAT %i found'%vfat)
+                    print('vt1 for VFAT {0} found'.format(vfat))
                 vt1[vfat]=(thresh+1)
                 break
             pass
@@ -391,14 +404,14 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
         for vfat in range(0,vfatsPerGemVariant[gemType]):
             if vfat not in dict_chipID:
                 continue
-            txt_vfat.write('%i\t%i\t%i\t%i\n'%(vfat,dict_chipID[vfat],vt1[vfat],trimRange[vfat]))
+            txt_vfat.write('{0}\t{1}\t{2}\t{3}\n'.format(vfat,dict_chipID[vfat],vt1[vfat],trimRange[vfat]))
             pass
     else:
         txt_vfat.write("vfatN/I:vfatID/I:vt1/I\n")
         for vfat in range(0,vfatsPerGemVariant[gemType]):
             if vfat not in dict_chipID:
                 continue
-            txt_vfat.write('%i\t%i\t%i\n'%(vfat,dict_chipID[vfat],vt1[vfat]))
+            txt_vfat.write('{0}i\t{1}\t{2}\n'.format(vfat,dict_chipID[vfat],vt1[vfat]))
             pass
     txt_vfat.close()
 
@@ -408,7 +421,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
         if args.isVFAT2:
             confF.write('vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:mask/I\n')
             if args.debug:
-                print 'vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:mask/I\n'
+                print('vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:mask/I\n')
             for vfat in range (0,vfatsPerGemVariant[gemType]):
                 if vfat not in dict_chipID:
                     continue                
@@ -431,7 +444,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
         else:
             confF.write('vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:trimPolarity/I:mask/I:maskReason/I\n')
             if args.debug:
-                print 'vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:mask/I\n'
+                print('vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:mask/I\n')
             for vfat in range (0,vfatsPerGemVariant[gemType]):
                 if vfat not in dict_chipID:
                     continue
@@ -439,7 +452,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
                 for chan in range(0,128):
                     isHotChan = vfatChanArray[ vfatChanArray['vfatCH'] == chan ]['mask']
                     if args.debug:
-                        print('%i\t%i\t%i\t%i\t%i\t%i\t%i\n'%(
+                        print('{0}\t{1}\t{2}\t{3}\t{4}\t{5}\t{6}\n'.format(
                             vfat,
                             dict_chipID[vfat],
                             chan,
@@ -447,7 +460,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
                             dict_vfatTrimMaskData[vfat][chan]['trimPolarity'],
                             int(isHotChan or dict_vfatTrimMaskData[vfat][chan]['mask']),
                             dict_vfatTrimMaskData[vfat][chan]['maskReason']))
-                    confF.write('%i\t%i\t%i\t%i\t%i\t%i\t%i\n'%(
+                    confF.write('{0}\t{1}\t{2}\t{3}\t{4}\t{5}\t{6}\n'.format(
                         vfat,
                         dict_chipID[vfat],
                         chan,
@@ -635,7 +648,7 @@ def calibrateThrDAC(args):
         dirPath = getDirByAnaType("scurve", infoTuple[0])
         if not filePathExists(dirPath, infoTuple[1]):
             raise IOError("calibrateThrDAC(): File {0}/{1} does not exist or is not readable".format(dirPath, infoTuple[1]))
-        filename = "%s/%s/%s"%(dirPath, infoTuple[1], tree_names["scurveAna"][0])
+        filename = "{0}/{1}/{2}".format(dirPath, infoTuple[1], tree_names["scurveAna"][0])
 
         # Load the file
         r.TH1.AddDirectory(False)
@@ -753,9 +766,9 @@ def calibrateThrDAC(args):
                 thisVFAT_ENCMean = 0 #dummy value
                 thisVFAT_ENCStd = 1 #dummy value
                 
-            histThresh = r.TH1F("scurveMean_vfat%i"%vfat,"VFAT %i;S-Curve Mean #left(fC#right);N"%vfat, 
+            histThresh = r.TH1F("scurveMean_vfat{0}".format(vfat),"VFAT {0};S-Curve Mean #left(fC#right);N".format(vfat), 
                                 40, thisVFAT_ThreshMean - 5. * thisVFAT_ThreshStd, thisVFAT_ThreshMean + 5. * thisVFAT_ThreshStd )
-            histENC = r.TH1F("scurveSigma_vfat%i"%vfat,"VFAT %i;S-Curve Sigma #left(fC#right);N"%vfat,
+            histENC = r.TH1F("scurveSigma_vfat{0}".format(vfat),"VFAT {0};S-Curve Sigma #left(fC#right);N".format(vfat),
                                  40, thisVFAT_ENCMean - 5. * thisVFAT_ENCStd, thisVFAT_ENCMean + 5. * thisVFAT_ENCStd )
 
             #discard armDacVal points with too few good channels
@@ -1107,8 +1120,8 @@ def calibrateThrDAC(args):
                 func_ScurveSigmaVsThrDac.GetParError(1))
                 )
 
-    print "| vfatN | armDacVal | Dead Chan | High Noise | High Eff Ped | Fit At Init Val |"
-    print "| :---: | :-------: | :-------: | :--------: | :----------: | :-------------: |"        
+    print("| vfatN | armDacVal | Dead Chan | High Noise | High Eff Ped | Fit At Init Val |")
+    print("| :---: | :-------: | :-------: | :--------: | :----------: | :-------------: |")
 
     for vfat in range(-1,vfatsPerGemVariant[gemType]):
         for infoTuple in listChamberAndScanDate:
@@ -1117,13 +1130,13 @@ def calibrateThrDAC(args):
             vfatnOrAll = str(vfat)
             if vfatnOrAll == "-1":
                 vfatnOrAll = "All"
-            print '| %s | %i | %i | %i | %i | %i |'%(
+            print('| {0} | {1} | {2} | {3} | {4} | {5} |'.format(
                 vfatnOrAll,
                 infoTuple[2],
                 dict_nBadChannels[vfat][infoTuple[2]]["DeadChannel"],
                 dict_nBadChannels[vfat][infoTuple[2]]["HighNoise"],
                 dict_nBadChannels[vfat][infoTuple[2]]["HighEffPed"],
-                dict_nBadChannels[vfat][infoTuple[2]]["FitAtInitVal"])
+                dict_nBadChannels[vfat][infoTuple[2]]["FitAtInitVal"]))
 
     if args.savePlots:
         for vfat in range(-1,vfatsPerGemVariant[gemType]):
@@ -1337,7 +1350,6 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
                 dict_Rate1DVsDACNameX[dacName][ohKey][vfat].SetMarkerStyle(23)
                 dict_Rate1DVsDACNameX[dacName][ohKey][vfat].SetMarkerSize(0.8)
                 dict_Rate1DVsDACNameX[dacName][ohKey][vfat].SetLineWidth(2)
-                print dacName, ohKey, vfat
                 # 2D Distributions
                 dict_vfatCHVsDACNameX_Rate2D[dacName][ohKey][vfat] = r.TGraph2D()
                 dict_vfatCHVsDACNameX_Rate2D[dacName][ohKey][vfat].SetName("g2D_vfatCH_vs_{0}_rate_vfat{1}".format(dacName.replace("_","-"),vfat))
@@ -1347,7 +1359,6 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
                 pass
             pass
         pass
-    print "here"
     # create output TFiles
     outputFiles = {}
     for entry in crateMap:
@@ -1365,7 +1376,6 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
             outputFiles[ohKey] = r.TFile(strDirName+scandate+"/"+outfilename,'recreate')
             pass
         pass
-    print outputFiles
     # Loop over events the tree and fill plots
     print("Looping over stored events in rateTree")
     from math import sqrt
@@ -1556,7 +1566,7 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
             
         vfatConfg.write("vfatN/I:vt1/I:trimRange/I\n")
         for vfat,armDACVal in innerDictByVFATKey.iteritems():
-            vfatConfg.write('%i\t%i\t%i\n'%(vfat, armDACVal,0))
+            vfatConfg.write('{0}\t{1}\t{2}\n'.format(vfat, armDACVal,0))
         vfatConfg.close()    
         
     return 

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -132,8 +132,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
     import numpy as np
     import root_numpy as rp
     
-    ##### NEED TO FIX
-    #### VERY TEMPORARY
+    ##### FIXME
     from gempython.gemplotting.mapping.chamberInfo import gemTypeMapping
     if 'gemType' not in thrTree.GetListOfBranches():
         gemType = "ge11"
@@ -583,8 +582,7 @@ def calibrateThrDAC(args):
     thrDacName = parsedTuple[1]
     chamberName = listChamberAndScanDate[0][0]
 
-    # ##### NEED TO FIX
-    # #### VERY TEMPORARY
+    ##### FIXME
     gemType = chamberName[:chamberName.find("-")].lower()
     # ##### END
     from gempython.tools.hw_constants import vfatsPerGemVariant
@@ -1282,14 +1280,12 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
         for entry in crateMap:
             detNamesMap[(entry['shelf'],entry['slot'],entry['link'])] = entry['detName'][0]
 
-    ##### NEED TO FIX
-    #### VERY TEMPORARY
+    ##### FIXME
     from gempython.gemplotting.mapping.chamberInfo import gemTypeMapping
     if 'gemType' not in inFile.latTree.GetListOfBranches():
         gemType = "ge11"
     else:
         gemType = gemTypeMapping[rp.tree2array(tree=inFile.latTree, branches =[ 'gemType' ] )[0][0]]
-    print gemType
     ##### END
     from gempython.tools.hw_constants import vfatsPerGemVariant
     nVFATS = vfatsPerGemVariant[gemType]
@@ -1307,16 +1303,6 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
         printYellow("crateMap:\n{0}".format(crateMap))
         printYellow("dacNameArray:\n{0}".format(dacNameArray))
 
-    ##### NEED TO FIX
-    #### VERY TEMPORARY
-    from gempython.gemplotting.mapping.chamberInfo import gemTypeMapping
-    if 'gemType' not in rateTree.GetListOfBranches():
-        gemType = "ge11"
-    else:
-        gemType = gemTypeMapping[rp.tree2array(tree=rateTree, branches =[ 'gemType' ] )[0][0]]
-    print gemType
-    ##### END
-        
     # make output directories
     from gempython.utils.wrappers import runCommand
     from gempython.gemplotting.utils.anautilities import getDirByAnaType
@@ -1507,7 +1493,7 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
                     canv_Summary2D.cd(vfat).SetLogz()
             else:
                 canv_Summary1D = getSummaryCanvas(dict_Rate1DVsDACNameX[dacName][ohKey], name="canv_Summary_Rate1D_vs_{0}".format(dacName), drawOpt="APE1", gemType=gemType)
-                 # make 24 TLines
+                 # make nVFATs TLines
                 kneeLine= []
                 for vfat in range(0,nVFATS):
                     canv_Summary1D.cd(vfat + 1).SetLogy()


### PR DESCRIPTION
PR for changing the gem plotting code to be compatible with GE21 plotting

## Description
The gem-plotting code is hardcoded with many magic numbers that are specific to the GE11, so with changes in the tree structure to add gemtype and detectortype, the plotting code can be expanded to allow for GE21 plotting that is determined on the fly by this gemType variable.

The bulk of the code is removing instances of 24, 8, 3, and combinations of these to more generic variables, ie nVFATS, maxiEta, maxiPhi. These variables are derived from `chamber_maxiEtaiPhiPair` in  `./mapping/chamberInfo.py` and from `vfatsPerGemVariant`  in `gempython.tools.hw_constants` All of the mapping/chamberInfo.py variables have been turned into dictionaries that require the gemType to get the correct variables, ie

 ```chamber_vfatPos2iEta   =>    chamber_vfatPos2iEta["ge11"]```
etc.

Since a large code change is the actual canvas creation code, the largest change is to canvas making. The `makeAxBCanvas` has been removed in place of merging this functionality into the `saveSummaryCanvas` to make a new function called `getSummaryCanvas`.  This means the function now always returns a canvas created and there is a flag to decide to save the canvas or not. ie function def is now

```def getSummaryCanvas(dictSummary, dictSummaryPanPin2=None, name='Summary', trimPt=None, drawOpt="colz", gemType="ge11", write2Disk=False)
canv = make3x8Canvas(...)    =>    canv = getSummaryCanvas(..., gemType="ge11")
saveSummaryCanvas(...)    =>    getSummaryCanvas(..., gemType="ge11", write2Disk=True)
```

Also, because the `makeAxBCanvas` function also added histograms to an existing canvas, this functionality has be put to a helper function `addPlotToCanvas` which hopefully will make the code more readable as well. So the change becomes

```
canv = make3x8Canvas(initialContent=hist1, ...)
canv = make3x8Canvas(initialContent=hist2, canv=canv, ...)

=>

canv = getSummaryCanvas(hist1, ..., gemType="ge11")
canv = addPlotToCanvas(canv, hist2, gemType="ge11")
```

Last, many functions include now a gemType variable that needs to be supplied to give the right gemType. The default is "ge11", so the code remains backwards compatible for all cases where the gemType isn't actually supplied.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue(s) here. -->
This change has mainly be motivated to be backwards compatible and to default to ge11 in all unknown cases. Since ge21 is needing plots specifically made for it (and not ones derived from ge11 algorithms), having code that can flexibly handle ge21 and in the future, me0 is a must.

For further information on this, look at issue #226 

## How Has This Been Tested?
For testing, the code was run over ge11 and ge21 files with the internal gemType flag flipped (ge21 files didn't have that tree in it). 

NOTE: currently, only the main run files (ie files in the top directory) are changed. Files in the `./macros` area have not been touched. Here is a list of what has been done.

- `anaDACScan.py`, `anaUltraScurve.py`, `anaSBitThresh.py`, `anaUltraLatency.py` - work for both
- `anaUltraThreshold.py`, `anaSBitMonitor.py` - work for ge11, could not fine ge21 file
- `anaSBitReadout.py`, `anaXDAQLatency.py` - could not find input file for either
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
