### PR TITLE
[BugFix] Addressing Multi-valued inflection point issues

### DIFF
--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -556,8 +556,7 @@ def findInflectionPts(graph):
     # We are defining the inflection point as the point where the most negative gradient sum begins
     try:
         inflxGrad = negGrad[bigIdx][0]
-        inflxIdices = np.where(grad == inflxGrad) #return the index at the specified value
-        inflxIdx = np.amax(inflxIdices) # if there are multiple possible points, take the largest one
+        inflxIdx = np.amax(np.where(grad == inflxGrad) ) #return the index at the specified value, if there are multiple possible points, take the largest one
         inflxPnt = (x[inflxIdx], y[inflxIdx] )
     # Error handling for problematic VFATs
     except IndexError:

--- a/utils/anautilities.py
+++ b/utils/anautilities.py
@@ -556,7 +556,8 @@ def findInflectionPts(graph):
     # We are defining the inflection point as the point where the most negative gradient sum begins
     try:
         inflxGrad = negGrad[bigIdx][0]
-        inflxIdx = np.where(grad == inflxGrad) #return the index at the specified value
+        inflxIdices = np.where(grad == inflxGrad) #return the index at the specified value
+        inflxIdx = np.amax(inflxIdices) # if there are multiple possible points, take the largest one
         inflxPnt = (x[inflxIdx], y[inflxIdx] )
     # Error handling for problematic VFATs
     except IndexError:

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -1452,7 +1452,7 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
                 # channelor case
                 if perchannel == False :
 	            dict_dacInflectPts[dacName][ohKey][vfat] = findInflectionPts(dict_Rate1DVsDACNameX[dacName][ohKey][vfat])
-                    inflectTable.append([ohKey, vfat, dict_dacInflectPts[dacName][ohKey][vfat][0][0] ])
+                    inflectTable.append([ohKey, vfat, dict_dacInflectPts[dacName][ohKey][vfat][0] ])
 
                 dict_dacValsBelowCutOff[dacName][ohKey][vfat] = 255 #default to max
                 for point in range(0,dict_Rate1DVsDACNameX[dacName][ohKey][vfat].GetN()):
@@ -1498,24 +1498,13 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
                 for vfat in range(0,nVFATS):
                     canv_Summary1D.cd(chamber_vfatPos2PadIdx[gemType][vfat]).SetLogy()
 
-                    # make sure the inflection point is there
-                    if dict_dacInflectPts[dacName][ohKey][vfat][0] == None:
-                        kneeLine.append(None)
-                        continue
-
                     # make TH1F into TGraph
                     graph = dict_Rate1DVsDACNameX[dacName][ohKey][vfat]
                     if type(graph) == r.TH1F :
                         graph = r.TGraph(graph)
 
                     graph.GetYaxis().SetRangeUser(1e-1,1e8)
-
-                    # Draw a line on the graphs
-                    kneeLine.append(r.TLine(dict_dacInflectPts[dacName][ohKey][vfat][0][0], 1e-1, dict_dacInflectPts[dacName][ohKey][vfat][0][0], 1e8))
-                    kneeLine[vfat].SetLineColor(2)
-                    kneeLine[vfat].SetVertical()
                     canv_Summary1D.cd(chamber_vfatPos2PadIdx[gemType][vfat])
-                    kneeLine[vfat].Draw()
                 canv_Summary1D.Update()
 
             # Save the graphs

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -1190,7 +1190,7 @@ def calibrateThrDAC(args):
 
     return 0
 
-def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outfilename='SBitRatePlots.root', scandate='noscandate', printTable=False, drawInflectLine=False):
+def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outfilename='SBitRatePlots.root', scandate='noscandate', printTable=True, drawInflectLine=False):
     """
     Analyzes a scan taken with sbitRateScanAllLinks(...) from gempython.vfatqc.utils.scanUtils
 

--- a/utils/threshAlgos.py
+++ b/utils/threshAlgos.py
@@ -1190,7 +1190,7 @@ def calibrateThrDAC(args):
 
     return 0
 
-def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outfilename='SBitRatePlots.root', scandate='noscandate'):
+def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outfilename='SBitRatePlots.root', scandate='noscandate', printTable=False, drawInflectLine=False):
     """
     Analyzes a scan taken with sbitRateScanAllLinks(...) from gempython.vfatqc.utils.scanUtils
 
