### PR TITLE
Changed formats to match root heading to file

### DIFF
--- a/utils/scurveAlgos.py
+++ b/utils/scurveAlgos.py
@@ -379,7 +379,7 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
 
             for chan in range(0,maxChans):
                 fitSummary.write(
-                        '{0}\t{1}\t{2}\t{3}\t{4}\t{5}\t{6}\n'.format(
+                        '{0:d}\t{1:d}\t{2:d}\t{3:f}\t{4:f}\t{5:f}\t{6:f}\n'.format(
                             vfat,
                             dict_vfatID[vfat],
                             chan,
@@ -903,7 +903,7 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
                     continue
 
                 for chan in range(0, maxChans):
-                    confF.write('{0}\t{1}\t{2}\t{3}\t{4}\t{5}\t{6}\n'.format(
+                    confF.write('{0:d}\t{1:d}\t{2:d}\t{3:d}\t{4:d}\t{5:d}\t{6:d}\n'.format(
                         vfat,
                         dict_vfatID[vfat],
                         chan,
@@ -919,7 +919,7 @@ def anaUltraScurve(args, scurveFilename, calFile=None, GEBtype="short", outputDi
                     continue
 
                 for chan in range (0, maxChans):
-                    confF.write('{0}\t{1}\t{2}\t{3}\t{4}\t{5}\n'.format(
+                    confF.write('{0:d}\t{1:d}\t{2:d}\t{3:d}\t{4:d}\t{5:d}\n'.format(
                         vfat,
                         dict_vfatID[vfat],
                         chan,

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -405,14 +405,14 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
         for vfat in range(0,nVFATS):
             if vfat not in dict_chipID:
                 continue
-            txt_vfat.write('{0}\t{1}\t{2}\t{3}\n'.format(vfat,dict_chipID[vfat],vt1[vfat],trimRange[vfat]))
+            txt_vfat.write('{0:d}\t{1:d}\t{2:d}\t{3:d}\n'.format(vfat,dict_chipID[vfat],vt1[vfat],trimRange[vfat]))
             pass
     else:
         txt_vfat.write("vfatN/I:vfatID/I:vt1/I\n")
         for vfat in range(0,nVFATS):
             if vfat not in dict_chipID:
                 continue
-            txt_vfat.write('{0}i\t{1}\t{2}\n'.format(vfat,dict_chipID[vfat],vt1[vfat]))
+            txt_vfat.write('{0:d}\t{1:d}\t{2:d}\n'.format(vfat,dict_chipID[vfat],vt1[vfat]))
             pass
     txt_vfat.close()
 
@@ -430,13 +430,13 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
                 for chan in range (0, maxChans):
                     isHotChan = vfatChanArray[ vfatChanArray['vfatCH'] == chan ]['mask']
                     if args.debug:
-                        print('{0}\t{1}\t{2}\t{3}\t{4}\n'.format(
+                        print('{0:d}\t{1:d}\t{2:d}\t{3:d}\t{4:d}\n'.format(
                             vfat,
                             dict_chipID[vfat],
                             chan,
                             dict_vfatTrimMaskData[vfat][chan]['trimDAC'],
                             int(isHotChan or dict_vfatTrimMaskData[vfat][chan]['mask'])))
-                    confF.write('{0}\t{1}\t{2}\t{3}\t{4}\n'.format(
+                    confF.write('{0:d}\t{1:d}\t{2:d}\t{3:d}\t{4:d}\n'.format(
                         vfat,
                         dict_chipID[vfat],
                         chan,
@@ -453,7 +453,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
                 for chan in range(0,maxChans):
                     isHotChan = vfatChanArray[ vfatChanArray['vfatCH'] == chan ]['mask']
                     if args.debug:
-                        print('{0}\t{1}\t{2}\t{3}\t{4}\t{5}\t{6}\n'.format(
+                        print('{0:d}\t{1:d}\t{2:d}\t{3:d}\t{4:d}\t{5:d}\t{6:d}\n'.format(
                             vfat,
                             dict_chipID[vfat],
                             chan,
@@ -461,7 +461,7 @@ def anaUltraThreshold(args,thrFilename,GEBtype="short",outputDir=None,fileScurve
                             dict_vfatTrimMaskData[vfat][chan]['trimPolarity'],
                             int(isHotChan or dict_vfatTrimMaskData[vfat][chan]['mask']),
                             dict_vfatTrimMaskData[vfat][chan]['maskReason']))
-                    confF.write('{0}\t{1}\t{2}\t{3}\t{4}\t{5}\t{6}\n'.format(
+                    confF.write('{0:d}\t{1:d}\t{2:d}\t{3:d}\t{4:d}\t{5:d}\t{6:d}\n'.format(
                         vfat,
                         dict_chipID[vfat],
                         chan,
@@ -1079,7 +1079,7 @@ def calibrateThrDAC(args):
         dict_ScurveSigmaVsThrDac_BoxPlot[vfat].Write()
 
         # Write CFG_THR_*_DAC calibration file
-        calThrDacFile.write("{0}\t{1}\t{2}\t{3}\t{4}\t{5}\n".format(
+        calThrDacFile.write("{0:d}\t{1:f}\t{2:f}\t{3:f}\t{4:f}\t{5:f}\n".format(
             vfat,
             dict_funcScurveMeanVsThrDac[vfat].GetParameter(0),
             dict_funcScurveMeanVsThrDac[vfat].GetParameter(1),
@@ -1558,7 +1558,7 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
             
         vfatConfg.write("vfatN/I:vt1/I:trimRange/I\n")
         for vfat,armDACVal in innerDictByVFATKey.iteritems():
-            vfatConfg.write('{0}\t{1}\t{2}\n'.format(vfat, armDACVal,0))
+            vfatConfg.write('{0:d}\t{1:d}\t{2:d}\n'.format(vfat, armDACVal,0))
         vfatConfg.close()    
         
     return 


### PR DESCRIPTION
## Description
Fixing for issue #278 
Changed all of format's that write to a file with a root header (eg
```python
confF.write('vfatN/I:vfatID/I:vfatCH/I:trimDAC/I:trimPolarity/I:mask/I:maskReason/I\n')
```
to match the expected value. eg
```python
confF.write('{0:d}\t{1:d}\t{2:d}\t{3:d}\t{4:d}\t{5:d}\t{6:d}\n'.format(...
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?
Ran over a GE11 file and checked chConfig file

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
