### PR TITLE
Automatically catch and report bad DAC scan fits

### DIFF
--- a/utils/anaInfo.py
+++ b/utils/anaInfo.py
@@ -12,6 +12,9 @@ Documentation
 
 import string
 
+#: If the chisquare value of the fit to DAC vs ADC is above this value, an exception will be raised
+dacScanFitChisquareMax = 100.
+
 #: CFG_THR_ARM_DAC calibration parameters
 #: The CFG_THR_ARM_DAC calibration routine involves performing a fit of scurveMean vs CFG_THR_ARM_DAC in which some points with bad quality, defined by the parameters below, are removed
 scurveMeanMin = 0.1 #: points are removed if they satisfy scurveMean < scurveMeanMin

--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -295,6 +295,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
     print("fitting DAC vs. ADC distributions")
 
     # Fit the TGraphErrors objects
+    dictOfDACsWithBadFit = {} # [(shelf,slot,link,vfat)] = (vfatID,dacName)
     for idx in range(len(dacNameArray)):
         dacName = np.asscalar(dacNameArray[idx])
         for entry in crateMap:
@@ -305,7 +306,20 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
                     dict_DACvsADC_Funcs[dacName][ohKey][vfat].SetLineColor(0)
                     continue
                 #the fits fail when the errors on dacValY (the x-axis variable) are used
-                dict_DACvsADC_Graphs[dacName][ohKey][vfat].Fit(dict_DACvsADC_Funcs[dacName][ohKey][vfat],"QEX0")
+                fitResult =  dict_DACvsADC_Graphs[dacName][ohKey][vfat].Fit(dict_DACvsADC_Funcs[dacName][ohKey][vfat],"SQEX0")
+
+                from anaInfo import dacScanFitChisquareMax
+                
+                if dict_DACvsADC_Funcs[dacName][ohKey][vfat].GetChisquare() > dacScanFitChisquareMax:
+                    dictOfDACsWithBadFit[(ohKey[0],ohKey[1],ohKey[2],vfat)] = (vfatIDArray[vfat],dacName)
+                    errorMsg = "Warning: large chisquare for VFAT{2} of chamber {3} (Shelf{4},Slot{5},OH{1}) DAC {0}.".format(
+                            dacName,
+                            ohKey[2],
+                            vfat,
+                            detName, 
+                            ohKey[0],
+                            ohKey[1])
+                    print(colormsg(errorMsg,logging.ERROR))
 
     # Create Determine max DAC size
     dict_maxByDacName = {}
@@ -433,9 +447,18 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
             pass
         pass
 
+
+    if len(dictOfDACsWithBadFit):
+        err_msg = "The following (vfatN,DAC Names) have large chisquare DAC vs ADC fits"
+        for ohKey,vfatDACtuple in dictOfDACsWithBadFit.iteritems():
+            err_msg = "{0}\n\t{1}\t{2}".format(err_msg,ohKey,vfatDACtuple)
+            pass
+        from gempython.gemplotting.utils.exceptions import VFATDACFitLargeChisquare
+        raise VFATDACFitLargeChisquare(err_msg, os.EX_DATAERR)
+    
     # Raise a ValueError if a DAC is found to be out of range
     if len(dictOfDACsWithBadBias):
-        err_msg = "The following (vfatN,DAC Names) where found to be out of range"
+        err_msg = "The following (vfatN,DAC Names) were found to be out of range"
         for ohKey,vfatDACtuple in dictOfDACsWithBadBias.iteritems():
             err_msg = "{0}\n\t{1}\t{2}".format(err_msg,ohKey,vfatDACtuple)
             pass

--- a/utils/exceptions.py
+++ b/utils/exceptions.py
@@ -29,6 +29,17 @@ class VFATDACBiasCannotBeReached(ValueError):
         self.errors = errors
         return
 
+class VFATDACFitLargeChisquare(ValueError):
+    """
+    This exception is raised when a DAC vs ADC fit returns a large chisquare value
+
+    """
+    def __init__(self, message, errors):
+        super(VFATDACFitLargeChisquare, self).__init__(message)
+
+        self.errors = errors
+        return
+
 class DBViewNotFound(KeyError):
     def __init__(self, message, errors):
         super(DBViewNotFound, self).__init__(message)


### PR DESCRIPTION
Automatically catches cases where a DAC vs ADC fit is low-quality

## Description
If a DAC fit has chisquare value greater than 100 (a value which can be configured in `anaInfo.py`), then an exception is thrown.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
DAC scan fits in which there appears to be a dead bit have been reported by the QC7 team e.g. 

http://cmsonline.cern.ch/cms-elog/1093542

and currently they would go undetected if the nominal DAC values based on the bad fit happen to be in the allowed range of the DAC.

## How Has This Been Tested?
I have tested it on some old DAC scan data: 

```
/data/bigdisk/GEM-Data-Taking/GE11_QC8/dacScanV3/2019.09.18.10.05/dacScanV3.root
```

and it seems to catch the bad DAC fits properly. For the bad DAC scan fit reported in 

http://cmsonline.cern.ch/cms-elog/1093542

I found that the chisquare value is 1400, while it is typically less than 10 in other cases.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
