### PR TITLE
chamberInfo.py should be replaced when the rpm is installed

### DIFF
--- a/pkg/installrpm.sh
+++ b/pkg/installrpm.sh
@@ -25,11 +25,9 @@ cat <<EOF >>INSTALLED_FILES
 %attr(0755,root,root) /opt/cmsgemos/bin/*.py
 # %attr(0755,root,root) %{python2_sitelib}/gempython/scripts/*.py
 # %attr(0755,root,root) %{python2_sitelib}/gempython/gemplotting/macros/*.py
-# %config(noreplace) %attr(0755,root,root) %{python2_sitelib}/gempython/gemplotting/mapping/chamberInfo.py
 %attr(0755,root,root) /usr/lib/python*/site-packages/gempython/scripts/*.py
 %attr(0755,root,root) /usr/lib/python*/site-packages/gempython/scripts/*.py
 %attr(0755,root,root) /usr/lib/python*/site-packages/gempython/gemplotting/macros/*.py
-%config(noreplace) %attr(0755,root,root) /usr/lib/python*/site-packages/gempython/gemplotting/mapping/chamberInfo.py
 EOF
 echo "Modified INSTALLED_FILES"
 cat INSTALLED_FILES


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request simply removes the line that prevents `chamberInfo.py` from being overwritten.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
If `chamberInfo.py` is not replaced, new features in `chamberInfo.py` are not installed.

## How Has This Been Tested?
Yes, I have installed the package in my virtual environment

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
