### PR TITLE
evaluate TGraphError instead of TF1

### DIFF
--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -361,8 +361,8 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
                 if vfat not in dict_nonzeroVFATs[ohKey]:
                     continue
 
-                #evaluate the fitted function at the nominal current or voltage value and convert to an integer
-                fittedDacValue = int(dict_DACvsADC_Funcs[dacName][ohKey][vfat].Eval(nominal[dacName]))
+                #evaluate the TGraphError the nominal current or voltage value and convert to an integer
+                fittedDacValue = int(dict_DACvsADC_Graphs[dacName][ohKey][vfat].Eval(nominal[dacName]))
                 finalDacValue = max(0,min(maxDacValue,fittedDacValue))
                 if fittedDacValue != finalDacValue:
                     dictOfDACsWithBadBias[(ohKey[0],ohKey[1],ohKey[2],vfat)] = (vfatIDArray[vfat],dacName)


### PR DESCRIPTION
Since we take DAC scans by scanning each DAC value 100 times, we have fine-grained and smooth enough data to just interpolate from the data, instead of evaluating a 5th order polynomial, which sometimes does not fit too well.

## Description
The TGraphError has a built-in `Eval` function which performs linear interpolation from two nearby points, so I have used that.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This change was proposed and discussed briefly here: https://github.com/cms-gem-daq-project/gem-plotting-tools/pull/265. As discussed there, we are keeping the fifth order polynomial to flag bad VFATs.

## How Has This Been Tested?
Yes, I have tested this on data from GE11-X-S-FIT-0004 and found very small changes in the nominal DAC values, as expected. For example:

```
< 4	17
< 5	24
< 6	23
---
> 4	16
> 5	23
> 6	24
13,14c13,14
< 12	27
< 13	18
---
> 12	28
> 13	19
20c20
< 19	23
---
> 19	22
23c23
< 22	22
---
> 22	21
```

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
