### PR TITLE
Reorganize DAC analysis exception classes

### DIFF
--- a/anaDACScan.py
+++ b/anaDACScan.py
@@ -81,10 +81,10 @@ if __name__ == '__main__':
         scandate = 'noscandate'
 
     from gempython.gemplotting.utils.anautilities import dacAnalysis
-    from gempython.gemplotting.utils.exceptions import VFATDACBiasCannotBeReached
+    from gempython.gemplotting.utils.exceptions import DACAnalysisException
     try:
         dacAnalysis(args, dacScanFile.dacScanTree, chamber_config, scandate=scandate)
-    except VFATDACBiasCannotBeReached as err:
+    except DACAnalysisException as err:
         from gempython.utils.gemlogger import printRed
         printRed(err.message)
         printRed("VFATs above may *NOT* be properly biased")

--- a/ana_scans.py
+++ b/ana_scans.py
@@ -36,7 +36,7 @@ def anaDACScan(args):
 
     from gempython.gemplotting.utils.anautilities import dacAnalysis
     from gempython.gemplotting.utils.anautilities import getScandateFromFilename
-    from gempython.gemplotting.utils.exceptions import VFATDACBiasCannotBeReached
+    from gempython.gemplotting.utils.exceptions import DACAnalysisException
     args.assignXErrors = False
     args.printSum = False
     for geoAddr,fileTuple in dictOfFiles.iteritems():
@@ -49,7 +49,7 @@ def anaDACScan(args):
 
         try:
             dacAnalysis(args, dacScanFile.dacScanTree, chamber_config, scandate=args.scandate)
-        except VFATDACBiasCannotBeReached as err:
+        except DACAnalysisException as err:
             from gempython.utils.gemlogger import printRed
             printRed(err.message)
             printRed("VFATs above may *NOT* be properly biased")

--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -464,24 +464,23 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
             pass
         pass
 
+    if len(dictOfDACsWithBadFit) or len(dictOfDACsWithBadBias):
+        err_msg = ""
+        if len(dictOfDACsWithBadFit):
+            err_msg = "The following (vfatID,DAC Names) have large chisquare DAC vs ADC fits"
+            for ohKey,vfatDACtuple in dictOfDACsWithBadFit.iteritems():
+                err_msg = "{0}\n\t{1}\t{2}".format(err_msg,ohKey,vfatDACtuple)
 
-    if len(dictOfDACsWithBadFit):
-        err_msg = "The following (vfatID,DAC Names) have large chisquare DAC vs ADC fits"
-        for ohKey,vfatDACtuple in dictOfDACsWithBadFit.iteritems():
-            err_msg = "{0}\n\t{1}\t{2}".format(err_msg,ohKey,vfatDACtuple)
-            pass
-        from gempython.gemplotting.utils.exceptions import VFATDACFitLargeChisquare
-        raise VFATDACFitLargeChisquare(err_msg, os.EX_DATAERR)
+        if len(dictOfDACsWithBadBias):
+            if len(err_msg):
+                err_msg += "\n"
+            err_msg += "The following (vfatID,DAC Names) were found to be out of range"
+            for ohKey,vfatDACtuple in dictOfDACsWithBadBias.iteritems():
+                err_msg = "{0}\n\t{1}\t{2}".format(err_msg,ohKey,vfatDACtuple)
+
+        from gempython.gemplotting.utils.exceptions import DACAnalysisException
+        raise DACAnalysisException(bool(len(dictOfDACsWithBadFit)),bool(len(dictOfDACsWithBadBias)),err_msg,os.EX_DATAERR)
     
-    # Raise a ValueError if a DAC is found to be out of range
-    if len(dictOfDACsWithBadBias):
-        err_msg = "The following (vfatID,DAC Names) were found to be out of range"
-        for ohKey,vfatDACtuple in dictOfDACsWithBadBias.iteritems():
-            err_msg = "{0}\n\t{1}\t{2}".format(err_msg,ohKey,vfatDACtuple)
-            pass
-        from gempython.gemplotting.utils.exceptions import VFATDACBiasCannotBeReached
-        raise VFATDACBiasCannotBeReached(err_msg, os.EX_DATAERR)
-
     return dict_dacVals
 
 def filePathExists(searchPath, subPath=None, debug=False):

--- a/utils/exceptions.py
+++ b/utils/exceptions.py
@@ -15,6 +15,18 @@ Documentation
 """
 
 class VFATDACBiasCannotBeReached(ValueError):
+
+    def __init__(self, message, errors):
+        super(VFATDACBiasCannotBeReached, self).__init__(message)
+
+        self.errors = errors
+        return
+
+class DACAnalysisException(ValueError):
+    """
+    This exception is raised when a DAC vs ADC fit returns a large chisquare value
+
+    """
     """
     This exception is raised if DAC analysis determines that to achieve the 
     nominal bias current/voltages in ``nominalDacValues`` dictionary, 
@@ -23,20 +35,11 @@ class VFATDACBiasCannotBeReached(ValueError):
     ``maxVfat3DACSize[dacSelect][0]``.  Info can be found on these ranges in
     the ``maxVfat3DACSize`` dictionary of: ``gempython.tools.hw_constants``
     """
-    def __init__(self, message, errors):
-        super(VFATDACBiasCannotBeReached, self).__init__(message)
+    def __init__(self, isBadFit, isBadBias, message, errors):
+        super(DACAnalysisException, self).__init__(message)
 
-        self.errors = errors
-        return
-
-class VFATDACFitLargeChisquare(ValueError):
-    """
-    This exception is raised when a DAC vs ADC fit returns a large chisquare value
-
-    """
-    def __init__(self, message, errors):
-        super(VFATDACFitLargeChisquare, self).__init__(message)
-
+        self.isBadFit = isBadFit
+        self.isBadBias = isBadBias
         self.errors = errors
         return
 

--- a/utils/exceptions.py
+++ b/utils/exceptions.py
@@ -14,21 +14,11 @@ Documentation
 -------------
 """
 
-class VFATDACBiasCannotBeReached(ValueError):
-
-    def __init__(self, message, errors):
-        super(VFATDACBiasCannotBeReached, self).__init__(message)
-
-        self.errors = errors
-        return
-
 class DACAnalysisException(ValueError):
     """
-    This exception is raised when a DAC vs ADC fit returns a large chisquare value
-
-    """
-    """
-    This exception is raised if DAC analysis determines that to achieve the 
+    This is exception is raised when one or more of the following flags is set.
+    isBadFit: This flag is set when a DAC vs ADC fit returns a large chisquare value
+    isBadBias: This flag is set DAC analysis determines that to achieve the 
     nominal bias current/voltages in ``nominalDacValues`` dictionary, 
     of: ``gempython.gemplotting.utils.anaInfo``, the DAC would need to be set
     to a value outside of the DAC range ``[0, max]`` where ``max`` is


### PR DESCRIPTION
A new exception class `DACAnalysisException` is introduced which combines `VFATDACBiasCannotBeReached` and `VFATDACFitLargeChisquare`.

## Description
The new exception class contains two `bool`s which identify which problem or problems cause the exception, and a message with the details.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
In the case of both a bad bias and a bad fit exception in the same DAC scan, only one of the two exceptions would be thrown, arbitrarily.

## How Has This Been Tested?
I have reanalyzed a DAC scan which has both types of exceptions.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
