### PR TITLE
Update nominal values data structure and output

### DIFF
--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -423,7 +423,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
                     sep="\t", 
                     header=False, 
                     index=True, 
-                    mode='a')
+                    mode='w')
                     
         # Summary Case
         dirSummary = outputFiles[ohKey].mkdir("Summary")

--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -384,13 +384,7 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
 
     print("Writing output data")
 
-    # Write out the dacVal results to a root file, a text file, and the terminal
-    for idx in range(len(dacNameArray)):
-        dacName = np.asscalar(dacNameArray[idx])
-        for entry in crateMap:
-            ohKey = (entry['shelf'],entry['slot'],entry['link'])
-            detName = getDetName(entry)
-
+    # Write out the results to a root file, a text file, and the terminal
     for entry in crateMap:
         ohKey = (entry['shelf'],entry['slot'],entry['link'])
         detName = getDetName(entry)

--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -385,16 +385,11 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
     print("Writing output data")
 
     # Write out the dacVal results to a root file, a text file, and the terminal
-    outputTxtFilenames_dacVals = ndict()
     for idx in range(len(dacNameArray)):
         dacName = np.asscalar(dacNameArray[idx])
         for entry in crateMap:
             ohKey = (entry['shelf'],entry['slot'],entry['link'])
             detName = getDetName(entry)
-            if scandate == 'noscandate':
-                outputTxtFilenames_dacVals[dacName][ohKey] = "{0}/{1}/NominalValues-{2}.txt".format(elogPath,detName,dacName)
-            else:
-                outputTxtFilenames_dacVals[dacName][ohKey] = "{0}/{1}/dacScans/{2}/NominalValues-{3}.txt".format(dataPath,detName,scandate,dacName)
 
     for entry in crateMap:
         ohKey = (entry['shelf'],entry['slot'],entry['link'])
@@ -416,8 +411,13 @@ def dacAnalysis(args, dacScanTree, chamber_config, scandate='noscandate'):
         for idx in range(len(dacNameArray)):
             dacName = np.asscalar(dacNameArray[idx])
 
+            if scandate == 'noscandate':
+                outputTxtFilename = "{0}/{1}/NominalValues-{2}.txt".format(elogPath,detName,dacName)
+            else:
+                outputTxtFilename = "{0}/{1}/dacScans/{2}/NominalValues-{3}.txt".format(dataPath,detName,scandate,dacName)
+            
             # The with...as statement ensures that the file is flushed when we are finished writing to it
-            with open(outputTxtFilenames_dacVals[dacName][ohKey],'w') as f:
+            with open(outputTxtFilename,'w') as f:
                 pd.Series(dict_dacVals[dacName][ohKey],index=dict_nonzeroVFATs[ohKey]).to_csv( 
                     path=f, 
                     sep="\t", 


### PR DESCRIPTION
This pull request fixes the issue of files being accessed prematurely by using a `with...as` block which defines the scope of the file, so it is automatically flushed and closed at the end of that block.

## Description
In addition, this pull request uses a `pandas` `Series` to output the nominal DAC values instead of the `write()` function.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This pull request partially resolves https://github.com/cms-gem-daq-project/vfatqc-python-scripts/issues/291. I will make another pull request `vfatqc-python-scripts` to fix the unclosed files there.

## How Has This Been Tested?
Yes, I reran a DAC scan analysis and found that the output NominalValues files were the same as when the HEAD of develop was used.

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
