### PR TITLE
[Bug Fix] In DAC scan analysis, ADC error was not being set correctly

### DIFF
--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -277,6 +277,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
                 calibrated_ADC_value -= nominal_iref 
 
             calibrated_ADC_value /= nominalDacScalingFactors[dacName]
+            calibrated_ADC_error /= nominalDacScalingFactors[dacName]
                 
         #the reversal of x and y is intended - we want to plot the dacName variable on the y-axis and the adcName variable on the x-axis
         #the dacName variable is the DAC register that is scanned, and we want to determine its nominal value


### PR DESCRIPTION
We are applying a scaling factor to the calibrated ADC value, and we should also apply this to its error.

## Description

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This pull request should resolve the issues with BLCC DAC scans reported in https://indico.cern.ch/event/855869/contributions/3601787/attachments/1929074/3194549/dac_variations_qc8_vs_p5_18-10.2019.pdf

## How Has This Been Tested?
Yes, I have tested this on coffin data:

With the HEAD of develop:

![SummaryGE11-X-S-INDIA-0002_DACScan_CFG_BIAS_PRE_I_BLCC](https://user-images.githubusercontent.com/3329216/67100363-cf458c80-f1bf-11e9-8f81-ca46bbf2e23a.png)

With this pull request:

![SummaryGE11-X-S-INDIA-0002_DACScan_CFG_BIAS_PRE_I_BLCC](https://user-images.githubusercontent.com/3329216/67100130-6d852280-f1bf-11e9-9989-e1b6b8103593.png)

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
