### PR TITLE
Fix the vfatID array in the DAC scan analysis

### DIFF
--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -91,6 +91,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
 
     # Get VFATID's
     vfatIDArray = getSubArray(vfatArray, ['vfatID','vfatN'])
+    vfatIDArray = np.unique(vfatIDArray)
     vfatIDArray = np.sort(vfatIDArray,order='vfatN')['vfatID'] # index now gauranteed to match vfatN
 
     # make the crateMap
@@ -459,7 +460,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
 
 
     if len(dictOfDACsWithBadFit):
-        err_msg = "The following (vfatN,DAC Names) have large chisquare DAC vs ADC fits"
+        err_msg = "The following (vfatID,DAC Names) have large chisquare DAC vs ADC fits"
         for ohKey,vfatDACtuple in dictOfDACsWithBadFit.iteritems():
             err_msg = "{0}\n\t{1}\t{2}".format(err_msg,ohKey,vfatDACtuple)
             pass
@@ -468,7 +469,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
     
     # Raise a ValueError if a DAC is found to be out of range
     if len(dictOfDACsWithBadBias):
-        err_msg = "The following (vfatN,DAC Names) were found to be out of range"
+        err_msg = "The following (vfatID,DAC Names) were found to be out of range"
         for ohKey,vfatDACtuple in dictOfDACsWithBadBias.iteritems():
             err_msg = "{0}\n\t{1}\t{2}".format(err_msg,ohKey,vfatDACtuple)
             pass


### PR DESCRIPTION
The VFAT ID array is now passed through np.unique such it will only have 24 entries, one for each VFAT.

## Description
Previously the VFAT ID array was thousands of entries long, because there is one entry in the DAC scan tree for each DAC value.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
The commissioning team found that VFATs on different detectors appeared to have the same vfat ID.

## How Has This Been Tested?
Yes, I ran over the DAC scan root file provided by @bregnery and got the expected output.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
