### PR TITLE
[Bug Fix] OH key was used but not set in loop

### DIFF
--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -1317,6 +1317,7 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
     # create output TFiles
     outputFiles = {}
     for entry in crateMap:
+        ohKey = (entry['shelf'],entry['slot'],entry['link'])        
         detName = getDetName(entry)
         if scandate == 'noscandate':
             outputFiles[ohKey] = r.TFile(elogPath+"/"+detName+"/"+outfilename,'recreate')


### PR DESCRIPTION
A dictionary of output files in the sbitThresh analysis routine was being incorrectly filled with only one OH key, causing a crash.

## Description
A loop over the OHs was being performed, but the OH key was not being set inside the loop, so it was always the last OH key from the previous loop.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
Resolves https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/253

## How Has This Been Tested?
Yes, I tested it with the example reported here:

https://mattermost.web.cern.ch/cms-gem-daq/pl/mtab9kigg7yytkixet8k91b8ko

### Screenshots (if appropriate):

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
