### PR TITLE
Allow the user to set the maxChi2 in the scurve fitting algorithm

### DIFF
--- a/anaUltraScurve.py
+++ b/anaUltraScurve.py
@@ -9,6 +9,7 @@ if __name__ == '__main__':
     # Define the parser
     import argparse
     from gempython.gemplotting.utils.anaoptions import parent_parser, parser_scurveChanMasks
+    from gempython.gemplotting.utils.anaInfo import maxChi2Default
     parser = argparse.ArgumentParser(description="Options to give to anaUltraScurve.py", parents=[parent_parser,parser_scurveChanMasks])
     
     # Positional arguments
@@ -20,6 +21,7 @@ if __name__ == '__main__':
     parser.add_argument("-e", "--extChanMapping", type=str, default=None,
                       help="Physical filename of a custom, non-default, channel mapping (optional)")
     parser.add_argument("--doNotFit", action="store_true", help="Do not attempt to fit scurves; only the summary plot showing the 2D scurve data will be generated")
+    parser.add_argument("--maxChi2", type=float,dest="maxChi2",default=maxChi2Default,help="Max acceptable chi2 in scurve fits")
     parser.add_argument("--isVFAT2", action="store_true", help="Provide this argument if input data was acquired from vfat2")
     parser.add_argument("-v", "--vfatList", type=str, default=None, help="Comma separated list of VFAT positions to consider for analysis.  If not provided default will be all positions")
     parser.add_argument("-z", "--zscore", type=float, default=3.5, help="Z-Score for Outlier Identification in MAD Algo")

--- a/ana_scans.py
+++ b/ana_scans.py
@@ -876,8 +876,10 @@ if __name__ == '__main__':
 
     # Create subparser for scurve
     # -------------------------------------------------
+    from gempython.gemplotting.utils.anaInfo import maxChi2Default
     parser_scurve = subparserCmds.add_parser("scurve", help="Analyzes scurve data taken with either ultraScurve.py or 'run_scans.py scurve'", parents = listOfParentParsers4Scurves)
     parser_scurve.add_argument("--doNotFit", action="store_true", help="Do not attempt to fit the scurves")
+    parser_scurve.add_argument("--maxChi2", type=float,dest="maxChi2",default=maxChi2Default,help="Max acceptable chi2 in scurve fits")
 
     parser_scurve.set_defaults(func=scurveParallelAna)
 

--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -130,6 +130,8 @@ class ScanDataFitter(DeadChannelFinder):
         isVFAT3 (bool): Whether the detector under consideration uses VFAT3
     """
 
+    from gempython.gemplotting.utils.anaInfo import maxChi2Default
+    
     def __init__(self, calDAC2Q_m=None, calDAC2Q_b=None, isVFAT3=False, nVFats=24):
         super(ScanDataFitter, self).__init__(nVFats)
 
@@ -146,6 +148,8 @@ class ScanDataFitter(DeadChannelFinder):
 
         self.isVFAT3    = isVFAT3
         self.nVFats     = nVFats
+
+        self.maxChi2 = maxChi2
         
         self.calDAC2Q_m = np.ones(self.nVFats)
         if calDAC2Q_m is not None:
@@ -373,7 +377,7 @@ class ScanDataFitter(DeadChannelFinder):
                         self.fitValid[vfat][ch] = True
                         MinChi2Temp = fitChi2
                         pass
-                    if (MinChi2Temp < 50): break
+                    if (MinChi2Temp < self.maxChi2): break
                     pass
                 if debug:
                     print("Converged fit results:")

--- a/utils/anaInfo.py
+++ b/utils/anaInfo.py
@@ -21,6 +21,9 @@ scurveMeanMin = 0.1 #: points are removed if they satisfy scurveMean < scurveMea
 scurveMeanFracErrMin = 0.001 #: points are removed if they satisfy scurveMeanError/scurveMean < scurveFracErrMin
 numOfGoodChansMinDefault = 10 #: default value of: minimum number of good channels scurveMean points are required to have
 
+#: The default value for the maximum chi2 an acceptable scurve fit
+maxChi2Default=10
+
 #: The default values for the cuts that determine the scurve fit quality masks
 maxEffPedPercentDefault=0.02
 highNoiseCutDefault=1.5

--- a/utils/scurveAlgos.py
+++ b/utils/scurveAlgos.py
@@ -35,6 +35,7 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
     deadChanCutHigh - Higher bound of charge range (in fC) that will be used to determine if a channel is dead based on its ENC
     debug - If true additional debugging information will be printed
     doNotFit - If true the scurves will not be fit; this will reduce the analysis tiem and output information
+    maxChi2 - Max acceptable chi2 in scurve fits
     drawbad - If true scurve fits with chi2 values less than 1 or greater than 1000 will be drawn on a separate TCanvas
     extChanMapping - Name of externally supplied file that specifies the ROBstr:PanPin:vfatCH mapping
     isVFAT2 - If true the data is understood as coming from VFAT2
@@ -52,7 +53,10 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
     outputDir - Directory where output plots are stored.  If None this will be default to $ELOG_PATH 
     vfatList - List of VFAT positions to consider in the analysis, if None analyzes all (default). Useful for debugging
     """
-        # Check attributes of input args
+
+    from gempython.gemplotting.utils.anaInfo import maxChi2Default
+
+    # Check attributes of input args
     # If not present assign appropriate default arguments
     if hasattr(args,'calFile') is False:
         args.calFile = None
@@ -66,6 +70,8 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
         args.debug = False
     if hasattr(args,'doNotFit') is False:
         args.doNotFit = False
+    if hasattr(args,'maxChi2') is False:
+        args.maxChi2 = maxChi2Default   
     if hasattr(args,'drawbad') is False:
         args.drawbad = False
     if hasattr(args,'extChanMapping') is False:
@@ -304,7 +310,8 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
                 calDAC2Q_m=calDAC2Q_Slope, 
                 calDAC2Q_b=calDAC2Q_Intercept,
                 isVFAT3=isVFAT3,
-                nVFats = nVFATS
+                nVFats = nVFATS,
+                maxChi2=args.maxChi2
                 )
         pass
 


### PR DESCRIPTION
Currently the maxChi2 in the scurve fitting algorithm is hardcoded to 50.

## Description
Adds an argument `maxChi2` which has a default of `10`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This may resolve issue https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/257. However, I cannot reproduce the issue, so I am not sure.

## How Has This Been Tested?
Yes, I ran this successfully on the scurve data mentioned in the issue https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/257

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