@@ -1213,6 +1213,8 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
         outfilename     - Name of output TFile to be created
         scandate        - Either a string 'noscandate' or an a datetime object formated as YYYY.MM.DD.hh.mm, e.g
                           returned from "datetime.datetime.now().strftime("%Y.%m.%d.%H.%M")"
+        printTable      - Print a table of the inflection points
+        drawInflectLine - Draw a red line where the inflection points are on the sbit graphs
     """
 
     # Get paths
@@ -1474,7 +1476,10 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
 
         # put inflection points in a table for each different ohKey
         if perchannel == False:
-            print(tabulate(inflectTable, headers = ['Geo Addr', 'VFAT Number', 'ARM DAC Inflection Pt'], tablefmt='orgtbl') )
+            # print a table of inflection points if requested
+            if printTable == True:
+                print(tabulate(inflectTable, headers = ['Geo Addr', 'VFAT Number', 'ARM DAC Inflection Pt'], tablefmt='orgtbl') )
+            # save the table of inflection points to a file
             if scandate == 'noscandate':
                 inflectTableFile = file("{0}/{1}/inflectionPointTable.txt".format(elogPath,detName), "w")
                 inflectTableFile.write(tabulate(inflectTable, headers = ['Geo Addr', 'VFAT Number', 'ARM DAC Inflection Pt'], tablefmt='orgtbl') )
@@ -1504,6 +1509,19 @@ def sbitRateAnalysis(chamber_config, rateTree, cutOffRate=0.0, debug=False, outf
                         graph = r.TGraph(graph)
 
                     graph.GetYaxis().SetRangeUser(1e-1,1e8)
+                    
+                    # draw line on the plot if requested by the user
+                    if drawInflectLine == True :
+                        # make sure there is an inflection point
+                        if dict_dacInflectPts[dacName][ohKey][vfat][0] == None: 
+                            kneeLine.append(None)   
+                            continue
+                        kneeLine.append(r.TLine(dict_dacInflectPts[dacName][ohKey][vfat][0], 1e-1, dict_dacInflectPts[dacName][ohKey][vfat][0], 1e8)) 
+                        kneeLine[vfat].SetLineColor(2)  
+                        kneeLine[vfat].SetVertical()    
+                        canv_Summary1D.cd(chamber_vfatPos2PadIdx[gemType][vfat])
+                        kneeLine[vfat].Draw()
+
                     canv_Summary1D.cd(chamber_vfatPos2PadIdx[gemType][vfat])
                 canv_Summary1D.Update()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Previously the inflection point finder allowed for multiple values, we have prevented this from happening by selecting the largest value when more than one is selected. Also, it was requested by the shifters for us to remove the red line from the sbit graphs.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation and Context
This bug prevented tests from being run at qc7 and needed to be addressed.

## How Has This Been Tested?
```bash
anaSBitThresh.py /data/bigdisk/GEM-Data-Taking/GE11_QC8///sbitRate/channelOR//2020.02.12.11.33/SBitRateData.root

echo "File 1"
echo "This tests how the code handles a vfat with a bad vfat"
echo "Please make sure (2,5,4) is filled in your system_specfic_constants.py file"

# This file causes issues because of a zero slope issue
anaSBitThresh.py /data/bigdisk/GEM-Data-Taking/GE11_QC8//sbitRate/channelOR/2019.10.25.13.59/SBitRateData.root

echo "File 2"
echo "This tests how the code handles a detector with missing vfats"
echo "Please make sure (1,2,0) is filled in your system_specfic_constants.py file"

# This file is from the coffin where the detector is missing vfats
anaSBitThresh.py /data/bigdisk/GEM-Data-Taking/GE11_Integration//sbitRate/channelOR//2019.10.24.17.45/SBitRateData.root
```

### Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Template thanks to https://www.talater.com/open-source-templates/#/page/99 -->
