### PR TITLE
Change DAC scan cut on chi2 to cut on chi2/ndof

### DIFF
--- a/utils/anaInfo.py
+++ b/utils/anaInfo.py
@@ -12,8 +12,8 @@ Documentation
 
 import string
 
-#: If the chisquare value of the fit to DAC vs ADC is above this value, an exception will be raised
-dacScanFitChisquareMax = 100.
+#: If the chisquare value divided by number of degrees of freedom of the fit to DAC vs ADC is above this value, an exception will be raised
+dacScanFitChiSqOverNDFMax = 15.
 
 #: CFG_THR_ARM_DAC calibration parameters
 #: The CFG_THR_ARM_DAC calibration routine involves performing a fit of scurveMean vs CFG_THR_ARM_DAC in which some points with bad quality, defined by the parameters below, are removed

--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -252,6 +252,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
 
     outputFiles = {}
     for entry in crateMap:
+        ohKey = (entry['shelf'],entry['slot'],entry['link'])
         detName = getDetName(entry)
         if scandate == 'noscandate':
             outputFiles[ohKey] = r.TFile(elogPath+"/"+detName+"/"+args.outfilename,'recreate')
@@ -310,6 +311,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
         dacName = np.asscalar(dacNameArray[idx])
         for entry in crateMap:
             ohKey = (entry['shelf'],entry['slot'],entry['link'])
+            detName = getDetName(entry)
             for vfat in range(0,nVFATS):
                 if vfat not in dict_nonzeroVFATs[ohKey]:
                     #so that the output plots for these VFATs are completely empty
@@ -318,9 +320,9 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
                 #the fits fail when the errors on dacValY (the x-axis variable) are used
                 fitResult =  dict_DACvsADC_Graphs[dacName][ohKey][vfat].Fit(dict_DACvsADC_Funcs[dacName][ohKey][vfat],"SQEX0")
 
-                from anaInfo import dacScanFitChisquareMax
+                from anaInfo import dacScanFitChiSqOverNDFMax
                 
-                if dict_DACvsADC_Funcs[dacName][ohKey][vfat].GetChisquare() > dacScanFitChisquareMax:
+                if dict_DACvsADC_Funcs[dacName][ohKey][vfat].GetNDF() > 0 and dict_DACvsADC_Funcs[dacName][ohKey][vfat].GetChisquare()/dict_DACvsADC_Funcs[dacName][ohKey][vfat].GetNDF() > dacScanFitChiSqOverNDFMax:
                     dictOfDACsWithBadFit[(ohKey[0],ohKey[1],ohKey[2],vfat)] = (vfatIDArray[vfat],dacName)
                     errorMsg = "Warning: large chisquare for VFAT{2} of chamber {3} (Shelf{4},Slot{5},OH{1}) DAC {0}.".format(
                             dacName,
@@ -349,7 +351,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
 
         for entry in crateMap:
             ohKey = (entry['shelf'],entry['slot'],entry['link'])
-            getDame = getDetName(entry)
+            detName = getDetName(entry)
             graph_dacVals[dacName][ohKey] = r.TGraph()
             graph_dacVals[dacName][ohKey].SetMinimum(0)
             graph_dacVals[dacName][ohKey].GetXaxis().SetTitle("VFATN")
@@ -387,6 +389,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
     for idx in range(len(dacNameArray)):
         dacName = np.asscalar(dacNameArray[idx])
         for entry in crateMap:
+            ohKey = (entry['shelf'],entry['slot'],entry['link'])
             detName = getDetName(entry)
             if scandate == 'noscandate':
                 outputTxtFiles_dacVals[dacName][ohKey] = open("{0}/{1}/NominalValues-{2}.txt".format(elogPath,detName,dacName),'w')


### PR DESCRIPTION
The cut on the chisquared of the DAC scan fit before an exception is thrown is changed to a cut on the chisquared divided by number of degrees of freedom. The default value of the cut is set to 20.

## Description
The cut on the value of chisquared of DAC vs ADC fits was too strict, and did not take into consideration that different DACs have different ranges.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
Partially resolves issue https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/262

## How Has This Been Tested?
Yes, I tested that non of the DAC scan fits in the example provided by @lpetre-ulb have chisquared/ndof larger than 10, then I added a safety factor of around 100%.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
