### PR TITLE
[BugFix] Restricted y axis range in SBitThresh Summary Graph

### DIFF
--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -1511,7 +1511,7 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
                     graph.GetYaxis().SetRangeUser(1e-1,1e8)
 
                     # Draw a line on the graphs
-                    kneeLine.append(r.TLine(dict_dacInflectPts[dacName][ohKey][vfat][0], 1e-1, dict_dacInflectPts[dacName][ohKey][vfat][0], 1e8) )
+                    kneeLine.append(r.TLine(dict_dacInflectPts[dacName][ohKey][vfat][0], 1e-1, dict_dacInflectPts[dacName][ohKey][vfat][0], 1e8))
                     kneeLine[vfat].SetLineColor(2)
                     kneeLine[vfat].SetVertical()
                     canv_Summary1D.cd(chamber_vfatPos2PadIdx[gemType][vfat])

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -1498,6 +1498,7 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
                 for vfat in range(0,nVFATS):
                     canv_Summary1D.cd(vfat + 1).SetLogy()
 
+
                     # make sure the inflection point is there
                     if dict_dacInflectPts[dacName][ohKey][vfat][0] == None:
                         kneeLine.append(None)
@@ -1508,6 +1509,9 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
                     if type(graph) == r.TH1F :
                         graph = r.TGraph(graph)
 
+                    # make sure the yaxis range is restricted
+                    graph.GetYaxis().SetRangeUser(1e-1,1e8)
+
                     # get maximum y value
                     y = graph.GetY()
                     y = np.array(y)
@@ -1517,7 +1521,7 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
                     kneeLine.append(r.TLine(dict_dacInflectPts[dacName][ohKey][vfat][0], 10.0, dict_dacInflectPts[dacName][ohKey][vfat][0], ymax) )
                     kneeLine[vfat].SetLineColor(2)
                     kneeLine[vfat].SetVertical()
-                    canv_Summary1D.cd(chamber_vfatPos2PadIdx[gemType][vfat] )
+                    canv_Summary1D.cd(vfat+1 )
                     kneeLine[vfat].Draw()
                 canv_Summary1D.Update()
 

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -1496,8 +1496,7 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
                  # make nVFATs TLines
                 kneeLine= []
                 for vfat in range(0,nVFATS):
-                    canv_Summary1D.cd(vfat + 1).SetLogy()
-
+                    canv_Summary1D.cd(chamber_vfatPos2PadIdx[gemType][vfat] ).SetLogy() # get pad corresponding to vfat
 
                     # make sure the inflection point is there
                     if dict_dacInflectPts[dacName][ohKey][vfat][0] == None:
@@ -1512,16 +1511,11 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
                     # make sure the yaxis range is restricted
                     graph.GetYaxis().SetRangeUser(1e-1,1e8)
 
-                    # get maximum y value
-                    y = graph.GetY()
-                    y = np.array(y)
-                    ymax = np.amax(y)
-
                     # Draw a line on the graphs
-                    kneeLine.append(r.TLine(dict_dacInflectPts[dacName][ohKey][vfat][0], 10.0, dict_dacInflectPts[dacName][ohKey][vfat][0], ymax) )
+                    kneeLine.append(r.TLine(dict_dacInflectPts[dacName][ohKey][vfat][0], 1e-1, dict_dacInflectPts[dacName][ohKey][vfat][0], 1e8) )
                     kneeLine[vfat].SetLineColor(2)
                     kneeLine[vfat].SetVertical()
-                    canv_Summary1D.cd(vfat+1 )
+                    canv_Summary1D.cd(chamber_vfatPos2PadIdx[gemType][vfat] )   
                     kneeLine[vfat].Draw()
                 canv_Summary1D.Update()
 

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -1508,14 +1508,13 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
                     if type(graph) == r.TH1F :
                         graph = r.TGraph(graph)
 
-                    # make sure the yaxis range is restricted
                     graph.GetYaxis().SetRangeUser(1e-1,1e8)
 
                     # Draw a line on the graphs
                     kneeLine.append(r.TLine(dict_dacInflectPts[dacName][ohKey][vfat][0], 1e-1, dict_dacInflectPts[dacName][ohKey][vfat][0], 1e8) )
                     kneeLine[vfat].SetLineColor(2)
                     kneeLine[vfat].SetVertical()
-                    canv_Summary1D.cd(chamber_vfatPos2PadIdx[gemType][vfat] )   
+                    canv_Summary1D.cd(chamber_vfatPos2PadIdx[gemType][vfat] )
                     kneeLine[vfat].Draw()
                 canv_Summary1D.Update()
 

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -1496,7 +1496,7 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
                  # make nVFATs TLines
                 kneeLine= []
                 for vfat in range(0,nVFATS):
-                    canv_Summary1D.cd(chamber_vfatPos2PadIdx[gemType][vfat] ).SetLogy() # get pad corresponding to vfat
+                    canv_Summary1D.cd(chamber_vfatPos2PadIdx[gemType][vfat]).SetLogy()
 
                     # make sure the inflection point is there
                     if dict_dacInflectPts[dacName][ohKey][vfat][0] == None:

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -1514,7 +1514,7 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
                     kneeLine.append(r.TLine(dict_dacInflectPts[dacName][ohKey][vfat][0], 1e-1, dict_dacInflectPts[dacName][ohKey][vfat][0], 1e8) )
                     kneeLine[vfat].SetLineColor(2)
                     kneeLine[vfat].SetVertical()
-                    canv_Summary1D.cd(chamber_vfatPos2PadIdx[gemType][vfat] )
+                    canv_Summary1D.cd(chamber_vfatPos2PadIdx[gemType][vfat])
                     kneeLine[vfat].Draw()
                 canv_Summary1D.Update()
 


### PR DESCRIPTION

## Description
The y-axis lost it's restriction in a previous version, I have fixed it so that the y-axis is fixed between 1e-1 and 1e8.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This was causing issues for the qc7 team, the y-axis should have remained fixed.

## How Has This Been Tested?
```bash
#!/usr/bin/env bash

#=========================================================================================
# Testing Suite for the Inflection Point finder ------------------------------------------
#=========================================================================================


echo "Welcome to Brendan's Testing Suite for the Inflection Point Finder"
echo "------------------------------------------------------------------------------------"
echo "This script executes a bunch of files known to cause issues for the inflection"
echo "point finder"
echo "------------------------------------------------------------------------------------"

echo "Did you remember to update??? With make pip and pip install rpm*.tar.gz?"

echo "File 1"
echo "This tests how the code handles a vfat with a bad vfat"
echo "Please make sure (2,5,4) is filled in your system_specfic_constants.py file"

# This file causes issues because of a zero slope issue
anaSBitThresh.py /data/bigdisk/GEM-Data-Taking/GE11_QC8//sbitRate/channelOR/2019.10.25.13.59/SBitRateData.root

echo "File 2"
echo "This tests how the code handles a detector with missing vfats"
echo "Please make sure (1,2,0) is filled in your system_specfic_constants.py file"

# This file is from the coffin where the detector is missing vfats
anaSBitThresh.py /data/bigdisk/GEM-Data-Taking/GE11_Integration//sbitRate/channelOR//2019.10.24.17.45/SBitRateData.root
```

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
