### PR TITLE
[Bug Fix] Add missing maxChi2 arg to ScanDataFitter

### DIFF
--- a/fitting/fitScanData.py
+++ b/fitting/fitScanData.py
@@ -132,7 +132,7 @@ class ScanDataFitter(DeadChannelFinder):
 
     from gempython.gemplotting.utils.anaInfo import maxChi2Default
     
-    def __init__(self, calDAC2Q_m=None, calDAC2Q_b=None, isVFAT3=False, nVFats=24):
+    def __init__(self, calDAC2Q_m=None, calDAC2Q_b=None, isVFAT3=False, nVFats=24, maxChi2=maxChi2Default):
         super(ScanDataFitter, self).__init__(nVFats)
 
         from gempython.utils.nesteddict import nesteddict as ndict


### PR DESCRIPTION
The `maxChi2` argument was missing from the ScanDataFitter class.

## Description
This pull request adds it at the end with a default argument.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
Resolves https://github.com/cms-gem-daq-project/gem-plotting-tools/issues/269

## How Has This Been Tested?
Yes, I just tested it successfully on some data from the coffin.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
